### PR TITLE
Bug 651590 - worker tab property pointing at activeTab, not page-mod tab

### DIFF
--- a/packages/addon-kit/tests/test-page-mod.js
+++ b/packages/addon-kit/tests/test-page-mod.js
@@ -301,7 +301,8 @@ exports['test tab worker on message'] = function(test) {
             if (this.tab.url === url1) {
               worker1 = this;
               tabs.open({ url: url2, inBackground: true });
-            } else if (this.tab.url === url2) {
+            }
+            else if (this.tab.url === url2) {
               mod.destroy();
               worker1.tab.close();
               worker1.destroy();


### PR DESCRIPTION
Creating a test with a scenario described under [bug-651590](https://bugzilla.mozilla.org/show_bug.cgi?id=651590)
