### PR TITLE
Bug 699566: Move extension manager related preferences to DEFAULT_COMMON_PREFS

### DIFF
--- a/python-lib/cuddlefish/prefs.py
+++ b/python-lib/cuddlefish/prefs.py
@@ -33,7 +33,6 @@ DEFAULT_COMMON_PREFS = {
 }
 
 DEFAULT_FENNEC_PREFS = {
-  'javascript.options.showInConsole': True,
   'browser.console.showInPanel': True,
   'browser.firstrun.show.uidiscovery': False
 }


### PR DESCRIPTION
Bug 699566: Move extension manager related preferences to DEFAULT_COMMON_PREFS so they are included when running other applications.
