### PR TITLE
Warning message for when cfx cannot find Firefox version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ jetpack-sdk-docs/
 # You can do this by creating ~/.gitignore and then running:
 #
 # git config --global core.excludesfile ~/.gitignore
+*.swp
+*.pyc

--- a/python-lib/cuddlefish/runner.py
+++ b/python-lib/cuddlefish/runner.py
@@ -266,21 +266,26 @@ def run_app(harness_root_dir, harness_options,
                           kp_kwargs=popen_kwargs)
 
     print "Using binary at '%s'." % runner.binary
-    
+
     platform_repo = runner.get_repositoryInfo().get('platform_repository')
-    mo = re.search(r"mozilla-(\d+)", platform_repo)
-    if not mo:
-        print "unable to find a mozilla version string in", platform_repo
-        return
-    version = mo.group(1)
-    if int(version) < 2:
-        print """
-cfx requires Firefox 4 or greater and is unable to find a compatible binary.
-Please install a newer version of Firefox or provide the path to your existing 
-compatible version with the --binary flag: 
-    
-  cfx --binary=PATH_TO_FIREFOX_BINARY"""
-        return
+
+    if not platform_repo:
+        print "WARNING: Unable to find 'SourceRepository' in %s" % os.path.join(os.path.dirname(runner.binary), 'platform.ini')
+        print "         Cannot guarantee firefox version, please ensure you are running 4.0 or higher"
+    else:
+        mo = re.search(r"mozilla-(\d+)", platform_repo)
+        if not mo:
+            print "unable to find a mozilla version string in", platform_repo
+            return
+        version = mo.group(1)
+        if int(version) < 2:
+            print """
+    cfx requires Firefox 4 or greater and is unable to find a compatible binary.
+    Please install a newer version of Firefox or provide the path to your existing 
+    compatible version with the --binary flag: 
+        
+      cfx --binary=PATH_TO_FIREFOX_BINARY"""
+            return
     
     print "Using profile at '%s'." % profile.profile
 


### PR DESCRIPTION
Added a warning message that appears when cfx cannot find the Firefox
version and therefore cannot confirm Firefox version > 4.0

The method 'get_repositoryInfo()' in **init**.py sets a value of 'None' for key 'platform_repository' in its return value when it cannot find platform.ini. This causes the version check in 'run_app()' in 'runner.py' to fail as it attempts to perform a regex match with 'None' instead of a string.
