### PR TITLE
Look in HKCU if Python is not found in HKLM on Windows (bug 684136)

### DIFF
--- a/bin/activate.bat
+++ b/bin/activate.bat
@@ -16,6 +16,15 @@ if "%WIN64%" EQU "1" (
   SET PYTHONKEY=HKLM\SOFTWARE\Python\PythonCore
 )
 
+REG QUERY "%PYTHONKEY%" >nul 2>nul
+if NOT %ERRORLEVEL% EQU 0 (
+  if "%WIN64%" EQU "1" (
+    SET PYTHONKEY=HKCU\SOFTWARE\Wow6432Node\Python\PythonCore
+  ) else (
+    SET PYTHONKEY=HKCU\SOFTWARE\Python\PythonCore
+  )
+)
+
 SET PYTHONVERSION=
 SET PYTHONINSTALL=
 


### PR DESCRIPTION
I think this works. I don't have Python installed "just for me", so I can't really test that it finds it in HKCU, but this looks like it would work.
