### PR TITLE
bug 618283 Timeout test page mod

### DIFF
--- a/packages/addon-kit/tests/pagemod-test-helpers.js
+++ b/packages/addon-kit/tests/pagemod-test-helpers.js
@@ -7,7 +7,7 @@ const {Cc,Ci} = require("chrome");
  * and checks the effect of the page mod on 'onload' event via testCallback.
  */
 exports.testPageMod = function testPageMod(test, testURL, pageModOptions,
-                                           testCallback) {
+                                           testCallback, timeout) {
   var xulApp = require("xul-app");
   if (!xulApp.versionInRange(xulApp.platformVersion, "1.9.3a3", "*") &&
       !xulApp.versionInRange(xulApp.platformVersion, "1.9.2.7", "1.9.2.*")) {
@@ -24,7 +24,12 @@ exports.testPageMod = function testPageMod(test, testURL, pageModOptions,
     return null;
   }
 
-  test.waitUntilDone();
+  if (timeout !== undefined) {
+	test.waitUntilDone(timeout);
+  } else {
+    test.waitUntilDone();
+  }
+
   let loader = test.makeSandboxedLoader();
   let pageMod = loader.require("page-mod");
 


### PR DESCRIPTION
Add timeout parameter to testPageMod helper function.

Especially pageMod tests on real web pages could take enormous amount of time before ending, where default timeout period always passes.
