### PR TITLE
contentURL

### DIFF
--- a/packages/addon-kit/docs/page-worker.md
+++ b/packages/addon-kit/docs/page-worker.md
@@ -75,7 +75,7 @@ its `destroy` method is called or the add-on is unloaded.
 @param [options] {object}
   The *`options`* parameter is optional, and if given it should be an object
   with any of the following keys:
-  @prop [contentURL] {URL,string}
+  @prop [contentURL] {string}
     The URL of the content to load in the panel.
   @prop [allow] {object}
     An object with keys to configure the permissions of the Page Worker.
@@ -98,7 +98,7 @@ its `destroy` method is called or the add-on is unloaded.
 </api>
 
 <api name="contentURL">
-@property {URL}
+@property {string}
 The URL of the content loaded.
 </api>
 

--- a/packages/addon-kit/docs/panel.md
+++ b/packages/addon-kit/docs/panel.md
@@ -124,8 +124,8 @@ The width of the panel in pixels.
 </api>
 
 <api name="contentURL">
-@property {URL}
-The [URL](#module/api-utils/url) of the content loaded in the panel.
+@property {string}
+The URL of the content loaded in the panel.
 </api>
 
 <api name="allow">

--- a/packages/addon-kit/docs/widget.md
+++ b/packages/addon-kit/docs/widget.md
@@ -277,9 +277,9 @@ Represents a widget object.
 </api>
 
 <api name="contentURL">
-@property {URL}
-  The [URL](#module/api-utils/url) of content to load into the widget.  This can
-  be [local content](#guide/web-content) or remote content, an image or web
+@property {string}
+  The URL of content to load into the widget.  This can be
+  [local content](#guide/web-content) or remote content, an image or web
   content.  Setting it updates the widget's appearance immediately.  However,
   if the widget was created using `content`, then this property is meaningless,
   and setting it has no effect.

--- a/packages/addon-kit/tests/test-page-worker.js
+++ b/packages/addon-kit/tests/test-page-worker.js
@@ -113,8 +113,8 @@ tests.testAutoDestructor = function(test) {
 tests.testValidateOptions = function(test) {
   test.assertRaises(
     function () Page({ contentURL: 'home' }),
-    "The `contentURL` option must be a URL.",
-    "Validation correctly denied a non-string content"
+    "The `contentURL` option must be a valid URL.",
+    "Validation correctly denied a non-URL contentURL"
   );
 
   test.assertRaises(

--- a/packages/addon-kit/tests/test-panel.js
+++ b/packages/addon-kit/tests/test-panel.js
@@ -1,6 +1,5 @@
 let { Cc, Ci } = require("chrome");
 let panels = require('panel');
-let URL = require("url").URL;
 let tests = {}, panels, Panel;
 
 tests.testPanel = function(test) {
@@ -190,33 +189,22 @@ tests.testContentURLOption = function(test) {
 
   let (panel = Panel({ contentURL: URL_STRING })) {
     test.pass("contentURL accepts a string URL.");
-    test.assert(panel.contentURL instanceof URL,
-                "contentURL is a URL object.");
-    test.assertEqual(panel.contentURL.toString(), URL_STRING,
-                "contentURL stringifies to the string to which it was set.");
-  }
-
-  let url = URL(URL_STRING);
-  let (panel = Panel({ contentURL: url })) {
-    test.pass("contentURL accepts a URL object.");
-    test.assert(panel.contentURL instanceof URL,
-                "contentURL is a URL object.");
-    test.assertEqual(panel.contentURL.toString(), url.toString(),
-                "contentURL stringifies to the URL to which it was set.");
+    test.assertEqual(panel.contentURL, URL_STRING,
+                "contentURL is the string to which it was set.");
   }
 
   let dataURL = "data:text/html," + encodeURIComponent(HTML_CONTENT);
   let (panel = Panel({ contentURL: dataURL })) {
     test.pass("contentURL accepts a data: URL.");
   }
-  
+
   let (panel = Panel({})) {
     test.assert(panel.contentURL == null,
                 "contentURL is undefined.");
   }
 
   test.assertRaises(function () Panel({ contentURL: "foo" }),
-                    "The `contentURL` option must be a URL.",
+                    "The `contentURL` option must be a valid URL.",
                     "Panel throws an exception if contentURL is not a URL.");
 };
 

--- a/packages/api-utils/docs/content/loader.md
+++ b/packages/api-utils/docs/content/loader.md
@@ -65,8 +65,8 @@ them once the DOM content of the page has been loaded.
 </api>
 
 <api name="contentURL">
-@property {URL}
-The URL of the content loaded in the panel.
+@property {string}
+The URL of the content loaded.
 </api>
 
 <api name="allow">

--- a/packages/api-utils/docs/content/symbiont.md
+++ b/packages/api-utils/docs/content/symbiont.md
@@ -94,7 +94,7 @@ them once the DOM content of the page has been loaded.
 </api>
 
 <api name="contentURL">
-@property {URL}
+@property {string}
 The URL of the content loaded.
 </api>
 

--- a/packages/api-utils/lib/content/loader.js
+++ b/packages/api-utils/lib/content/loader.js
@@ -47,7 +47,6 @@ const file = require("file");
 // map of property validations
 const valid = {
   contentURL: {
-    map: function (value) URL(value),
     ok: function (value) {
       try {
         URL(value);
@@ -57,7 +56,7 @@ const valid = {
       }
       return true;
     },
-    msg: 'The `contentURL` option must be a URL.'
+    msg: 'The `contentURL` option must be a valid URL.'
   },
   contentScriptFile: {
     is: ['undefined', 'null', 'string', 'array'],
@@ -136,7 +135,7 @@ const Loader = EventEmitter.compose({
   get contentURL() this._contentURL,
   set contentURL(value) {
     value = validate(value, valid.contentURL);
-    if (this._contentURL + '' != value + '') {
+    if (this._contentURL != value) {
       this._emit('propertyChange', {
         contentURL: this._contentURL = value
       });

--- a/packages/api-utils/tests/test-content-loader.js
+++ b/packages/api-utils/tests/test-content-loader.js
@@ -8,22 +8,22 @@ exports['test:contentURL'] = function(test) {
 
   test.assertRaises(
     function() loader.contentURL = undefined,
-    'The `contentURL` option must be a URL.',
+    'The `contentURL` option must be a valid URL.',
     'Must throw an exception if `contentURL` is not URL.'
   );
    test.assertRaises(
     function() loader.contentURL = null,
-    'The `contentURL` option must be a URL.',
+    'The `contentURL` option must be a valid URL.',
     'Must throw an exception if `contentURL` is not URL.'
   );
   test.assertRaises(
     function() loader.contentURL = 4,
-    'The `contentURL` option must be a URL.',
+    'The `contentURL` option must be a valid URL.',
     'Must throw an exception if `contentURL` is not URL.'
   );
  test.assertRaises(
     function() loader.contentURL = { toString: function() 'Oops' },
-    'The `contentURL` option must be a URL.',
+    'The `contentURL` option must be a valid URL.',
     'Must throw an exception if `contentURL` is not URL.'
   );
 


### PR DESCRIPTION
Since the Loader trait's contentURL property is exposed in high-level addon-kit APIs and the url module is not part of addon-kit, contentURL should be a string, not a URL object.
