### PR TITLE
Ignore .DS_Store files when building the XPI

### DIFF
--- a/python-lib/cuddlefish/xpi.py
+++ b/python-lib/cuddlefish/xpi.py
@@ -19,7 +19,7 @@ def build_xpi(template_root_dir, manifest, xpi_name,
         zf.write(str(harness_options['icon64']), 'icon64.png')
         del harness_options['icon64']
 
-    IGNORED_FILES = [".hgignore", "install.rdf", 
+    IGNORED_FILES = [".hgignore", ".DS_Store", "install.rdf",
                      "application.ini", xpi_name]
     IGNORED_FILE_SUFFIXES = ["~"]
     IGNORED_DIRS = [".svn", ".hg", ".git"]


### PR DESCRIPTION
When extensions are built on OSX, all the .DS_Store files get into the XPI as well. This adds them to the ignore list so they are not packaged.

@warner can you review this?
