### PR TITLE
Bug 705011 - Disable failing XHR test until platform bug 707256 is fixed.

### DIFF
--- a/packages/api-utils/tests/test-xhr.js
+++ b/packages/api-utils/tests/test-xhr.js
@@ -2,12 +2,14 @@ var xhr = require("xhr");
 var timer = require("timer");
 var { Loader } = require("./helpers");
 
+/* Test is intentionally disabled until platform bug 707256 is fixed.
 exports.testAbortedXhr = function(test) {
   var req = new xhr.XMLHttpRequest();
   test.assertEqual(xhr.getRequestCount(), 1);
   req.abort();
   test.assertEqual(xhr.getRequestCount(), 0);
 };
+*/
 
 exports.testLocalXhr = function(test) {
   var req = new xhr.XMLHttpRequest();


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=705011
