### PR TITLE
Bug 592512 - don't use constant filename for resultsfile

### DIFF
--- a/python-lib/cuddlefish/runner.py
+++ b/python-lib/cuddlefish/runner.py
@@ -225,10 +225,16 @@ def run_app(harness_root_dir, harness_options,
     
     if args:
         cmdargs.extend(shlex.split(args))
-    
-    resultfile = os.path.join(tempfile.gettempdir(), 'harness_result')
-    if os.path.exists(resultfile):
-        os.remove(resultfile)
+
+    # tempfile.gettempdir() was constant, preventing two simultaneous "cfx
+    # run"/"cfx test" on the same host. On unix it points at /tmp (which is
+    # world-writeable), enabling a symlink attack (e.g. imagine some bad guy
+    # does 'ln -s ~/.ssh/id_rsa /tmp/harness_result'). NamedTemporaryFile
+    # gives us a unique filename that fixes both problems. We leave the
+    # (0-byte) file in place until the browser-side code starts writing to
+    # it, otherwise the symlink attack becomes possible again.
+    fileno,resultfile = tempfile.mkstemp(prefix="harness-result-")
+    os.close(fileno)
     harness_options['resultFile'] = resultfile
 
     def maybe_remove_logfile():
@@ -241,7 +247,8 @@ def run_app(harness_root_dir, harness_options,
         if not logfile:
             # If we're on Windows, we need to keep a logfile simply
             # to print console output to stdout.
-            logfile = os.path.join(tempfile.gettempdir(), 'harness_log')
+            fileno,logfile = tempfile.mkstemp(prefix="harness-log-")
+            os.close(fileno)
         logfile_tail = follow_file(logfile)
         atexit.register(maybe_remove_logfile)
 
@@ -309,11 +316,12 @@ def run_app(harness_root_dir, harness_options,
                     sys.stderr.flush()
             if os.path.exists(resultfile):
                 output = open(resultfile).read()
-                if output in ['OK', 'FAIL']:
-                    done = True
-                else:
-                    sys.stderr.write("Hrm, resultfile (%s) contained something weird (%d bytes)\n" % (resultfile, len(output)))
-                    sys.stderr.write("'"+output+"'\n")
+                if output:
+                    if output in ['OK', 'FAIL']:
+                        done = True
+                    else:
+                        sys.stderr.write("Hrm, resultfile (%s) contained something weird (%d bytes)\n" % (resultfile, len(output)))
+                        sys.stderr.write("'"+output+"'\n")
             if timeout and (time.time() - starttime > timeout):
                 raise Exception("Wait timeout exceeded (%ds)" %
                                 timeout)


### PR DESCRIPTION
Previously, 'cfx run' and 'cfx test' on unix put results in a constant file
in /tmp/, so two users on the same box could not run simultaneously, and a
symlink attack was possible. OS-X uses a per-user tempfile, preventing the
symlink attack, but still preventing one user from running two sets of tests
at the same time.

This changes those commands to use a unique filename for each run, avoiding
both problems. It uses tempfile.mkstemp() to be python2.5-safe.

@gozala , please review.. it's very close to the previous version you reviewed, but with a different tempfile-making function.
