### PR TITLE
Bug 638742: mozrunner: handle non-unpacked addons

### DIFF
--- a/python-lib/cuddlefish/app-extension/install.rdf
+++ b/python-lib/cuddlefish/app-extension/install.rdf
@@ -7,7 +7,7 @@
     <em:version>1.0</em:version>
     <em:type>2</em:type>
     <em:bootstrap>true</em:bootstrap>
-    <em:unpack>true</em:unpack>
+    <em:unpack>false</em:unpack>
 
     <!-- Firefox -->
     <em:targetApplication>

--- a/python-lib/cuddlefish/rdf.py
+++ b/python-lib/cuddlefish/rdf.py
@@ -123,7 +123,7 @@ def gen_manifest(template_root_dir, target_cfg, jid,
     manifest.set("em:creator",
                  target_cfg.get("author", ""))
     manifest.set("em:bootstrap", str(bootstrap).lower())
-    manifest.set("em:unpack", "true")
+    manifest.set("em:unpack", "false")
 
     if update_url:
         manifest.set("em:updateURL", update_url)


### PR DESCRIPTION
This merely changes mozrunner to honor the case of unpack=false. It does not
changes the XPI generation process to _produce_ such a value. This mozrunner
should handle both =false and =true.

Code adapted from current mozbase.mozprofile . I have another branch which
does a wholesale import of current mozbase (a much larger code drop), which
also handles non-unpacked addons, but involves many more changes too. This
approach seemed less disruptive.

@gozala, once we land this, I think it'll be safe to land your changes to build XPIs with unpack=false
