### PR TITLE
Bug 715340: let package.json control XPIs being packed/unpacked

### DIFF
--- a/python-lib/cuddlefish/rdf.py
+++ b/python-lib/cuddlefish/rdf.py
@@ -123,7 +123,12 @@ def gen_manifest(template_root_dir, target_cfg, jid,
     manifest.set("em:creator",
                  target_cfg.get("author", ""))
     manifest.set("em:bootstrap", str(bootstrap).lower())
-    manifest.set("em:unpack", "false")
+    # XPIs remain packed by default, but package.json can override that. The
+    # RDF format accepts "true" as True, anything else as False, so we need
+    # to tolerate package.json passing True/False (boolean) or
+    # "True"/"true"/"False"/"false" (strings).
+    manifest.set("em:unpack",
+                 str(target_cfg.get("unpack", "false")).lower())
 
     if update_url:
         manifest.set("em:updateURL", update_url)

--- a/python-lib/cuddlefish/tests/bug-715340-files/pkg-1-pack/package.json
+++ b/python-lib/cuddlefish/tests/bug-715340-files/pkg-1-pack/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "empty",
+    "license": "MPL 1.1/GPL 2.0/LGPL 2.1",
+    "author": "",
+    "version": "0.1",
+    "fullName": "empty",
+    "id": "jid1-80fr8b6qeRlQSQ",
+    "unpack": false,
+    "description": "test unpack= support"
+}

--- a/python-lib/cuddlefish/tests/bug-715340-files/pkg-2-pack/package.json
+++ b/python-lib/cuddlefish/tests/bug-715340-files/pkg-2-pack/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "empty",
+    "license": "MPL 1.1/GPL 2.0/LGPL 2.1",
+    "author": "",
+    "version": "0.1",
+    "fullName": "empty",
+    "id": "jid1-80fr8b6qeRlQSQ",
+    "unpack": "false",
+    "description": "test unpack= support"
+}

--- a/python-lib/cuddlefish/tests/bug-715340-files/pkg-3-pack/package.json
+++ b/python-lib/cuddlefish/tests/bug-715340-files/pkg-3-pack/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "empty",
+    "license": "MPL 1.1/GPL 2.0/LGPL 2.1",
+    "author": "",
+    "version": "0.1",
+    "fullName": "empty",
+    "id": "jid1-80fr8b6qeRlQSQ",
+    "unpack": "False",
+    "description": "test unpack= support"
+}

--- a/python-lib/cuddlefish/tests/bug-715340-files/pkg-4-unpack/package.json
+++ b/python-lib/cuddlefish/tests/bug-715340-files/pkg-4-unpack/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "empty",
+    "license": "MPL 1.1/GPL 2.0/LGPL 2.1",
+    "author": "",
+    "version": "0.1",
+    "fullName": "empty",
+    "id": "jid1-80fr8b6qeRlQSQ",
+    "unpack": true,
+    "description": "test unpack= support"
+}

--- a/python-lib/cuddlefish/tests/bug-715340-files/pkg-5-unpack/package.json
+++ b/python-lib/cuddlefish/tests/bug-715340-files/pkg-5-unpack/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "empty",
+    "license": "MPL 1.1/GPL 2.0/LGPL 2.1",
+    "author": "",
+    "version": "0.1",
+    "fullName": "empty",
+    "id": "jid1-80fr8b6qeRlQSQ",
+    "unpack": "true",
+    "description": "test unpack= support"
+}

--- a/python-lib/cuddlefish/tests/bug-715340-files/pkg-6-unpack/package.json
+++ b/python-lib/cuddlefish/tests/bug-715340-files/pkg-6-unpack/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "empty",
+    "license": "MPL 1.1/GPL 2.0/LGPL 2.1",
+    "author": "",
+    "version": "0.1",
+    "fullName": "empty",
+    "id": "jid1-80fr8b6qeRlQSQ",
+    "unpack": "True",
+    "description": "test unpack= support"
+}

--- a/python-lib/cuddlefish/tests/bug-715340-files/pkg-7-pack/package.json
+++ b/python-lib/cuddlefish/tests/bug-715340-files/pkg-7-pack/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "empty",
+    "license": "MPL 1.1/GPL 2.0/LGPL 2.1",
+    "author": "",
+    "version": "0.1",
+    "fullName": "empty",
+    "id": "jid1-80fr8b6qeRlQSQ",
+    "description": "test unpack= support"
+}

--- a/python-lib/cuddlefish/tests/test_rdf.py
+++ b/python-lib/cuddlefish/tests/test_rdf.py
@@ -1,8 +1,12 @@
 import unittest
 import xml.dom.minidom
+import os.path
 
-from cuddlefish import rdf
+from cuddlefish import rdf, packaging
 
+parent = os.path.dirname
+test_dir = parent(os.path.abspath(__file__))
+template_dir = os.path.join(parent(test_dir), "app-extension")
 
 class RDFTests(unittest.TestCase):
     def testBug567660(self):
@@ -13,3 +17,27 @@ class RDFTests(unittest.TestCase):
         self.assertEqual(obj.dom.documentElement.firstChild.nodeValue,
                          u'\u2026')
         self.assertEqual(str(obj).replace("\n",""), x.replace("\n",""))
+
+    def failUnlessIn(self, substring, s, msg=""):
+        if substring not in s:
+            self.fail("(%s) substring '%s' not in string '%s'"
+                      % (msg, substring, s))
+
+    def testUnpack(self):
+        basedir = os.path.join(test_dir, "bug-715340-files")
+        for n in ["pkg-1-pack", "pkg-2-pack", "pkg-3-pack",
+                  "pkg-4-unpack", "pkg-5-unpack", "pkg-6-unpack",
+                  "pkg-7-pack"]:
+            cfg = packaging.get_config_in_dir(os.path.join(basedir, n))
+            m = rdf.gen_manifest(template_dir, cfg, jid="JID")
+            if n.endswith("-pack"):
+                # these ones should remain packed
+                self.failUnlessEqual(m.get("em:unpack"), "false")
+                self.failUnlessIn("<em:unpack>false</em:unpack>", str(m), n)
+            else:
+                # and these should be unpacked
+                self.failUnlessEqual(m.get("em:unpack"), "true")
+                self.failUnlessIn("<em:unpack>true</em:unpack>", str(m), n)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This adds code to copy the "unpack" property of the addon's package.json into the XPI's `install.rdf`, allowing addon authors to control whether the XPIs are unpacked or remain packed (and control it through their source code, rather than a command-line flag). There are tests, and the default remains packed.

@ochameau: things to consider:
- I picked "unpack" to match what goes into `install.rdf`, even though "pack" or "packed" or "packedXPI" might be easier to read.. thoughts?

@wbamberg: I'm not sure how/where to document this, feel free to throw a patch my way or just point me to the right place to add a sentence about it. 
