### PR TITLE
Add an empty test to the annotator example (follow-up to bug 624607)

### DIFF
--- a/examples/annotator/tests/test-main.js
+++ b/examples/annotator/tests/test-main.js
@@ -1,0 +1,3 @@
+exports.testMain = function(test) {
+  test.pass("TODO: Write some tests.");
+};


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=624607 added a new example without any tests, making cfx testex and cfx testall fail when attempting to test it:

Testing annotator...
Using binary at '/Applications/Minefield.app/Contents/MacOS/firefox-bin'.
Using profile at '/var/folders/Mm/MmHGbDXZHGqXIK97vgbSaU+++TI/-Tmp-/tmpEeY_94.mozrunner'.
Running tests on Firefox 4.0b12pre/Gecko 2.0b12pre ({ec8030f7-c20a-464f-9b0e-13a3a9e97384}) under Darwin/x86-gcc3.

0 of 0 tests passed.
No tests were run
FAIL
