### PR TITLE
minor tweak to uri.userPass lookup in url module.

### DIFF
--- a/packages/jetpack-core/lib/url.js
+++ b/packages/jetpack-core/lib/url.js
@@ -98,7 +98,7 @@ function URL(url, base) {
 
   var userPass = null;
   try {
-    userPass = uri.userPass ? uri.userPass : null;
+    userPass = uri.userPass || null;
   } catch (e if e.result == Cr.NS_ERROR_FAILURE) {}
 
   var host = null;

--- a/packages/jetpack-core/tests/test-url.js
+++ b/packages/jetpack-core/tests/test-url.js
@@ -37,6 +37,15 @@ exports.testParseHttp = function(test) {
   test.assertEqual(info.path, "/bar");
 };
 
+exports.testParseHttpsWithUserPassAndPort = function(test) {
+  var info = url.URL("https://username:password@foo.com:55/bar");
+  test.assertEqual(info.scheme, "https");
+  test.assertEqual(info.host, "foo.com");
+  test.assertEqual(info.port, 55);
+  test.assertEqual(info.userPass, "username:password");
+  test.assertEqual(info.path, "/bar");
+};
+
 exports.testParseChrome = function(test) {
   var info = url.URL("chrome://global/content/blah");
   test.assertEqual(info.scheme, "chrome");


### PR DESCRIPTION
This is a minor tweak so that url.userPass is only looked up once instead of twice, if it exists. I added a test because I didn't see one that tested a url w/ a username:password, but it's probably not that beneficial.
