### PR TITLE
Bug 654095 - fix link-time package search behavior.

### DIFF
--- a/python-lib/cuddlefish/__init__.py
+++ b/python-lib/cuddlefish/__init__.py
@@ -690,7 +690,7 @@ def run(arguments=sys.argv[1:], target_cfg=None, pkg_cfg=None,
     from cuddlefish.manifest import build_manifest
     uri_prefix = "resource://%s" % unique_prefix
     include_tests = False #bool(command=="test")
-    manifest = build_manifest(target_cfg, pkg_cfg, uri_prefix, include_tests)
+    manifest = build_manifest(target_cfg, pkg_cfg, deps, uri_prefix, include_tests)
     harness_options['manifest'] = manifest.get_harness_options_manifest(uri_prefix)
 
     if command == 'xpi':

--- a/python-lib/cuddlefish/tests/linker-files/one/lib/main.js
+++ b/python-lib/cuddlefish/tests/linker-files/one/lib/main.js
@@ -1,0 +1,5 @@
+var panel = require("panel");
+var two = require("two");
+var a = require("./two");
+var b = require("addon-kit/tabs");
+var c = require("./subdir/three");

--- a/python-lib/cuddlefish/tests/linker-files/one/lib/subdir/three.js
+++ b/python-lib/cuddlefish/tests/linker-files/one/lib/subdir/three.js
@@ -1,0 +1,2 @@
+exports.foo = 1;
+var main = require("../main");

--- a/python-lib/cuddlefish/tests/linker-files/one/lib/two.js
+++ b/python-lib/cuddlefish/tests/linker-files/one/lib/two.js
@@ -1,0 +1,4 @@
+
+// this ought to find our sibling, not packages/development-mode/lib/main.js
+var main = require("main");
+exports.foo = 1;

--- a/python-lib/cuddlefish/tests/linker-files/one/package.json
+++ b/python-lib/cuddlefish/tests/linker-files/one/package.json
@@ -1,0 +1,3 @@
+{ "name": "one",
+  "main": "main"
+}

--- a/python-lib/cuddlefish/tests/test_linker.py
+++ b/python-lib/cuddlefish/tests/test_linker.py
@@ -1,0 +1,50 @@
+import os.path
+import unittest
+from cuddlefish import packaging, manifest
+from cuddlefish.bunch import Bunch
+
+def up(path, generations=1):
+    for i in range(generations):
+        path = os.path.dirname(path)
+    return path
+
+class Basic(unittest.TestCase):
+    def setUp(self):
+        self.root = up(os.path.abspath(__file__), 4)
+    def get_pkg(self, name):
+        d = os.path.join(up(os.path.abspath(__file__)), "linker-files", name)
+        return packaging.get_config_in_dir(d)
+
+    def test_deps(self):
+        target_cfg = self.get_pkg("one")
+        pkg_cfg = packaging.build_config(self.root, target_cfg)
+        deps = packaging.get_deps_for_targets(pkg_cfg, ["one"])
+        self.failUnlessEqual(deps, ["one"])
+        deps = packaging.get_deps_for_targets(pkg_cfg,
+                                              [target_cfg.name, "addon-kit"])
+        self.failUnlessEqual(deps, ["addon-kit", "api-utils", "one"])
+
+    def assertReqIs(self, manifest, modname, reqname, uri):
+        reqs = manifest["P/one-lib/%s.js" % modname]["requirements"]
+        self.failUnlessEqual(reqs[reqname]["uri"], uri)
+
+    def test_manifest(self):
+        target_cfg = self.get_pkg("one")
+        pkg_cfg = packaging.build_config(self.root, target_cfg)
+        deps = packaging.get_deps_for_targets(pkg_cfg,
+                                              [target_cfg.name, "addon-kit"])
+        self.failUnlessEqual(deps, ["addon-kit", "api-utils", "one"])
+        m = manifest.build_manifest(target_cfg, pkg_cfg, deps,
+                                    "P/", scan_tests=False)
+        m = m.get_harness_options_manifest("P/")
+        self.assertReqIs(m, "main", "panel", "P/addon-kit-lib/panel.js")
+        self.assertReqIs(m, "main", "two", "P/one-lib/two.js")
+        self.assertReqIs(m, "main", "./two", "P/one-lib/two.js")
+        self.assertReqIs(m, "main", "addon-kit/tabs", "P/addon-kit-lib/tabs.js")
+        self.assertReqIs(m, "main", "./subdir/three", "P/one-lib/subdir/three.js")
+        self.assertReqIs(m, "two", "main", "P/one-lib/main.js")
+        self.assertReqIs(m, "subdir/three", "../main", "P/one-lib/main.js")
+
+if __name__ == '__main__':
+    unittest.main()
+    


### PR DESCRIPTION
Change the search rules to find bare require("MOD") imports in the current
package, before checking others. Also allow require("DIR/MOD") to search
other "library" packages. Restrict all searches to "deps", the list of
packages found by traversing the package.json ".dependencies" property. For
normal addons, this should exclude the "development-mode" and "test-harness"
packages, just like the linker worked before the link-time search changes
landed.

Original patch by Irakli, cleanups and tests by warner.
This incorporates and obsoletes (due to a rebase/rewrite) https://github.com/mozilla/addon-sdk/pull/154
