### PR TITLE
Bug 676616 self.data.url() should not return a string with 'undefined'

### DIFF
--- a/packages/api-utils/lib/self-maker.js
+++ b/packages/api-utils/lib/self-maker.js
@@ -20,6 +20,7 @@
  *
  * Contributor(s):
  *   Brian Warner <warner@mozilla.com>
+ *   Erik Vold <erikvvold@gmail.com>
  *
  * Alternatively, the contents of this file may be used under the terms of
  * either the GNU General Public License Version 2 or later (the "GPL"), or
@@ -55,6 +56,7 @@ exports.makeSelfModule = function (reqdata) {
   // and we want resource://jid0-abc123/reading-data-data/
 
   var data_url = function(name) {
+    name = name || "";
     // dataURIPrefix ends with a slash
     var x = reqdata.dataURIPrefix + name;
     return x;
@@ -63,7 +65,7 @@ exports.makeSelfModule = function (reqdata) {
     let fn = url.toFilename(data_url(name));
     return file.read(fn);
   };
-    
+
   var self = {
     id: jid,
     uri: uri,

--- a/packages/api-utils/tests/test-self.js
+++ b/packages/api-utils/tests/test-self.js
@@ -14,6 +14,11 @@ exports.testSelf = function(test) {
   // depends on self.id . We can only assert that it ends in the right
   // thing.
   var url = self.data.url("bootstrap-remote-process.js");
-  test.assertEqual(typeof(url), "string", "self.data.url() returns string");
+  test.assertEqual(typeof(url), "string", "self.data.url('x') returns string");
   test.assertEqual(/\/bootstrap-remote-process\.js$/.test(url), true);
+
+  // Make sure 'undefined' is not in url when no string is provided.
+  var url = self.data.url();
+  test.assertEqual(typeof(url), "string", "self.data.url() returns string");
+  test.assertEqual(/\/undefined$/.test(url), false);
 };


### PR DESCRIPTION
if you run `self.data.url()` then you will get a string with `undefined` at the end which should not be there.
