### PR TITLE
Bug 561944 - Make invalid hostname error more understandable

### DIFF
--- a/python-lib/cuddlefish/packaging.py
+++ b/python-lib/cuddlefish/packaging.py
@@ -296,7 +296,7 @@ def generate_build_for_target(pkg_cfg, target, deps,
                 # ensure that package name is valid
                 try:
                     validate_resource_hostname(cfg.name)
-                except ValueError as err:
+                except ValueError, err:
                     print err
                     sys.exit(1)
                 # ensure that this package has an entry


### PR DESCRIPTION
This at least makes the error message less cryptic than "invalid resource hostname". It doesn't strip anything from the name, and it doesn't hide the traceback, but at least it's a start... With some recent things landed in the SDK (pull request 276, maybe?), the output of the error for a package named "bad/name" is:

Traceback (most recent call last):
  File "C:\Users\kwierso\mysdkfork\addon-sdk\bin\cfx", line 29, in <module>
    cuddlefish.run()
  File "C:\Users\kwierso\mysdkfork\addon-sdk\python-lib\cuddlefish__init__.py", line 674, in run
    include_dep_tests=options.dep_tests
  File "C:\Users\kwierso\mysdkfork\addon-sdk\python-lib\cuddlefish\packaging.py", line 317, in gener
ate_build_for_target
    add_section_to_build(target_cfg, "tests", is_code=True)
  File "C:\Users\kwierso\mysdkfork\addon-sdk\python-lib\cuddlefish\packaging.py", line 293, in add_s
ection_to_build
    validate_resource_hostname(cfg.name)
  File "C:\Users\kwierso\mysdkfork\addon-sdk\python-lib\cuddlefish\packaging.py", line 85, in valida
te_resource_hostname
    raise ValueError('package names can only contain letters, numbers, underscores and dashes: %s' %
 name)
ValueError: package names can only contain letters, numbers, underscores and dashes: bad/name

It now only shows the package name's value, not the URI generated from it.
