### PR TITLE
Bug 706744 - Closing Firefox opened by cfx run does not terminate the cfx run command.

### DIFF
--- a/packages/api-utils/lib/system.js
+++ b/packages/api-utils/lib/system.js
@@ -68,8 +68,11 @@ exports.env = require('./environment').env;
  */
 exports.exit = function exit(code) {
   // This is used by 'cfx' to find out exit code.
-  if ('resultFile' in options)
-    file.open(options.resultFile, 'w').write(code ? 'FAIL' : 'OK');
+  if ('resultFile' in options) {
+    let stream = file.open(options.resultFile, 'w');
+    stream.write(code ? 'FAIL' : 'OK');
+    stream.close();
+  }
 
   appStartup.quit(code ? E_ATTEMPT : E_FORCE);
 };

--- a/python-lib/cuddlefish/tests/addons/simplest-test/main.js
+++ b/python-lib/cuddlefish/tests/addons/simplest-test/main.js
@@ -1,0 +1,13 @@
+const { Cc, Ci } = require("chrome");
+
+exports.main = function(options, callbacks) {
+  // Close Firefox window. Firefox should quit.
+  require("api-utils/window-utils").activeBrowserWindow.close();
+
+  // But not on Mac where it stay alive! We have to request application quit.
+  if (require("api-utils/runtime").OS == "Darwin") {
+    let appStartup = Cc['@mozilla.org/toolkit/app-startup;1'].
+                     getService(Ci.nsIAppStartup);
+    appStartup.quit(appStartup.eAttemptQuit);
+  }
+}

--- a/python-lib/cuddlefish/tests/addons/simplest-test/package.json
+++ b/python-lib/cuddlefish/tests/addons/simplest-test/package.json
@@ -1,0 +1,6 @@
+{
+  "id": "simplest-test",
+  "directories": {
+    "lib": "."
+  }
+}

--- a/python-lib/cuddlefish/tests/addons/simplest-test/tests/test-minimal.js
+++ b/python-lib/cuddlefish/tests/addons/simplest-test/tests/test-minimal.js
@@ -1,0 +1,3 @@
+exports.minimalTest = function(test) {
+  test.assert(true);
+};

--- a/python-lib/cuddlefish/tests/test_init.py
+++ b/python-lib/cuddlefish/tests/test_init.py
@@ -3,6 +3,8 @@ from StringIO import StringIO
 from cuddlefish import initializer, get_unique_prefix
 from cuddlefish.templates import MAIN_JS, TEST_MAIN_JS, PACKAGE_JSON
 
+tests_path = os.path.abspath(os.path.dirname(__file__))
+
 class TestInit(unittest.TestCase):
 
     def run_init_in_subdir(self, dirname, f, *args, **kwargs):
@@ -91,6 +93,61 @@ class TestRun(unittest.TestCase):
             get_unique_prefix("{74343602-334C-4570-BBCD-69BDE8CAFBD1}"),
             "74343602-334c-4570-bbcd-69bde8cafbd1"
         )
+
+class TestCfxQuits(unittest.TestCase):
+
+    def run_cfx(self, addon_name, command):
+        old_cwd = os.getcwd()
+        addon_path = os.path.join(tests_path,
+                                  "addons", addon_name)
+        os.chdir(addon_path)
+        import sys
+        old_stdout = sys.stdout
+        old_stderr = sys.stderr
+        sys.stdout = out = StringIO()
+        sys.stderr = err = StringIO()
+        try:
+            import cuddlefish
+            args = list(command)
+            # Pass arguments given to cfx so that cfx can find firefox path
+            # if --binary option is given:
+            args.extend(sys.argv[1:])
+            cuddlefish.run(arguments=args)
+        except SystemExit, e:
+            if "code" in e:
+                rc = e.code
+            elif "args" in e and len(e.args)>0:
+                rc = e.args[0]
+            else:
+                rc = 0
+        finally:
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
+            os.chdir(old_cwd)
+        out.flush()
+        err.flush()
+        return rc, out.getvalue(), err.getvalue()
+
+    # this method doesn't exists in python 2.5,
+    # implements our own
+    def assertIn(self, member, container):
+        """Just like self.assertTrue(a in b), but with a nicer default message."""
+        if member not in container:
+            standardMsg = '"%s" not found in "%s"' % (member,
+                                                  container)
+            self.fail(standardMsg)
+
+    def test_run(self):
+        rc, out, err = self.run_cfx("simplest-test", ["run"])
+        self.assertEqual(rc, 0)
+        self.assertIn("Program terminated successfully.", err)
+
+    def test_test(self):
+        rc, out, err = self.run_cfx("simplest-test", ["test"])
+        self.assertEqual(rc, 0)
+        self.assertIn("1 of 1 tests passed.", err)
+        self.assertIn("Program terminated successfully.", err)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Backporting of all landings related to this bug merged into one for stabilization branch!
