### PR TITLE
bug 682681 - tab.title should never be empty (use xul tab label instead o

### DIFF
--- a/packages/api-utils/lib/tabs/tab.js
+++ b/packages/api-utils/lib/tabs/tab.js
@@ -134,8 +134,8 @@ const TabTrait = Trait.compose(EventEmitter, {
    * Changing this property changes an actual title.
    * @type {String}
    */
-  get title() this._contentDocument.title,
-  set title(value) this._contentDocument.title = String(value),
+  get title() this._tab.label,
+  set title(value) this._tab.label = String(value),
   /**
    * Location of the page currently loaded in this tab.
    * Changing this property will loads page under under the specified location.


### PR DESCRIPTION
bug 682681 - tab.title should never be empty (use xul tab label instead of content document title, also makes e10s compat)
