### PR TITLE
Bug 660724 - Make sure page-mod can use regex "include" properties now that match-pattern supports them.

### DIFF
--- a/packages/addon-kit/lib/page-mod.js
+++ b/packages/addon-kit/lib/page-mod.js
@@ -55,7 +55,6 @@ const HAS_DOCUMENT_ELEMENT_INSERTED =
         xulApp.versionInRange(xulApp.platformVersion, "2.0b6", "*");
 const ON_CONTENT = HAS_DOCUMENT_ELEMENT_INSERTED ? 'document-element-inserted' :
                    'content-document-global-created';
-const ERR_INCLUDE = 'The PageMod must have a string or array `include` option.';
 
 // Workaround bug 642145: document-element-inserted is fired multiple times.
 // This bug is fixed in Firefox 4.0.1, but we want to keep FF 4.0 compatibility
@@ -115,12 +114,6 @@ const PageMod = Loader.compose(EventEmitter, {
     rules.on('add', this._onRuleAdd = this._onRuleAdd.bind(this));
     rules.on('remove', this._onRuleRemove = this._onRuleRemove.bind(this));
 
-    // Validate 'include'
-    if (typeof(include) == "object" && !Array.isArray(include))
-      throw new Error(ERR_INCLUDE);
-    if (typeof(include) == "number" || typeof(include) == "undefined")
-      throw new Error(ERR_INCLUDE);
-
     if (Array.isArray(include))
       rules.add.apply(null, include);
     else
@@ -128,7 +121,7 @@ const PageMod = Loader.compose(EventEmitter, {
 
     this.on('error', this._onUncaughtError = this._onUncaughtError.bind(this));
     pageModManager.add(this._public);
-    
+
     this._loadingWindows = [];
   },
 
@@ -138,32 +131,32 @@ const PageMod = Loader.compose(EventEmitter, {
     pageModManager.remove(this._public);
     this._loadingWindows = [];
   },
-  
+
   _loadingWindows: [],
-  
+
   _onContent: function _onContent(window) {
     // not registered yet
     if (!pageModManager.has(this))
       return;
-    
+
     if (!HAS_BUG_642145_FIXED) {
       if (this._loadingWindows.indexOf(window) != -1)
         return;
       this._loadingWindows.push(window);
     }
-    
+
     if ('start' == this.contentScriptWhen) {
       this._createWorker(window);
       return;
     }
-    
+
     let eventName = 'end' == this.contentScriptWhen ? 'load' : 'DOMContentLoaded';
     let self = this;
     window.addEventListener(eventName, function onReady(event) {
       if (event.target.defaultView != window)
         return;
       window.removeEventListener(eventName, onReady, true);
-      
+
       self._createWorker(window);
     }, true);
   },
@@ -178,7 +171,7 @@ const PageMod = Loader.compose(EventEmitter, {
     let self = this;
     worker.once('detach', function detach() {
       worker.destroy();
-      
+
       if (!HAS_BUG_642145_FIXED) {
         let idx = self._loadingWindows.indexOf(window);
         if (idx != -1)

--- a/packages/addon-kit/tests/test-page-mod.js
+++ b/packages/addon-kit/tests/test-page-mod.js
@@ -19,7 +19,7 @@ exports.delay = function(test) {
 exports.testPageMod1 = function(test) {
   let pageMod;
   [pageMod] = testPageMod(test, "about:", [{
-      include: "about:*",
+      include: /about:/,
       contentScriptWhen: 'end',
       contentScript: 'new ' + function WorkerScope() {
         window.document.body.setAttribute("JEP-107", "worked");
@@ -116,7 +116,7 @@ exports.testPageModErrorHandling = function(test) {
   test.assertRaises(function() {
       new pageMod.PageMod();
     },
-    'The PageMod must have a string or array `include` option.',
+    'pattern is undefined',
     "PageMod() throws when 'include' option is not specified.");
 };
 


### PR DESCRIPTION
Remove custom error handling for `include`, since `MatchPattern` will throw error with appropriate error message if wrong value is used.
