### PR TITLE
Bug 612726 - bypass content scripts for an addon's own local content

### DIFF
--- a/packages/api-utils/data/test-trusted-document.html
+++ b/packages/api-utils/data/test-trusted-document.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+    <title>Worker test</title>
+</head>
+<body>
+  <p id="paragraph">Lorem ipsum dolor sit amet.</p>
+  <script>
+    addon.port.on('addon-to-document', function (arg) {
+      addon.port.emit('document-to-addon', arg);
+    });
+  </script>
+</body>
+</html>

--- a/packages/api-utils/lib/content/worker.js
+++ b/packages/api-utils/lib/content/worker.js
@@ -333,6 +333,16 @@ const WorkerGlobalScope = AsyncEventEmitter.compose({
       apply: 'rw'
     }
 
+    // Inject `addon` global into target document if document is trusted,
+    // `addon` in document is equivalent to `self` in content script.
+    if (worker._injectInDocument) {
+      let win = window.wrappedJSObject ? window.wrappedJSObject : window;
+      Object.defineProperty(win, "addon", {
+          get: function () publicAPI
+        }
+      );
+    }
+
     // The order of `contentScriptFile` and `contentScript` evaluation is
     // intentional, so programs can load libraries like jQuery from script URLs
     // and use them in scripts.
@@ -634,5 +644,11 @@ const Worker = AsyncEventEmitter.compose({
    * @type {Object}
    */
   _window: null,
+
+  /**
+   * Flag to enable `addon` object injection in document. (bug 612726)
+   * @type {Boolean}
+   */
+  _injectInDocument: false
 });
 exports.Worker = Worker;

--- a/packages/api-utils/tests/test-content-symbiont.js
+++ b/packages/api-utils/tests/test-content-symbiont.js
@@ -151,3 +151,36 @@ exports["test:document element present on 'start'"] = function(test) {
     }
   });
 };
+
+exports["test:direct communication with trusted document"] = function(test) {
+  test.waitUntilDone();
+
+  let worker = Symbiont({
+    contentURL: require("self").data.url("test-trusted-document.html")
+  });
+
+  worker.port.on('document-to-addon', function (arg) {
+    test.assertEqual(arg, "ok", "Received an event from the document");
+    worker.destroy();
+    test.done();
+  });
+  worker.port.emit('addon-to-document', 'ok');
+};
+
+exports["test:`addon` is not available when a content script is set"] = function(test) {
+  test.waitUntilDone();
+
+  let worker = Symbiont({
+    contentURL: require("self").data.url("test-trusted-document.html"),
+    contentScript: "new " + function ContentScriptScope() {
+      self.port.emit("cs-to-addon", "addon" in unsafeWindow);
+    }
+  });
+
+  worker.port.on('cs-to-addon', function (hasAddon) {
+    test.assertEqual(hasAddon, false,
+      "`addon` is not available");
+    worker.destroy();
+    test.done();
+  });
+};


### PR DESCRIPTION
Expose `addon` to trusted documents used with Symbiont API (Widget, Panel, Page-worker) that is equivalent to `self` in content scripts. It allows to communicate with commonJS modules directly from the document, instead of using a content script in between.
