### PR TITLE
Bug 604499 - Need to be able to use old addon id as the id for Jetpack SDK generated extension

### DIFF
--- a/python-lib/cuddlefish/__init__.py
+++ b/python-lib/cuddlefish/__init__.py
@@ -496,11 +496,19 @@ def run(arguments=sys.argv[1:], target_cfg=None, pkg_cfg=None,
         jid = harness_guid
 
     assert not jid.endswith("@jetpack")
-    bundle_id = jid + "@jetpack"
-    # the resource: URLs prefix is treated too much like a DNS hostname
+    if (jid.startswith("jid0-") or jid.startswith("anonid0-")):
+        bundle_id = jid + "@jetpack"
+    # Don't append "@jetpack" to old-style IDs, as they should be exactly
+    # as specified by the addon author so AMO and Firefox continue to treat
+    # their addon bundles as representing the same addon (and also because
+    # they may already have an @ sign in them, and there can be only one).
+    else:
+        bundle_id = jid
+
+    # the resource: URL's prefix is treated too much like a DNS hostname
     unique_prefix = unique_prefix.lower()
-    assert "@" not in unique_prefix
-    assert "." not in unique_prefix
+    unique_prefix = unique_prefix.replace("@", "-at-")
+    unique_prefix = unique_prefix.replace(".", "-dot-")
 
     targets = [target]
     if command == "test":

--- a/python-lib/cuddlefish/preflight.py
+++ b/python-lib/cuddlefish/preflight.py
@@ -55,9 +55,6 @@ def vk_to_jid(vk):
     jid = "jid0-" + s
     return jid
 
-def jid_to_programid(jid):
-    return jid + "@jetpack"
-
 def create_key(keydir, name):
     # return jid
     from ecdsa import SigningKey, NIST256p
@@ -66,7 +63,7 @@ def create_key(keydir, name):
     vk = sk.get_verifying_key()
     vk_text = "public-jid0-%s" % my_b32encode(vk.to_string())
     jid = vk_to_jid(vk)
-    program_id = jid_to_programid(jid)
+    program_id = jid + "@jetpack"
     # save privkey to ~/.jetpack-keys/$jid
     f = open(os.path.join(keydir, jid), "w")
     f.write("private-key: %s\n" % sk_text)
@@ -77,14 +74,19 @@ def create_key(keydir, name):
     f.close()
     return jid
 
-def programid_to_jid(programid):
-    assert programid.endswith("@jetpack")
-    jid = programid[:-len("@jetpack")]
-    return jid
-
 def check_for_privkey(keydir, jid, stderr):
+    # the "anonymous ID" case
     if jid.startswith("anonid0-"):
         return None
+
+    # the "old-style ID" case
+    # FIXME: once it is possible for addons to change from old-style IDs
+    # to new, cryptographic IDs on AMO and in Firefox, warn users that
+    # continuing to use old-style IDs is less secure, and provide them with
+    # instructions for changing to new IDs.
+    if not jid.startswith("jid0-"):
+        return None
+
     keypath = os.path.join(keydir, jid)
     if not os.path.isfile(keypath):
         msg = """\

--- a/python-lib/cuddlefish/tests/test_preflight.py
+++ b/python-lib/cuddlefish/tests/test_preflight.py
@@ -67,7 +67,7 @@ class Util(unittest.TestCase):
                 fieldnames.append(k)
         return fields, fieldnames
 
-    def test_no_name(self):
+    def test_preflight(self):
         basedir = self.make_basedir()
         fn = os.path.join(basedir, "package.json")
         keydir = os.path.join(basedir, "keys")
@@ -156,6 +156,36 @@ class Util(unittest.TestCase):
                         in out, out)
         self.failUnless("If you are the original developer" in out, out)
         self.failUnless("Otherwise, if you are a new developer" in out, out)
+
+        # name and anonymous ID? without asking to see its papers, ship it
+        config3 = '{"name": "my-old-skool-package", "id": "anonid0-deadbeef"}'
+        self.write(config3)
+        out = StringIO()
+        cfg = self.get_cfg()
+        config_was_ok, modified = preflight.preflight_config(cfg, fn,
+                                                             stderr=out,
+                                                             keydir=keydir,
+                                                             err_if_privkey_not_found=False)
+        self.failUnlessEqual(config_was_ok, True)
+        self.failUnlessEqual(modified, False)
+        config3a = self.read()
+        self.failUnlessEqual(config3a, config3)
+        self.failUnlessEqual(out.getvalue().strip(), "")
+
+        # name and old-style ID? with nostalgic trepidation, ship it
+        config4 = '{"name": "my-old-skool-package", "id": "foo@bar.baz"}'
+        self.write(config4)
+        out = StringIO()
+        cfg = self.get_cfg()
+        config_was_ok, modified = preflight.preflight_config(cfg, fn,
+                                                             stderr=out,
+                                                             keydir=keydir,
+                                                             err_if_privkey_not_found=False)
+        self.failUnlessEqual(config_was_ok, True)
+        self.failUnlessEqual(modified, False)
+        config4a = self.read()
+        self.failUnlessEqual(config4a, config4)
+        self.failUnlessEqual(out.getvalue().strip(), "")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Here's a fix for [bug 604499](https://bugzilla.mozilla.org/show_bug.cgi?id=604499) that allows addons to use old-style IDs. As part of this fix, I also added a test for anonymous IDs, which didn't have one. And I removed jid_to_programid, which is called only once, and programid_to_jid, which is never called, as that seemed both a simplification and safer, now that a "jid" can theoretically also represent an old-style ID.
