### PR TITLE
Bug 648077 - Error in `assert.throws`

### DIFF
--- a/packages/api-utils/lib/test/assert.js
+++ b/packages/api-utils/lib/test/assert.js
@@ -297,10 +297,10 @@ Assert.prototype = {
       };
 
       if (exception)
-        failure = e.actual = exception;
+        failure.actual = exception;
 
       if (Error)
-        failure = e.expected = Error;
+        failure.expected = Error;
 
       this.fail(failure);
     }


### PR DESCRIPTION
Fixing error introduced with refactoring.
