### PR TITLE
Bug 612758 - browserWindows.openWindow() should be simply open() bugzilla-review-requestee:myk@mozilla.org 

### DIFF
--- a/packages/addon-kit/docs/tabs.md
+++ b/packages/addon-kit/docs/tabs.md
@@ -83,9 +83,7 @@ Listeners are passed the `tab` object that triggered the event.
 <api name="active">
 @property {Tab}
 
-The currently active tab in this list. This property can be set to a `tab`
-object, which will focus that tab. If this is a list of all tabs, setting this
-property will focus the parent window and bring the tab to the foreground.
+The currently active tab in this list. This property is read only.
 
 **Example**
 
@@ -191,10 +189,10 @@ passed the `tab` object that triggered the event.
     var tabs = require("tabs").tabs;
 
     // Close the active tab.
-    tabs.active.close();
+    tabs.activeTab.close();
 
     // Move the active tab one position to the right.
-    tabs.active.index++;
+    tabs.activeTab.index++;
 
     // Open a tab and listen for content being ready.
     tabs.open({
@@ -250,8 +248,8 @@ This property can be set to pin / unpin this tab.
 Close this tab.
 </api>
 
-<api name="focus">
+<api name="activate">
 @method
-Makes this tab active.
+Makes this tab active, which will bring this tab to the foreground.
 </api>
 </api>

--- a/packages/addon-kit/docs/windows.md
+++ b/packages/addon-kit/docs/windows.md
@@ -59,8 +59,7 @@ Object emits all the events listed under "Events" section.
 <api name="activeWindow">
 @property {BrowserWindow}
 
-The currently active window. This property can be set to an instance of
-`BrowserWindow` which will focus that window and bring it to the foreground.
+The currently active window. This property is read only.
 
 **Example**
 
@@ -69,24 +68,24 @@ The currently active window. This property can be set to an instance of
     console.log("title of active window is " +
                 windows.browserWindows.activeWindow.title);
 
+    anotherWindow.activate();
     // set
-    windows.activeWindow = anotherWindow;
-
+    windows.activeWindow == anotherWindow // true
 </api>
 
 </api>
 
-<api name="openWindow">
+<api name="open">
 @function
 Open a new window.
 
     var windows = require("windows").browserWindows;
 
     // Open a new window.
-    windows.openWindow("http://www.mysite.com");
+    windows.open("http://www.mysite.com");
 
     // Open a new window and set a listener for "open" event.
-    windows.openWindow({
+    windows.open({
       url: "http://www.mysite.com",
       onOpen: function(window) {
         // do stuff like listen for content
@@ -95,7 +94,7 @@ Open a new window.
     });
 
     // Open new window with two tabs.
-    windows.openWindow({
+    windows.open({
       tabs: [
         "http://www.mysite.com",
         { url: "http:/mozilla.com",
@@ -109,7 +108,7 @@ An object containing configurable options for how this window will be opened,
 as well as a callback for being notified when the window has fully opened.
 
 If the only option being used is `url`, then a bare string URL can be passed to
-`openWindow` instead of specifying it as a property of the `options` object.
+`open` instead of specifying it as a property of the `options` object.
 
 @prop url {string}
 String URL to be opened in the new window.
@@ -172,9 +171,10 @@ all the open tabs for this window.
 This property is read-only.
 </api>
 
-<api name="focus">
+<api name="activate">
 @method
-Makes window active
+Makes window active, which will focus that window and bring it to the
+foreground.
 </api>
 
 <api name="close">

--- a/packages/addon-kit/lib/tabs.js
+++ b/packages/addon-kit/lib/tabs.js
@@ -52,7 +52,7 @@ exports.tabs = tabs;
 Object.defineProperties(tabs, {
   open: { value: function open(options) {
     if (options.inNewWindow)
-        return browserWindows.openWindow({ tabs: [ options ] });
+        return browserWindows.open({ tabs: [ options ] });
     // Open in active window if new window was not required.
     return browserWindows.activeWindow.tabs.open(options);
   }}

--- a/packages/addon-kit/lib/windows.js
+++ b/packages/addon-kit/lib/windows.js
@@ -195,11 +195,7 @@ const browserWindows = Trait.resolve({ toString: null }).compose(
       let window = WM.getMostRecentWindow(null);
       return this._isBrowser(window) ? BrowserWindow({ window: window }) : null;
     },
-    set activeWindow(window) {
-      if (window instanceof BrowserWindow)
-        window.focus()
-    },
-    openWindow: function openWindow(options) {
+    open: function open(options) {
       if (typeof options === "string")
         options = { tabs: [Options(options)] };
       return BrowserWindow(options);

--- a/packages/addon-kit/tests/test-tabs.js
+++ b/packages/addon-kit/tests/test-tabs.js
@@ -48,9 +48,9 @@ exports.testActiveTab_getter = function(test) {
       location,
       {
         onLoad: function(e) {
-          test.assert(tabs.active);
-          test.assertEqual(tabs.active.location, location);
-          test.assertEqual(tabs.active.title, "foo");
+          test.assert(tabs.activeTab);
+          test.assertEqual(tabs.activeTab.location, location);
+          test.assertEqual(tabs.activeTab.title, "foo");
           closeBrowserWindow(window, function() test.done());
         }
       }
@@ -68,14 +68,14 @@ exports.testActiveTab_setter = function(test) {
 
     tabs.on('ready', function onReady(tab) {
       tabs.removeListener('ready', onReady);
-      test.assertEqual(tabs.active.location, "about:blank", "activeTab location has not changed");
+      test.assertEqual(tabs.activeTab.location, "about:blank", "activeTab location has not changed");
       test.assertEqual(tab.location, location, "location of new background tab matches");
       tabs.on('activate', function onActivate() {
         tabs.removeListener('activate', onActivate);
-        test.assertEqual(tabs.active.location, location, "location after activeTab setter matches");
+        test.assertEqual(tabs.activeTab.location, location, "location after activeTab setter matches");
         closeBrowserWindow(window, function() test.done());
       });
-      tabs.active = tab;
+      tab.activate();
     })
 
     tabs.open({
@@ -162,12 +162,12 @@ exports.testTabClose = function(test) {
     let { tabs } = require("tabs");
     let url = "data:text/html,foo";
 
-    test.assertNotEqual(tabs.active.location, url, "tab is now the active tab");
+    test.assertNotEqual(tabs.activeTab.location, url, "tab is now the active tab");
     tabs.on('ready', function onReady(tab) {
       tabs.removeListener('ready', onReady);
-      test.assertEqual(tabs.active.location, tab.location, "tab is now the active tab");
+      test.assertEqual(tabs.activeTab.location, tab.location, "tab is now the active tab");
       tab.close();
-      test.assertNotEqual(tabs.active.location, url, "tab is no longer the active tab");
+      test.assertNotEqual(tabs.activeTab.location, url, "tab is no longer the active tab");
       closeBrowserWindow(window, function() test.done());
     });
 
@@ -265,15 +265,15 @@ exports.testInBackground = function(test) {
   test.waitUntilDone();
   openBrowserWindow(function(window, browser) {
     let { tabs } = require("tabs");
-    let activeUrl = tabs.active.location;
+    let activeUrl = tabs.activeTab.location;
     let url = "data:text/html,background";
     test.assertEqual(activeWindow, window, "activeWindow matches this window");
     tabs.on('ready', function onReady(tab) {
       tabs.removeListener('ready', onReady);
-      test.assertEqual(tabs.active.location, activeUrl, "URL of active tab has not changed");
+      test.assertEqual(tabs.activeTab.location, activeUrl, "URL of active tab has not changed");
       test.assertEqual(tab.location, url, "URL of the new background tab matches");
       test.assertEqual(activeWindow, window, "a new window was not opened");
-      test.assertNotEqual(tabs.active.location, url, "URL of active tab is not the new URL");
+      test.assertNotEqual(tabs.activeTab.location, url, "URL of active tab is not the new URL");
       closeBrowserWindow(window, function() test.done());
     });
     tabs.open({
@@ -311,7 +311,7 @@ exports.testOpenInNewWindow = function(test) {
         test.assertEqual(activeWindow, newWindow, "new window is active");
         test.assertEqual(tab.location, url, "URL of the new tab matches");
         test.assertEqual(newWindow.content.location, url, "URL of new tab in new window matches");
-        test.assertEqual(tabs.active.location, url, "URL of activeTab matches");
+        test.assertEqual(tabs.activeTab.location, url, "URL of activeTab matches");
         for (var i in cache) cache[i] = null;
         wt.unload();
         closeBrowserWindow(newWindow, function() {

--- a/packages/addon-kit/tests/test-windows.js
+++ b/packages/addon-kit/tests/test-windows.js
@@ -44,12 +44,12 @@ exports.testOpenAndCloseWindow = function(test) {
 
   test.assertEqual(windows.length, 1, "Only one window open");
 
-  windows.openWindow({
+  windows.open({
     url: "data:text/html,<title>windows API test</title>",
     onOpen: function(window) {
       test.assertEqual(window.tabs.length, 1, "Only one tab open");
       test.assertEqual(windows.length, 2, "Two windows open");
-      window.tabs.active.on('ready', function onReady(tab) {
+      window.tabs.activeTab.on('ready', function onReady(tab) {
         tab.removeListener('ready', onReady);
         test.assert(window.title.indexOf("windows API test") != -1,
                     "URL correctly loaded");
@@ -120,7 +120,7 @@ exports.testOnOpenOnCloseListeners = function(test) {
   }
 
 
-  windows.openWindow({
+  windows.open({
     url: "data:text/html,foo",
     onOpen: function(window) {
       window.close(verify);
@@ -132,7 +132,7 @@ exports.testWindowTabsObject = function(test) {
   test.waitUntilDone();
   let windows = require("windows").browserWindows;
 
-  windows.openWindow({
+  windows.open({
     url: "data:text/html,<title>tab 1</title>",
     onOpen: function onOpen(window) {
       test.assertEqual(window.tabs.length, 1, "Only 1 tab open");
@@ -143,7 +143,7 @@ exports.testWindowTabsObject = function(test) {
         onReady: function onReady(newTab) {
           test.assertEqual(window.tabs.length, 2, "New tab open");
           test.assertEqual(newTab.title, "tab 2", "Correct new tab title");
-          test.assertEqual(window.tabs.active.title, "tab 1", "Correct active tab");
+          test.assertEqual(window.tabs.activeTab.title, "tab 1", "Correct active tab");
 
           let i = 1;
           for each (let tab in window.tabs)
@@ -210,31 +210,31 @@ exports.testActiveWindow = function(test) {
     },
     function() {
       test.assertEqual(windows.activeWindow, null, "Non-browser windows aren't handled by this module");
-      windows.activeWindow = window2;
+      window2.activate();
       continueAfterFocus(rawWindow2);
     },
     function() {
       test.assertEqual(windows.activeWindow.title, window2.title, "Correct active window - 2");
-      windows.activeWindow = window3;
+      window3.activate();
       continueAfterFocus(rawWindow3);
     },
     function() {
       test.assertEqual(windows.activeWindow.title, window3.title, "Correct active window - 3");
-      windows.activeWindow = nonBrowserWindow;
+      nonBrowserWindow.focus();
       finishTest();
     }
   ];
 
-  windows.openWindow({
+  windows.open({
     url: "data:text/html,<title>window 2</title>",
     onOpen: function(window) {
       window2 = window;
       rawWindow2 = wm.getMostRecentWindow("navigator:browser");
 
-      windows.openWindow({
+      windows.open({
         url: "data:text/html,<title>window 3</title>",
         onOpen: function(window) {
-          window.tabs.active.on('ready', function onReady() {
+          window.tabs.activeTab.on('ready', function onReady() {
             window3 = window;
             rawWindow3 = wm.getMostRecentWindow("navigator:browser");
             nextStep()

--- a/packages/jetpack-core/lib/tabs/tab.js
+++ b/packages/jetpack-core/lib/tabs/tab.js
@@ -81,7 +81,7 @@ const TabTrait = Trait.compose(EventEmitter, {
 
     this.pinned = options.pinned;
     if (!options.inBackground)
-        this.focus();
+        this.activate();
     // Since we will have to identify tabs by a DOM elements facade function
     // is used as constructor that collects all the instances and makes sure
     // that they more then one wrapper is not created per tab.
@@ -191,7 +191,7 @@ const TabTrait = Trait.compose(EventEmitter, {
    * will be the case. Besides this function is called from a constructor where
    * we would like to return instance before firing a 'TabActivated' event.
    */
-  focus: Enqueued(function focus() {
+  activate: Enqueued(function activate() {
     if (this._window) // Ignore if window is closed by the time this is invoked.
       this._window.gBrowser.selectedTab = this._tab;
   }),

--- a/packages/jetpack-core/lib/windows/dom.js
+++ b/packages/jetpack-core/lib/windows/dom.js
@@ -50,7 +50,7 @@ const WindowDom = Trait.compose({
     if (window) window.close();
     return this._public;
   },
-  focus: function focus() {
+  activate: function activate() {
     let window = this._window;
     if (window) window.focus();
     return this._public;

--- a/packages/jetpack-core/lib/windows/tabs.js
+++ b/packages/jetpack-core/lib/windows/tabs.js
@@ -155,16 +155,15 @@ const TabList = List.resolve({ constructor: "_init" }).compose(
       return this;
     },
     _onActivate: function _onActivate(value) {
-      this._emit(EVENTS.deactivate.name, this._active);
-      this._active = value;
+      this._emit(EVENTS.deactivate.name, this._activeTab);
+      this._activeTab = value;
     },
     _onError: function _onError(error) {
       if (1 <= this._listeners('error').length)
         console.exception(error);
     },
-    get active() this._active,
-    set active(active) active.focus(),
-    _active: null,
+    get activeTab() this._activeTab,
+    _activeTab: null,
 
     open: function open(options) {
       options = Options(options);


### PR DESCRIPTION
This note that this change makes following:
1. Renaming `browserWindows.openWindow` -> `browserWindows.open`.
2. Converting `browserWindows.activeWindow` to read only.
3. Renaming `tabs.active` -> `tabs.activeTab` and makeing it readonly.
4. renameing `focus` -> `activate`. 

As it was suggested on [mailing list](http://groups.google.com/group/mozilla-labs-jetpack/browse_thread/thread/108df8db72e9a7da#).

Splitting this into several changes was not a good idea since all of them depend on each other.
