### PR TITLE
Bug 676715 - test-private-browsing.testActivateDeactivate and .testStart time out

### DIFF
--- a/packages/addon-kit/tests/test-private-browsing.js
+++ b/packages/addon-kit/tests/test-private-browsing.js
@@ -57,6 +57,9 @@ if (pbService) {
     pbService.privateBrowsingEnabled = true;
     test.assert(pb.isActive,
                 "private-browsing.isActive is correct after modifying PB service");
+
+    // Switch back to normal mode.
+    pbService.privateBrowsingEnabled = false;
   };
 
   // tests that activating does put the browser into private browsing mode
@@ -115,7 +118,7 @@ if (pbService) {
       test.fail("should not be called:x");
     });
     loader.unload();
-    
+
     // Then switch to private mode in order to check that the previous instance
     // is correctly destroyed
     pb.activate();
@@ -123,6 +126,9 @@ if (pbService) {
       require("timer").setTimeout(function () {
         test.assert(!called, 
           "First private browsing instance is destroyed and inactive");
+
+        // Must reset to normal mode, so that next test starts with it.
+        pb.deactivate();
         test.done();
       }, 0);
     });


### PR DESCRIPTION
At the end of each test private browsing mode should be reset to normal so that next test starts from the normal mode.

https://bugzilla.mozilla.org/show_bug.cgi?id=676715
