### PR TITLE
Bug 703108 - Reenable a test and convert rest of tests to use httpd.js

### DIFF
--- a/packages/addon-kit/data/test-request-complex-headers.php
+++ b/packages/addon-kit/data/test-request-complex-headers.php
@@ -1,0 +1,18 @@
+<html>
+<?php
+
+// Header with extra colon
+header('x-zpao-header: Jamba Juice is: delicious');
+
+// same header twice, should be sent twice
+header('x-zpao-header-2: foo');
+header('x-zpao-header-2: bar', false);
+
+// header with comman seperated values
+header('x-zpao-header-3: sup dawg, i heard you like x, so we put a x in yo x so you can y while you y');
+
+// cookies?
+setcookie("foo", "bar");
+setcookie("baz", "foo");
+
+?>

--- a/packages/addon-kit/data/test-request-getpost.php
+++ b/packages/addon-kit/data/test-request-getpost.php
@@ -1,0 +1,14 @@
+<?php
+
+// print("GET: ");
+// print_r($_GET);
+// 
+// print("POST: ");
+// print_r($_POST);
+// //print($_POST["p"]);
+$out = array(
+  "POST" => $_POST,
+  "GET" => $_GET
+);
+print(json_encode($out));
+?>

--- a/packages/addon-kit/data/test-request-headers.txt
+++ b/packages/addon-kit/data/test-request-headers.txt
@@ -1,0 +1,1 @@
+This tests adding headers to the server's response.

--- a/packages/addon-kit/data/test-request-headers.txt^headers^
+++ b/packages/addon-kit/data/test-request-headers.txt^headers^
@@ -1,0 +1,1 @@
+x-jetpack-header: Jamba Juice


### PR DESCRIPTION
This re-enables the simple testKnownHeader test, as well as adapt the remaining (still disabled) tests to start and stop the httpd.js server (and renames the test files to fit in better).

test-request-headers.txt is used in testKnownHeader.
test-request-headers.txt^headers^ is a special file used with httpd.js to modify headers: https://developer.mozilla.org/En/Httpd.js/HTTP_server_for_unit_tests#Header_modification_for_files

I'm not quite sure why "testKnownHeader" was used twice in test-request.js. I renamed the second one (which is still disabled because I couldn't get it to work) to testKnownHeader2, because I don't know if you can have the same name used multiple times. I couldn't get this test to work like the first one here because I don't think that method of modifying headers allows you to do the things the original test-request-complex-headers.php was doing (appending values to a single header and setting cookies), and none of the PHP files seem to be getting processed (can httpd.js even process PHP files?).

The rest of the tests are also using PHP in ways I don't think httpd.js has the capability of doing, so they're still disabled. (I tried looking at https://developer.mozilla.org/En/Httpd.js/HTTP_server_for_unit_tests#SJS:_server-side_scripts for a way to do them, but didn't really have much success.)

(All of zpao's original unmodified test files are located here: http://playground.zpao.com/jetpack/request/request_test.zip if anyone else wants to take a look at them and try to re-enable them.)
