### PR TITLE
Bug 649361 - require("passwords").store() throws exception if optional onComplete not provided

### DIFF
--- a/packages/addon-kit/lib/passwords.js
+++ b/packages/addon-kit/lib/passwords.js
@@ -51,8 +51,8 @@ const defer = require("utils/function").Enqueued;
  */
 function getCallbacks(options) {
   let value = [
-    'onComplete' in options ? defer(options.onComplete) : null,
-    'onError' in options ? defer(options.onError) : defer(console.exception)
+    'onComplete' in options ? options.onComplete : null,
+    'onError' in options ? defer(options.onError) : console.exception
   ];
 
   delete options.onComplete;
@@ -70,7 +70,16 @@ function createWrapperMethod(wrapped) {
   return function (options) {
     let [ onComplete, onError ] = getCallbacks(options);
     try {
-      onComplete(wrapped(options));
+      let value = wrapped(options);
+      if (onComplete) {
+        defer(function() {
+          try {
+            onComplete(value);
+          } catch (exception) {
+            onError(exception);
+          }
+        })();
+      }
     } catch (exception) {
       onError(exception);
     }

--- a/packages/addon-kit/tests/test-passwords.js
+++ b/packages/addon-kit/tests/test-passwords.js
@@ -30,6 +30,34 @@ exports["test store requires `username` field"] = function(assert, done) {
   });
 };
 
+exports["test onComplete is optional"] = function(assert, done) {
+  store({
+    realm: "bla",
+    username: "bla",
+    password: "bla",
+    onError: function onError() {
+      assert.fail("onError was called");
+    }
+  });
+  assert.pass("exception is not thrown if `onComplete is missing")
+  done();
+};
+
+exports["test exceptions in onComplete are reported"] = function(assert, done) {
+  store({
+    realm: "throws",
+    username: "error",
+    password: "boom!",
+    onComplete: function onComplete(error) {
+      throw new Error("Boom!")
+    },
+    onError: function onError(error) {
+      assert.equal(error.message, "Boom!", "Error thrown is reported");
+      done();
+    }
+  });
+};
+
 exports["test store requires `realm` field"] = function(assert, done) {
   store({
     username: "foo",


### PR DESCRIPTION
Catching exceptions thrown by `onComplete` in order to log them via`onError` and making `onComplete` truly optional. 
