### PR TITLE
add link to worker documentation in the API reference

### DIFF
--- a/packages/addon-kit/docs/page-mod.md
+++ b/packages/addon-kit/docs/page-mod.md
@@ -347,7 +347,7 @@ This event is emitted this event when the page-mod's content scripts are
 attached to a page whose URL matches the page-mod's `include` filter.
 
 @argument {Worker}
-The listener function is passed a `Worker` object that can be used to communicate
+The listener function is passed a [`Worker`](packages/api-utils/docs/content/worker.html) object that can be used to communicate
 with any content scripts attached to this page.
 </api>
 


### PR DESCRIPTION
A link to the [Worker](https://addons.mozilla.org/en-US/developers/docs/sdk/1.0/packages/api-utils/docs/content/worker.html) doc is missing in the API reference of page-mod.

This page is linked at a random place in the page-mod doc but is missing from the place you are the most likely to search it.
