### PR TITLE
Core keys fix

### DIFF
--- a/packages/api-utils/lib/traits/core.js
+++ b/packages/api-utils/lib/traits/core.js
@@ -189,8 +189,10 @@ exports.compose = compose;
  */
 function exclude(keys, trait) {
   let exclusions = Map(keys),
-      result = {},
-      keys = getOwnPropertyNames(trait);
+      result = {};
+
+  keys = getOwnPropertyNames(trait);
+
   for each (let key in keys) {
     if (!hasOwn.call(exclusions, key) || trait[key].required)
       result[key] = trait[key];


### PR DESCRIPTION
The module `traits/core` had a redeclaration of arguments that gives a lot of warning during running and testing. Just move out the `keys` from the variables declared.
