### PR TITLE
Fix missing default values for integer preferences

### DIFF
--- a/python-lib/cuddlefish/app-extension/bootstrap.js
+++ b/python-lib/cuddlefish/app-extension/bootstrap.js
@@ -72,7 +72,7 @@ function setDefaultPrefs() {
           branch.setBoolPref(key, val);
           break;
         case "number":
-          if (value % 1 == 0) // number must be a integer, otherwise ignore it
+          if (val % 1 == 0) // number must be a integer, otherwise ignore it
             branch.setIntPref(key, val);
           break;
         case "string":


### PR DESCRIPTION
The new simple-prefs API has a little typo which prevents int prefs from having default values. Please merge this into 1.4rc1.
