### PR TITLE
Bug 565765 - Add assertStrictEqual and assertNotStrictEqual for ===

### DIFF
--- a/packages/addon-kit/tests/test-context-menu.js
+++ b/packages/addon-kit/tests/test-context-menu.js
@@ -1054,13 +1054,13 @@ exports.testInsertionPoint = function (test) {
   let insertionPoint = loader.globalScope.insertionPoint;
 
   let ip = insertionPoint("a", []);
-  test.assert(ip === null, "Insertion point should be null");
+  test.assertStrictEqual(ip, null, "Insertion point should be null");
 
   ip = insertionPoint("a", mockElts(["b"]));
   test.assertEqual(ip.label, "b", "Insertion point should be 'b'");
 
   ip = insertionPoint("c", mockElts(["b"]));
-  test.assert(ip === null, "Insertion point should be null");
+  test.assertStrictEqual(ip, null, "Insertion point should be null");
 
   ip = insertionPoint("b", mockElts(["a", "c"]));
   test.assertEqual(ip.label, "c", "Insertion point should be 'c'");
@@ -1072,7 +1072,7 @@ exports.testInsertionPoint = function (test) {
   test.assertEqual(ip.label, "b", "Insertion point should be 'b'");
 
   ip = insertionPoint("d", mockElts(["a", "b", "c"]));
-  test.assert(ip === null, "Insertion point should be null");
+  test.assertStrictEqual(ip, null, "Insertion point should be null");
 
   test.done();
 };

--- a/packages/api-utils/lib/unit-test.js
+++ b/packages/api-utils/lib/unit-test.js
@@ -199,6 +199,36 @@ TestRunner.prototype = {
     }
   },
 
+  assertNotStrictEqual: function assertNotStrictEqual(a, b, message) {
+    if (a !== b) {
+      if (!message)
+        message = "a !== b !== " + uneval(a);
+      this.pass(message);
+    } else {
+      var equality = uneval(a) + " === " + uneval(b);
+      if (!message)
+        message = equality;
+      else
+        message += " (" + equality + ")";
+      this.fail(message);
+    }
+  },
+
+  assertStrictEqual: function assertStrictEqual(a, b, message) {
+    if (a === b) {
+      if (!message)
+        message = "a === b === " + uneval(a);
+      this.pass(message);
+    } else {
+      var inequality = uneval(a) + " !== " + uneval(b);
+      if (!message)
+        message = inequality;
+      else
+        message += " (" + inequality + ")";
+      this.fail(message);
+    }
+  },
+
   done: function done() {
     if (!this.isDone) {
       this.isDone = true;

--- a/packages/api-utils/tests/test-url.js
+++ b/packages/api-utils/tests/test-url.js
@@ -129,10 +129,10 @@ exports.testURL = function(test) {
   test.assertEqual(b.toString(),
                    "h:foo",
                    "a URL can be initialized from another URL");
-  test.assert(a !== b,
-              "a URL initialized from another URL is not the same object");
+  test.assertNotStrictEqual(a, b,
+                            "a URL initialized from another URL is not the same object");
   test.assert(a == "h:foo",
               "toString is implicit when a URL is compared to a string via ==");
-  test.assert(a + "" === "h:foo",
-              "toString is implicit when a URL is concatenated to a string");
+  test.assertStrictEqual(a + "", "h:foo",
+                         "toString is implicit when a URL is concatenated to a string");
 };


### PR DESCRIPTION
This adds the methods to the exported object from unit-test.js and updates existing tests that are following the assert(a === b) formula.

I just `grep`ed in `packages/api-utils/tests` and `packages/addon-kit/tests` for `===` and `!==` looking for lines with assert. There were some matches in `interoperablejs-read-only`, but "read-only" sounded like I shouldn't touch it.
