### PR TITLE
remove version from base.html file used for testing sdocs, since real base.html doesn't include the version anymore, and it shouldn't be necessary to keep updating it

### DIFF
--- a/python-lib/cuddlefish/tests/static-files/doc/static-files/base.html
+++ b/python-lib/cuddlefish/tests/static-files/doc/static-files/base.html
@@ -125,7 +125,7 @@
   </div>
   </div>
   <div id="footer">
-    <span class="full-name">Add-on SDK Documentation v1.3a0</span>
+    <span class="full-name">Add-on SDK Documentation</span>
   </div>
 
 </div>


### PR DESCRIPTION
remove version from base.html file used for testing sdocs, since real base.html doesn't include the version anymore, and it shouldn't be necessary to keep updating it
