### PR TITLE
Bug 613341 - addons should be marked as compatible with 4.0b8pre

### DIFF
--- a/python-lib/cuddlefish/app-extension/application.ini
+++ b/python-lib/cuddlefish/app-extension/application.ini
@@ -8,4 +8,4 @@ ID=xulapp@toolness.com
 
 [Gecko]
 MinVersion=1.9.2.0
-MaxVersion=2.0b4
+MaxVersion=2.0b8pre

--- a/python-lib/cuddlefish/app-extension/install.rdf
+++ b/python-lib/cuddlefish/app-extension/install.rdf
@@ -20,8 +20,8 @@
     <em:targetApplication>
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
-        <em:minVersion>3.6</em:minVersion>
-        <em:maxVersion>4.0b6</em:maxVersion>
+        <em:minVersion>4.0b7</em:minVersion>
+        <em:maxVersion>4.0b8pre</em:maxVersion>
       </Description>
     </em:targetApplication>
 


### PR DESCRIPTION
Talked to Myk on IRC about additionally changing `minVersion` for Firefox to 4.0b7, since that's all we're testing on now, and also changing the Gecko `maxVersion` to 2.0b8pre in `application.ini` for XULRunner use.
