### PR TITLE
591343 c js module

### DIFF
--- a/packages/api-utils/lib/securable-module.js
+++ b/packages/api-utils/lib/securable-module.js
@@ -245,11 +245,18 @@
                })(sandbox.globalScope.Iterator)
              );
              sandbox.evaluate("var exports = {};");
+             sandbox.evaluate("var module = {exports: exports};");
+             sandbox.evaluate("module.id = '" + module + "';");
+             // circular imports will be inconsistent: if module A assigns to
+             // module.exports, any modules loaded for the first time from
+             // within A will get an empty object from require("A") . We could
+             // forcibly break import cycles by removing the next line.
              self.modules[path] = sandbox.getProperty("exports");
              self.module_infos[path] = module_info;
              if (self.modifyModuleSandbox)
                self.modifyModuleSandbox(sandbox, module_info);
              sandbox.evaluate(module_info);
+             self.modules[path] = sandbox.getProperty("module").exports;
            }
            exports = self.modules[path];
          }

--- a/packages/api-utils/tests/set-exports.js
+++ b/packages/api-utils/tests/set-exports.js
@@ -1,0 +1,2 @@
+
+module.exports = 4;

--- a/packages/api-utils/tests/test-set-exports.js
+++ b/packages/api-utils/tests/test-set-exports.js
@@ -1,0 +1,13 @@
+
+let four = require("set-exports");
+
+exports.testSet = function(test) {
+  test.assertEqual(four, 4);
+}
+
+exports.testModule = function(test) {
+  // module.id is not cast in stone yet. For now, it's just the module name.
+  // In the future, it may include the package name too, or may possibly be a
+  // URL of some sort.
+  test.assertEqual(module.id, "test-set-exports")
+}


### PR DESCRIPTION
This adds 'module' and 'module.exports', and makes the latter assignable. It also adds 'module.id', equal to the short module name (I don't think we should commit to sticking with this value of module.id for the long term: it might be better to use something else).
