### PR TITLE
Bug 692002 slightly better error message for missing '</api>' exception

### DIFF
--- a/python-lib/cuddlefish/docs/apiparser.py
+++ b/python-lib/cuddlefish/docs/apiparser.py
@@ -110,7 +110,8 @@ class APIParser:
                         raise ParseError("unknown '@' section header %s in \
                                            '%s'" % (tag, line), lineno + 1)
             lineno += 1
-        raise ParseError("closing </api> tag not found", lineno + 1)
+        raise ParseError("closing </api> tag not found for <api name=\"" +
+                         api["name"] + "\">", lineno + 1)
 
     def _parse_title_line(self, title_line, lineno):
         if "name" not in title_line:


### PR DESCRIPTION
Bug 692002 providing a slightly better error message for a rare exception during api parsing when a '</api>' is missing
