### PR TITLE
Check if win exists before working on it

### DIFF
--- a/packages/api-utils/lib/content/worker.js
+++ b/packages/api-utils/lib/content/worker.js
@@ -573,9 +573,12 @@ const Worker = AsyncEventEmitter.compose({
   },
   
   get tab() {
-    let tab = require("../tabs/tab");
-    // this._window will be null after detach
-    return this._window ? tab.getTabForWindow(this._window) : null;
+    if (this._window) {
+      let tab = require("../tabs/tab");
+      // this._window will be null after detach
+      return tab.getTabForWindow(this._window);
+    }
+    return null;
   },
   
   /**


### PR DESCRIPTION
Sometimes I had an error, that win is null.
The error occured when I was logging in on a page where I was working
on. The login was done by an AJAX call but after the login page
reloaded. Then I tried to run my script I got the error message.

The error was come from the content/worker.js line 533
