### PR TITLE
add missing license headers; move headers in batch files below '@echo off' command; make line endings consistent

### DIFF
--- a/bin/activate
+++ b/bin/activate
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # This file must be used with "source bin/activate" *from bash*
 # you cannot run it directly
 

--- a/bin/activate.bat
+++ b/bin/activate.bat
@@ -1,8 +1,8 @@
+@echo off
 rem This Source Code Form is subject to the terms of the Mozilla Public
 rem License, v. 2.0. If a copy of the MPL was not distributed with this
 rem file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@echo off
 set VIRTUAL_ENV=%~dp0
 set VIRTUAL_ENV=%VIRTUAL_ENV:~0,-5%
 set CUDDLEFISH_ROOT=%VIRTUAL_ENV%

--- a/bin/activate.ps1
+++ b/bin/activate.ps1
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 $Env:VIRTUAL_ENV = (gl);
 $Env:CUDDLEFISH_ROOT = $Env:VIRTUAL_ENV;
 

--- a/bin/cfx.bat
+++ b/bin/cfx.bat
@@ -1,7 +1,6 @@
+@echo off
 rem This Source Code Form is subject to the terms of the Mozilla Public
 rem License, v. 2.0. If a copy of the MPL was not distributed with this
 rem file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-@echo off
 
 python "%VIRTUAL_ENV%\bin\cfx" %*

--- a/bin/deactivate.bat
+++ b/bin/deactivate.bat
@@ -1,8 +1,7 @@
+@echo off
 rem This Source Code Form is subject to the terms of the Mozilla Public
 rem License, v. 2.0. If a copy of the MPL was not distributed with this
 rem file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-@echo off
 
 if defined _OLD_VIRTUAL_PROMPT (
     set "PROMPT=%_OLD_VIRTUAL_PROMPT%"


### PR DESCRIPTION
Here are fixes for some issues I missed in my review/testing of the license upgrade change:
1. A few files were missing license headers; I have added them.
2. License headers in Windows batch scripts were added above the `@echo off` command and thus appeared on the console when you ran the scripts; they have been moved under that command.
3. Line endings in Windows batch scripts were inconsistent (Windows-style CRLF on most lines of the scripts but Unix-style LF on the header lines); they have been made consistent (all Windows-style CRLF).

@warner: can you review these changes? Should be an easy one.

cc: @gerv so he's aware of these issues for subsequent license upgrades.
