### PR TITLE
remove unnecessary access to the 'chrome' and 'xpcom' modules from the 'widget' and 'windows' modules

### DIFF
--- a/packages/addon-kit/lib/widget.js
+++ b/packages/addon-kit/lib/widget.js
@@ -42,8 +42,6 @@
 
 "use strict";
 
-const {Cc, Ci} = require("chrome");
-
 // Widget content types
 const CONTENT_TYPE_URI    = 1;
 const CONTENT_TYPE_HTML   = 2;

--- a/packages/addon-kit/lib/windows.js
+++ b/packages/addon-kit/lib/windows.js
@@ -53,7 +53,6 @@ const { Cc, Ci } = require('chrome'),
       { WindowLoader } = require('api-utils/windows/loader'),
       { WindowTrackerTrait } = require('api-utils/window-utils'),
       { Options } = require('api-utils/tabs/tab'),
-      { utils } = require('api-utils/xpcom'),
       apiUtils = require('api-utils/api-utils'),
       unload = require('api-utils/unload'),
 


### PR DESCRIPTION
@warner Rezwana Karim (@rkarim?) noticed that `widget` and `windows` access `chrome` and `xpcom`, respectively, without using them, which violates POLA, so let's bring them back in line. Here's the trivial fix.
