### PR TITLE
_version.py: prefer short "2.0" over longer "2.0rc1"

### DIFF
--- a/python-lib/cuddlefish/_version.py
+++ b/python-lib/cuddlefish/_version.py
@@ -61,18 +61,21 @@ def versions_from_expanded_variables(variables, tag_prefix):
     if refnames.startswith("$Format"):
         return {} # unexpanded, so not in an unpacked git-archive tarball
     refs = set([r.strip() for r in refnames.strip("()").split(",")])
-    refs.discard("HEAD") ; refs.discard("master")
-    for ref in reversed(sorted(refs)):
+    for ref in list(refs):
+        if not re.search(r'\d', ref):
+            refs.discard(ref)
+            # Assume all version tags have a digit. git's %d expansion
+            # behaves like git log --decorate=short and strips out the
+            # refs/heads/ and refs/tags/ prefixes that would let us
+            # distinguish between branches and tags. By ignoring refnames
+            # without digits, we filter out many common branch names like
+            # "release" and "stabilization", as well as "HEAD" and "master".
+    for ref in sorted(refs):
+        # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
             r = ref[len(tag_prefix):]
-            if re.search(r'\d', r):
-                # git's %d expansion behaves like git log --decorate=short
-                # and strips out the refs/heads/ and refs/tags/ prefixes that
-                # would let us distinguish between branches and tags. By
-                # ignoring refnames without digits, we filter out many common
-                # branch names like "release" and "stabilization".
-                return { "version": r,
-                         "full": variables["full"].strip() }
+            return { "version": r,
+                     "full": variables["full"].strip() }
     # no suitable tags, so we use the full revision id
     return { "version": variables["full"].strip(),
              "full": variables["full"].strip() }


### PR DESCRIPTION
@mykmelez: this fix anticipates a problem that would happen when we get to the end of the 1.4 release cycle, if we wind up with both the "1.4" and "1.4rc1" tags pointed at the same revision. A tarball generated (with 'git archive') from that revision will need to decide whether to describe itself as "1.4" or as "1.4rc1". Without this patch, the decision is kind of random. With the patch, it will always choose the shorter tag.

This will need to be cherry-picked to the will-become-1.4 stabilization branch.

(We still need to discuss release-process, which may result in us not using this what-is-my-version-number feature, but if we do use that feature, we'll need this fix)
