### PR TITLE
Bug 660873 - cfx xpi creates corrupted add-ons if directories.lib is '.'

### DIFF
--- a/packages/api-utils/lib/securable-module.js
+++ b/packages/api-utils/lib/securable-module.js
@@ -589,7 +589,8 @@
    exports.CompositeFileSystem = function CompositeFileSystem(options) {
      // We sort file systems in alphabetical order of a package name.
      this.fses = options.fses.sort(function(a, b) a.root > b.root);
-     this.jetpackID = options.jetpackID;
+     this.jetpackID = options.jetpackID.
+                              replace(/\@/g, '-at-').replace(/\./, '-dot-');
      this.name = options.name;
      this.packages = options.metadata || {};
    };


### PR DESCRIPTION
Replacing `@` and `.` with `-at-` and `-dot-` to match cuddlefish's behavior. Without this change runtime checks fail for packages that specify package `id` manually.
