### PR TITLE
Bug 713264 Warning: function WindowTracker does not always return a value

### DIFF
--- a/packages/api-utils/lib/window-utils.js
+++ b/packages/api-utils/lib/window-utils.js
@@ -89,6 +89,8 @@ var WindowTracker = exports.WindowTracker = function WindowTracker(delegate) {
   gWindowWatcher.registerNotification(this);
 
   require("./unload").ensure(this);
+
+  return this;
 };
 
 WindowTracker.prototype = {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=713264
