### PR TITLE
fix bug 672443 - reuse compartments between module sandboxes

### DIFF
--- a/packages/api-utils/lib/cuddlefish.js
+++ b/packages/api-utils/lib/cuddlefish.js
@@ -158,7 +158,7 @@ const Loader = {
     // 'reference to undefined property "principal"' warnings when the argument
     // is deconstructed in the "new" function's parameter list.
     // FIXME: stop setting "principal" once bug 705795 is fixed.
-    let sandbox = this.sandboxes[module.uri] =
+    let sandbox = this.sandboxes[module.path] =
       Sandbox.new({ principal: null,
                     prototype: this.globals,
                     name: module.uri,


### PR DESCRIPTION
This patch fixes bug 672443 by reusing compartments between module sandboxes created by an instance of the loader. It drastically reduces the number of entries for modules in about:memory?verbose when tested against the annotator example. It also happens to fix [bug 680821](https://bugzilla.mozilla.org/show_bug.cgi?id=680821), which is also being addressed by [pull request 323](https://github.com/mozilla/addon-sdk/pull/323). Since this pull request fixes both issues, it's the better one to merge.
