### PR TITLE
don't require 'source bin/activate' step on platforms where it's not required

### DIFF
--- a/bin/cfx
+++ b/bin/cfx
@@ -1,5 +1,28 @@
 #! /usr/bin/env python
 
+import os
+import sys
+
+# set the cuddlefish "root directory" for this process if it's not already
+# set in the environment
+cuddlefish_root = os.path.dirname(os.path.dirname(os.path.abspath(sys.argv[0])))
+
+if 'CUDDLEFISH_ROOT' not in os.environ:
+    os.environ['CUDDLEFISH_ROOT'] = cuddlefish_root
+
+# add our own python-lib path to the python module search path.
+python_lib_dir = os.path.join(cuddlefish_root, "python-lib")
+if python_lib_dir not in sys.path:
+    sys.path.append(python_lib_dir)
+
+# now export to env so sub-processes get it too
+if 'PYTHONPATH' not in os.environ:
+    os.environ['PYTHONPATH'] = python_lib_dir
+elif python_lib_dir not in os.environ['PYTHONPATH'].split(os.pathsep):
+    paths = os.environ['PYTHONPATH'].split(os.pathsep)
+    paths.insert(0, python_lib_dir)
+    os.environ['PYTHONPATH'] = os.pathsep.join(paths)
+
 import cuddlefish
 
 if __name__ == '__main__':


### PR DESCRIPTION
with just a couple lines of python it becomes unnecesary to 'source bin/activate', and ultimately less to explain in a tutorial.  The developer can add bin to their path if they so choose.
