### PR TITLE
Bug 704711 - Remove reference to nsIHttpServer

### DIFF
--- a/packages/api-utils/lib/httpd.js
+++ b/packages/api-utils/lib/httpd.js
@@ -701,9 +701,7 @@ nsHttpServer.prototype =
   //
   QueryInterface: function(iid)
   {
-    if (iid.equals(Ci.nsIHttpServer) ||
-        iid.equals(Ci.nsIServerSocketListener) ||
-        iid.equals(Ci.nsISupports))
+    if (iid.equals(Ci.nsIServerSocketListener) || iid.equals(Ci.nsISupports))
       return this;
 
     throw Cr.NS_ERROR_NO_INTERFACE;


### PR DESCRIPTION
This removes the reference in the code to nsIHttpServer, and running the tests mentioned in bug 704711 no longer spews out all that junk about it.

So that's nice.

(nsIHttpServer is still mentioned a lot in the comments in httpd.js, though.)
