### PR TITLE
Titlebars, name and id for Panels

### DIFF
--- a/packages/addon-kit/docs/panel.md
+++ b/packages/addon-kit/docs/panel.md
@@ -1,5 +1,6 @@
 <!-- contributed by Myk Melez [myk@mozilla.org] -->
 <!-- contributed by Irakli Gozalishvili [gozala@mozilla.com] -->
+<!-- contributed by Rob Campbell [rcampbell@mozilla.com] -->
 
 The `panel` module creates floating modal "popup dialogs" that appear on top of
 web content and browser chrome and persist until dismissed by users or programs.
@@ -89,12 +90,19 @@ Creates a panel.
     The width of the panel in pixels. Optional.
   @prop [height] {number}
     The height of the panel in pixels. Optional.
+  @prop [name] {string}
+    An optional string giving the panel a name. If used with the [titlebar]
+    option, the name will be used as the titlebar's label.
+  @prop [titlebar] {boolean}
+    An optional boolean property enabling or disabling a draggable titlebar in
+    the panel. If set to true, the properties "noautohide" and "close"
+    (button) will also be set for the panel.
   @prop [contentURL] {string}
     The URL of the content to load in the panel.
   @prop [allow] {object}
-    An optional object describing permissions for the content.  It should
+    An optional object describing permissions for the content. It should
     contain a single key named `script` whose value is a boolean that indicates
-    whether or not to execute script in the content.  `script` defaults to true.
+    whether or not to execute script in the content. `script` defaults to true.
   @prop [contentScriptFile] {string,array}
     A local file URL or an array of local file URLs of content scripts to load.
     Content scripts specified by this property are loaded *before* those
@@ -124,6 +132,16 @@ The height of the panel in pixels.
 <api name="width">
 @property {number}
 The width of the panel in pixels.
+</api>
+
+<api name="titlebar">
+@property {boolean}
+Create the panel with a titlebar.
+</api>
+
+<api name="name">
+@property {string}
+The name of the panel. Will be used as the panel's titlebar label if present.
 </api>
 
 <api name="contentURL">

--- a/packages/addon-kit/lib/panel.js
+++ b/packages/addon-kit/lib/panel.js
@@ -20,6 +20,7 @@
  * Contributor(s):
  *   Myk Melez <myk@mozilla.org> (Original Author)
  *   Irakli Gozalishvili <gozala@mazilla.com>
+ *   Rob Campbell <rcampbell@mozilla.com>
  *
  * Alternatively, the contents of this file may be used under the terms of
  * either the GNU General Public License Version 2 or later (the "GPL"), or
@@ -111,6 +112,10 @@ const Panel = Symbiont.resolve({
       this.height = options.height;
     if ('contentURL' in options)
       this.contentURL = options.contentURL;
+    if ('name' in options)
+      this.name = options.name;
+    if ('titlebar' in options)
+      this.titlebar = options.titlebar;
 
     this._init(options);
   },
@@ -133,8 +138,14 @@ const Panel = Symbiont.resolve({
   /* Public API: Panel.height */
   get height() this._height,
   set height(value)
-    this._height =  valid({ $: value }, { $: validNumber }).$ || this._height,
+    this._height = valid({ $: value }, { $: validNumber }).$ || this._height,
   _height: 240,
+  /* Public API: Panel.titlebar */
+  get titlebar() this._titlebar,
+  set titlebar(value) this._titlebar = value,
+  /* Public API: Panel.name */
+  get name() this._name,
+  set name(value) this._name = value,
   /* Public API: Panel.show */
   show: function show(anchor) {
     anchor = anchor || null;
@@ -148,9 +159,16 @@ const Panel = Symbiont.resolve({
       frame.setAttribute('transparent', 'transparent');
       // Load an empty document in order to have an immediatly loaded iframe, 
       // so swapFrameLoaders is going to work without having to wait for load.
-      frame.setAttribute("src","data:,"); 
+      frame.setAttribute("src", "data:,"); 
       xulPanel.appendChild(frame);
       document.getElementById("mainPopupSet").appendChild(xulPanel);
+    }
+    if (this.titlebar) {
+      xulPanel.setAttribute("titlebar", "normal");
+      xulPanel.setAttribute("noautohide", "true");
+      xulPanel.setAttribute("close", "true");
+      if (this.name)
+        xulPanel.label = this.name;
     }
     let { width, height } = this, when = 'before_start', x, y;
     // Open the popup by the anchor.

--- a/packages/addon-kit/tests/test-panel.js
+++ b/packages/addon-kit/tests/test-panel.js
@@ -139,6 +139,35 @@ tests.testSeveralShowHides = function(test) {
   panel.show();
 };
 
+tests.testNameAndTitlebar = function(test) {
+  test.waitUntilDone();
+  let panelTitle = "Panelwerld!";
+  let panel = panels.Panel({
+    contentURL: "about:buildconfig",
+    contentScript: "postMessage('')",
+    contentScriptWhen: "ready",
+    titlebar: true,
+    name: panelTitle,
+    onMessage: function() {
+      panel.show();
+    },
+    onShow: function () {
+      test.pass("the panel was shown");
+      test.assert(panel.titlebar, "the panel has a titlebar");
+      test.assertEqual(panel.name, panelTitle, "the panel's name attribute is" +
+        "equal to Panelwerld!");
+      panel.hide();
+    },
+    onHide: function () {
+      test.pass("panel hidden");
+      test.done();
+    }
+  });
+  panel.on('error', function(e) {
+    test.fail('error was emitted:' + e.message + '\n' + e.stack);
+  });
+};
+
 function makeEventOrderTest(options) {
   let expectedEvents = [];
 


### PR DESCRIPTION
Patches provide option to create a titlebar with closebutton and label in panel.js. An optional id can also be set.
