### PR TITLE
Bug 616755 - remove Tab.thumbnail property

### DIFF
--- a/packages/addon-kit/docs/tabs.md
+++ b/packages/addon-kit/docs/tabs.md
@@ -191,17 +191,21 @@ The index of the tab relative to other tabs in the application window.
 This property can be set to change it's relative position.
 </api>
 
-<api name="thumbnail">
-@property {string}
-Data URI of a thumbnail of the page currently loaded in the tab.
-This property is read-only.
-</api>
-
 <api name="isPinned">
 @property {boolean}
 Whether or not tab is pinned as an [app tab].
 This property is read-only.
 [app tab]:http://blog.mozilla.com/faaborg/2010/07/28/app-tabs-in-firefox-4-beta-2/
+</api>
+
+<api name="getThumbnail">
+@method
+Calls callback function with a data URI of a thumbnail of the page currently
+loaded in the tab.
+@param options {object}
+An object containing configurable options. _Not implemented yet._
+@param callback {function}
+A function to be called with a data URI string of a thumbnail.
 </api>
 
 <api name="pin">

--- a/packages/addon-kit/tests/test-tabs.js
+++ b/packages/addon-kit/tests/test-tabs.js
@@ -99,8 +99,10 @@ exports.testTabProperties = function(test) {
         test.assert(tab.favicon, "favicon of the new tab is not empty");
         test.assertEqual(tab.style, null, "style of the new tab matches");
         test.assertEqual(tab.index, 1, "index of the new tab matches");
-        test.assertNotEqual(tab.getThumbnailURL(), null, "thumbnail of the new tab matches");
-        closeBrowserWindow(window, function() test.done());
+        tab.getThumbnail({}, function onThumbnail(data) {
+          test.assertNotEqual(data, null, "thumbnail of the new tab matches");
+          closeBrowserWindow(window, function() test.done());
+        });
       }
     });
   });

--- a/packages/api-utils/lib/tabs/tab.js
+++ b/packages/api-utils/lib/tabs/tab.js
@@ -173,8 +173,9 @@ const TabTrait = Trait.compose(EventEmitter, {
    * Thumbnail data URI of the page currently loaded in this tab.
    * @type {String}
    */
-  getThumbnailURL: function getThumbnailURL()
-    getThumbnailURIForWindow(this._contentWindow),
+  getThumbnail: function getThumbnail(options, callback) {
+    Enqueued(callback)(getThumbnailURIForWindow(this._contentWindow))
+  },
   /**
    * Whether or not tab is pinned (Is an app-tab).
    * @type {Boolean}


### PR DESCRIPTION
Implementing [Dietrich's proposal](https://bugzilla.mozilla.org/show_bug.cgi?id=616755#c2) 
