### PR TITLE
Bug 651590 - worker tab property pointing at activeTab, not page-mod tab

### DIFF
--- a/packages/addon-kit/tests/test-page-mod.js
+++ b/packages/addon-kit/tests/test-page-mod.js
@@ -282,8 +282,8 @@ exports['test tab worker on message'] = function(test) {
   let tabs = require("tabs");
   let { PageMod } = require("page-mod");
 
-  let url1 = "data:text/html,<title>#1</title><h1>worker#1.tab</h1>";
-  let url2 = "data:text/html,<title>#2</title><h1>worker#2.tab</h1>";
+  let url1 = "data:text/html,<title>tab1</title><h1>worker1.tab</h1>";
+  let url2 = "data:text/html,<title>tab2</title><h1>worker2.tab</h1>";
   let worker1 = null;
 
   let mod = PageMod({


### PR DESCRIPTION
Removing `#` symbol from data URIs in test to avoid url encoding issues on nightly. Not sure if this is related to the errors we see on build bots though: http://tinderbox.mozilla.org/showbuilds.cgi?tree=Jetpack&hours=72

Also don't know how this can be verified without pushing this.
