### PR TITLE
add a .gitattributes file to exclude certain files from builds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+.gitignore export-ignore
+.hgignore export-ignore
+.hgtags export-ignore
+.gitattributes export-ignore


### PR DESCRIPTION
Certain files should be excluded from builds, namely .gitignore, .hgignore, and .hgtags. This change adds a .gitattributes file that excludes them from builds generated via:

git archive --format=zip --output ~/addon-sdk-1.0b1rc1.zip --worktree-attributes --prefix addon-sdk-1.0b1/ HEAD
git archive --format=tar --output ~/addon-sdk-1.0b1rc1.tar --worktree-attributes --prefix addon-sdk-1.0b1/ HEAD

(where --worktree-attributes is the flag that instructs git to use .gitattributes)

Brian: can you review this and pull it into the canonical repo if it looks good?
