### PR TITLE
Bug 671598 - Add-on sometimes doesn't start when Firefox does

### DIFF
--- a/python-lib/cuddlefish/app-extension/components/harness.js
+++ b/python-lib/cuddlefish/app-extension/components/harness.js
@@ -358,9 +358,6 @@ function buildHarnessService(rootFileSpec, dump, logError,
           case FENNEC_ID:
             obSvc.addObserver(this, "xul-window-visible", true);
             break;
-          case FIREFOX_ID:
-            obSvc.addObserver(this, "sessionstore-windows-restored", true);
-            break;
           default:
             obSvc.addObserver(this, "final-ui-startup", true);
             break;


### PR DESCRIPTION
Firefox not always emits 'sessionstore-windows-restored', in which causes add-ons don't start.

https://bugzilla.mozilla.org/show_bug.cgi?id=671598
