### PR TITLE
correct text in preferences-service about what it does when a consumer tr

### DIFF
--- a/packages/api-utils/lib/preferences-service.js
+++ b/packages/api-utils/lib/preferences-service.js
@@ -91,10 +91,8 @@ var set = exports.set = function set(name, value) {
     break;
 
   case "Number":
-    // We throw if the number is outside the range, since the result
-    // will never be what the consumer wanted to store, but we only warn
-    // if the number is non-integer, since the consumer might not mind
-    // the loss of precision.
+    // We throw if the number is outside the range or not an integer, since
+    // the result will not be what the consumer wanted to store.
     if (value > MAX_INT || value < MIN_INT)
       throw new Error("you cannot set the " + name +
                       " pref to the number " + value +
@@ -113,7 +111,7 @@ var set = exports.set = function set(name, value) {
 
   default:
     throw new Error("can't set pref " + name + " to value '" + value +
-                    "'; it isn't a String, Number, or Boolean");
+                    "'; it isn't a string, integer, or boolean");
   }
 };
 


### PR DESCRIPTION
correct text in preferences-service about what it does when a consumer tries to set a pref to a non-string/integer/boolean value

Change 699f4f29176a7ec1b8ef7126df5cc112a6a4bdea altered the behavior but not the text that explains it. This change fixes the text.
