### PR TITLE
Startup topic fix – Addons are not loaded in apps that doesn't support `sessionstore-windows-restored`

### DIFF
--- a/packages/api-utils/lib/xul-app.js
+++ b/packages/api-utils/lib/xul-app.js
@@ -47,13 +47,15 @@ var version = exports.version = appInfo.version;
 var platformVersion = exports.platformVersion = appInfo.platformVersion;
 
 // The following mapping of application names to GUIDs was taken from:
-// 
+//
 //   https://addons.mozilla.org/en-US/firefox/pages/appversions
 //
 // Using the GUID instead of the app's name is preferable because sometimes
 // re-branded versions of a product have different names: for instance,
 // Firefox, Minefield, Iceweasel, and Shiretoko all have the same
 // GUID.
+// This mapping is duplicated in `app-extensions/bootstrap.js`. They should keep
+// in sync, so if you change one, change the other too!
 
 var ids = exports.ids = {
   Firefox: "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",

--- a/python-lib/cuddlefish/app-extension/bootstrap.js
+++ b/python-lib/cuddlefish/app-extension/bootstrap.js
@@ -58,6 +58,9 @@ let loader = null;
 // Gets the topic that fit best as application startup event, in according with
 // the current application (e.g. Firefox, Fennec, Thunderbird...)
 function getAppStartupTopic() {
+  // The following mapping of application names to GUIDs was taken
+  // from `xul-app` module. They should keep in sync, so if you change one,
+  // change the other too!
   let ids = {
     Firefox: '{ec8030f7-c20a-464f-9b0e-13a3a9e97384}',
     Mozilla: '{86c18b42-e466-45a9-ae7a-9b95ba6f5640}',


### PR DESCRIPTION
After the improvements of the Module Loader, the Addon SDK stopped to work for _Thunderbird_ – even if is not officially supported, it worked in the past.
That was because the topic `sessionstore-windows-restored` was used for all applications, when only _Firefox_ and _SeaMonkey_ support it (and apparently _Fennec_ as well, but is not documented. See: https://developer.mozilla.org/en/Observer_Notifications).
So the fix provides a function that based on the current application returns the topic that fit best for the startup.
