### PR TITLE
Bug 661652 - Annotator's text content has become invisible in 1.0RC

### DIFF
--- a/examples/annotator/data/annotation/annotation.html
+++ b/examples/annotator/data/annotation/annotation.html
@@ -8,7 +8,6 @@
 
 body {
         font: 100% arial, helvetica, sans-serif;
-        background-color: #F5F5F5;
     }
 
 div {

--- a/examples/annotator/data/editor/annotation-editor.html
+++ b/examples/annotator/data/editor/annotation-editor.html
@@ -5,15 +5,21 @@
 <head>
   <title>Annotation</title>
   <style type="text/css" media="all">
-  body {
+  body, html {
     font: 100% arial, helvetica, sans-serif;
-    background-color: #F5F5F5;
+    padding: 0;
+    margin: 0;
+    position: fixed;
   }
   textarea {
-    width: 180px;
-    height: 180px;
+    width: 100%;
+    height: 100%;
     margin: 10px;
-    padding: 0px;
+    padding: 0;
+    color: inherit !important;
+    font: inherit !important;
+    background: transparent;
+    border: none;
   }
   </style>
 


### PR DESCRIPTION
Switch to default color scheme so that it looks as native in all platforms.
