### PR TITLE
Please add overrideMimeType option to Request class. 

### DIFF
--- a/packages/addon-kit/lib/request.js
+++ b/packages/addon-kit/lib/request.js
@@ -61,7 +61,11 @@ const validator = new OptionsValidator({
   },
   contentType: {
     map: function (v) v || "application/x-www-form-urlencoded",
-    is:  ["string"]
+    is:  ["string"],
+  },
+  overrideMimeType: {
+    map: function(v) v || null,
+    is: ["string", "null"],
   }
 });
 
@@ -106,6 +110,11 @@ function Request(options) {
     // set other headers
     for (let k in options.headers) {
       request.setRequestHeader(k, options.headers[k]);
+    }
+
+    // set overrideMimeType
+    if (options.overrideMimeType) {
+      request.overrideMimeType(options.overrideMimeType);
     }
 
     // handle the readystate, create the response, and call the callback


### PR DESCRIPTION
Hi,

Now I'm using this sdk to create extension.
However some response which created by request module has garbled characters.

In raw xmlhttprequest, we can use overrideMimeType option to resolve this problem.
However request.Request don't have this option.

This patch will add this option.

GM_xmlhttprequest function in greasemonkey api already has this option.
https://github.com/greasemonkey/greasemonkey/blob/master/content/xmlhttprequester.js#L64
