### PR TITLE
Bug 616779 - fix this._port is null in tests by adding a forgotten widget.destroy()

### DIFF
--- a/packages/addon-kit/tests/test-widget.js
+++ b/packages/addon-kit/tests/test-widget.js
@@ -507,6 +507,7 @@ exports.testWidgetMessaging = function testWidgetMessaging(test) {
         widget.postMessage(origMessage);
       else {
         test.assertEqual(origMessage, message);
+        widget.destroy();
         test.done();
       }
     }


### PR DESCRIPTION
From https://bugzilla.mozilla.org/show_bug.cgi?id=616779#c14

Running the full test suite or just these two tests:
    $ cfx test -b /Applications/Minefield.app -v -f "test-widget|test-windows"

fails (failure text below). This patch adds a widget.destroy() to fix the test.

<pre>
...
  File "resource://addon-kit-addon-kit-tests/test-widget.js", line 507, in 
    widget.postMessage(origMessage);
  File "resource://addon-kit-addon-kit-lib/widget.js", line 205, in Widget_postMessage
    browserManager.updateItem(this._public, "postMessage", message);
  File "resource://addon-kit-addon-kit-lib/widget.js", line 273, in browserManager_updateItem
    this.windows.forEach(function (w) w.updateItem(item, property, value));
  File "resource://addon-kit-addon-kit-lib/widget.js", line 273, in 
    this.windows.forEach(function (w) w.updateItem(item, property, value));
  File "resource://addon-kit-addon-kit-lib/widget.js", line 414, in BW_updateItem
    item.symbiont.postMessage(value);
  File "resource://addon-kit-api-utils-lib/content/worker.js", line 75, in postMessage
    this._port._asyncEmit('message',  JSON.parse(JSON.stringify(data)));

TypeError: this._port is null
</pre>
