### PR TITLE
propagate exceptions across the process boundary

### DIFF
--- a/packages/api-utils/lib/e10s.js
+++ b/packages/api-utils/lib/e10s.js
@@ -62,7 +62,7 @@ function AddonProcess(jetpack) {
     if (name in syncListeners)
       throw new Error("call already registered for '" + name + "'");
     syncListeners[name] = true;
-    jetpack.registerReceiver(name, errors.catchAndLog(cb));
+    jetpack.registerReceiver(name, errors.catchAndReturn(cb));
   };
 
   this.send = function() {

--- a/packages/api-utils/lib/errors.js
+++ b/packages/api-utils/lib/errors.js
@@ -67,3 +67,24 @@ exports.catchAndLogProps = function catchAndLogProps(object,
                                      logException);
     });
 };
+
+/**
+ * Catch and return an exception while calling the callback.  If the callback
+ * doesn't throw, return the return value of the callback in a way that makes it
+ * possible to distinguish between a return value and an exception.
+ *
+ * This function is useful when you need to pass the result of a call across
+ * a process boundary (across which exceptions don't propagate).  It probably
+ * doesn't need to be factored out into this module, since it is only used by
+ * a single caller, but putting it here works around bug 625560.
+ */
+exports.catchAndReturn = function(callback) {
+  return function() {
+    try {
+      return { returnValue: callback.apply(this, arguments) };
+    }
+    catch (exception) {
+      return { exception: exception };
+    }
+  };
+};

--- a/packages/api-utils/tests/test-errors.js
+++ b/packages/api-utils/tests/test-errors.js
@@ -44,3 +44,19 @@ exports.testCatchAndLogProps = function(test) {
               (thing.bar() == "err"),
               "multiple props should be wrapped if array passed in");
 };
+
+exports.testCatchAndReturn = function(test) {
+  var wrapped = errors.catchAndReturn(function(x) {
+                                        if (x == 1)
+                                          return "one";
+                                        if (x == 2)
+                                          throw new Error("two");
+                                        return this + x;
+                                      });
+
+  test.assertEqual(wrapped(1).returnValue, "one",
+                   "arg should be passed; return value should be returned");
+  test.assert(wrapped(2).exception, "exception should be returned");
+  test.assertEqual(wrapped.call("hi", 3).returnValue, "hi3",
+                   "`this` should be set correctly");
+};


### PR DESCRIPTION
In order to provide developers with more useful information when a blocking cross-process call generates an exception, the exception should be sent back across the process boundary to the originating process, where it can be rethrown.
