### PR TITLE
bug 718666: API exposed to content script should be defined in same principal

### DIFF
--- a/packages/addon-kit/lib/context-menu.js
+++ b/packages/addon-kit/lib/context-menu.js
@@ -638,7 +638,7 @@ const ContextMenuWorker = Worker.compose({
 
   // Returns true if any context listeners are defined in the worker's port.
   anyContextListeners: function CMW_anyContextListeners() {
-    return this._contentWorker._listeners("context").length > 0;
+    return this._contentWorker.hasListenerFor("context");
   },
 
   // Returns the first string or truthy value returned by a context listener in
@@ -646,16 +646,11 @@ const ContextMenuWorker = Worker.compose({
   // no context listeners, returns false.  popupNode is the node that was
   // context-clicked.
   isAnyContextCurrent: function CMW_isAnyContextCurrent(popupNode) {
-    let listeners = this._contentWorker._listeners("context");
-    for (let i = 0; i < listeners.length; i++) {
-      try {
-        let val = listeners[i].call(this._contentWorker._sandbox, popupNode);
-        if (typeof(val) === "string" || val)
-          return val;
-      }
-      catch (err) {
-        console.exception(err);
-      }
+    let results = this._contentWorker.emitSync("context", popupNode);
+    for (let i = 0; i < results.length; i++) {
+      let val = results[i];
+      if (typeof val === "string" || val)
+        return val;
     }
     return false;
   },
@@ -664,7 +659,7 @@ const ContextMenuWorker = Worker.compose({
   // context-clicked, and clickedItemData is the data of the item that was
   // clicked.
   fireClick: function CMW_fireClick(popupNode, clickedItemData) {
-    this._contentWorker._asyncEmit("click", popupNode, clickedItemData);
+    this._contentWorker.emitSync("click", popupNode, clickedItemData);
   }
 });
 

--- a/packages/addon-kit/lib/panel.js
+++ b/packages/addon-kit/lib/panel.js
@@ -43,7 +43,6 @@ const Panel = Symbiont.resolve({
   _onSymbiontInit: Symbiont.required,
   _symbiontDestructor: Symbiont.required,
   _emit: Symbiont.required,
-  _asyncEmit: Symbiont.required,
   on: Symbiont.required,
   removeListener: Symbiont.required,
 

--- a/packages/addon-kit/tests/test-context-menu.js
+++ b/packages/addon-kit/tests/test-context-menu.js
@@ -18,7 +18,6 @@ const OVERFLOW_POPUP_ID = "jetpack-content-menu-overflow-popup";
 
 const TEST_DOC_URL = module.uri.replace(/\.js$/, ".html");
 
-
 // Destroying items that were previously created should cause them to be absent
 // from the menu.
 exports.testConstructDestroy = function (test) {
@@ -512,7 +511,6 @@ exports.testMultipleContexts = function (test) {
   });
 };
 
-
 // Once a context is removed, it should no longer cause its item to appear.
 exports.testRemoveContext = function (test) {
   test = new TestHelper(test);
@@ -962,7 +960,6 @@ exports.testMenuClick = function (test) {
     });
   });
 };
-
 
 // Click listeners should work when multiple modules are loaded.
 exports.testItemClickMultipleModules = function (test) {

--- a/packages/api-utils/data/worker.js
+++ b/packages/api-utils/data/worker.js
@@ -1,0 +1,243 @@
+const ContentWorker = Object.freeze({
+  // TODO: Bug 727854 Use same implementation than common JS modules,
+  // i.e. EventEmitter module
+
+  /**
+   * Create an EventEmitter instance.
+   */
+  createEventEmitter: function createEventEmitter(emit) {
+    let listeners = Object.create(null);
+    let eventEmitter = Object.freeze({
+      emit: emit,
+      on: function on(name, callback) {
+        if (typeof callback !== "function")
+          return this;
+        if (!(name in listeners))
+          listeners[name] = [];
+        listeners[name].push(callback);
+        return this;
+      },
+      once: function once(name, callback) {
+        eventEmitter.on(name, function onceCallback() {
+          eventEmitter.removeListener(name, onceCallback);
+          callback.apply(callback, arguments);
+        });
+      },
+      removeListener: function removeListener(name, callback) {
+        if (!(name in listeners))
+          return;
+        let index = listeners[name].indexOf(name);
+        if (index == -1)
+          return;
+        listeners[name].splice(index, 1);
+      }
+    });
+    function onEvent(name) {
+      if (!(name in listeners))
+        return [];
+      let args = Array.slice(arguments, 1);
+      let results = [];
+      for each (let callback in listeners[name]) {
+        results.push(callback.apply(null, args));
+      }
+      return results;
+    }
+    function hasListenerFor(name) {
+      if (!(name in listeners))
+        return false;
+      return listeners[name].length > 0;
+    }
+    return {
+      eventEmitter: eventEmitter,
+      emit: onEvent,
+      hasListenerFor: hasListenerFor
+    };
+  },
+
+  /**
+   * Create an EventEmitter instance to communicate with chrome module
+   * by passing only strings between compartments.
+   * This function expects `emitToChrome` function, that allows to send
+   * events to the chrome module. It returns the EventEmitter as `pipe`
+   * attribute, and, `onChromeEvent` a function that allows chrome module
+   * to send event into the EventEmitter.
+   *
+   *                  pipe.emit --> emitToChrome
+   *              onChromeEvent --> callback registered through pipe.on
+   */
+  createPipe: function createPipe(emitToChrome) {
+    function onEvent() {
+      // Convert to real array
+      let args = Array.slice(arguments);
+      // JSON.stringify is buggy with cross-sandbox values,
+      // it may return "{}" on functions. Use a replacer to match them correctly.
+      function replacer(k, v) {
+        return typeof v === "function" ? undefined : v;
+      }
+      let str = JSON.stringify(args, replacer);
+      emitToChrome(str);
+    }
+
+    let { eventEmitter, emit, hasListenerFor } =
+      ContentWorker.createEventEmitter(onEvent);
+
+    return {
+      pipe: eventEmitter,
+      onChromeEvent: function onChromeEvent(array) {
+        // We either receive a stringified array, or a real array.
+        // We still allow to pass an array of objects, in WorkerSandbox.emitSync
+        // in order to allow sending DOM node reference between content script
+        // and modules (only used for context-menu API)
+        let args = typeof array == "string" ? JSON.parse(array) : array;
+        return emit.apply(null, args);
+      },
+      hasListenerFor: hasListenerFor
+    };
+  },
+
+  injectConsole: function injectConsole(exports, pipe) {
+    exports.console = Object.freeze({
+      log: pipe.emit.bind(null, "console", "log"),
+      info: pipe.emit.bind(null, "console", "info"),
+      warn: pipe.emit.bind(null, "console", "warn"),
+      error: pipe.emit.bind(null, "console", "error"),
+      debug: pipe.emit.bind(null, "console", "debug"),
+      exception: pipe.emit.bind(null, "console", "exception"),
+      trace: pipe.emit.bind(null, "console", "trace")
+    });
+  },
+
+  injectTimers: function injectTimers(exports, chromeAPI, pipe, console) {
+    // wrapped functions from `'timer'` module.
+    // Wrapper adds `try catch` blocks to the callbacks in order to
+    // emit `error` event on a symbiont if exception is thrown in
+    // the Worker global scope.
+    // @see http://www.w3.org/TR/workers/#workerutils
+
+    // List of all living timeouts/intervals
+    let _timers = Object.create(null);
+
+    // Keep a reference to original timeout functions
+    let {
+      setTimeout: chromeSetTimeout,
+      setInterval: chromeSetInterval,
+      clearTimeout: chromeClearTimeout,
+      clearInterval: chromeClearInterval
+    } = chromeAPI.timers;
+
+    exports.setTimeout = function ContentScriptSetTimeout(callback, delay) {
+      let params = Array.slice(arguments, 2);
+      let id = chromeSetTimeout(function() {
+        try {
+          delete _timers[id];
+          callback.apply(null, params);
+        } catch(e) {
+          console.exception(e);
+        }
+      }, delay);
+      _timers[id] = "timeout";
+      return id;
+    };
+    exports.clearTimeout = function ContentScriptClearTimeout(id) {
+      delete _timers[id];
+      return chromeClearTimeout(id);
+    };
+
+    exports.setInterval = function ContentScriptSetInterval(callback, delay) {
+      let params = Array.slice(arguments, 2);
+      let id = chromeSetInterval(function() {
+        try {
+          callback.apply(null, params);
+        } catch(e) {
+          console.exception(e);
+        }
+      }, delay);
+      _timers[id] = "interval";
+      return id;
+    };
+    exports.clearInterval = function ContentScriptClearInterval(id) {
+      delete _timers[id];
+      return chromeClearInterval(id);
+    };
+    pipe.on("destroy", function clearTimeouts() {
+      // Unregister all setTimeout/setInterval on page unload
+      for (let id in _timers) {
+        let kind = _timers[id];
+        if (kind == "timeout")
+          chromeClearTimeout(id);
+        else
+          chromeClearInterval(id);
+      }
+    });
+  },
+
+  injectMessageAPI: function injectMessageAPI(exports, pipe) {
+
+    let { eventEmitter: port, emit : portEmit } =
+      ContentWorker.createEventEmitter(pipe.emit.bind(null, "event"));
+    pipe.on("event", portEmit);
+
+    let self = Object.freeze({
+      port: port,
+      postMessage: pipe.emit.bind(null, "message"),
+      on: pipe.on.bind(null),
+      once: pipe.once.bind(null),
+      removeListener: pipe.removeListener.bind(null),
+    });
+    Object.defineProperty(exports, "self", {
+      value: self
+    });
+
+    // Deprecated use of on/postMessage from globals
+    exports.postMessage = function deprecatedPostMessage() {
+      console.warn("The global `postMessage()` function in content " +
+                   "scripts is deprecated in favor of the " +
+                   "`self.postMessage()` function, which works the same. " +
+                   "Replace calls to `postMessage()` with calls to " +
+                   "`self.postMessage()`." +
+                   "For more info on `self.on`, see " +
+                   "<https://addons.mozilla.org/en-US/developers/docs/sdk/latest/dev-guide/addon-development/web-content.html>.");
+      return self.postMessage.apply(null, arguments);
+    };
+    exports.on = function deprecatedOn() {
+      console.warn("The global `on()` function in content scripts is " +
+                   "deprecated in favor of the `self.on()` function, " +
+                   "which works the same. Replace calls to `on()` with " +
+                   "calls to `self.on()`" +
+                   "For more info on `self.on`, see " +
+                   "<https://addons.mozilla.org/en-US/developers/docs/sdk/latest/dev-guide/addon-development/web-content.html>.");
+      return self.on.apply(null, arguments);
+    };
+
+    // Deprecated use of `onMessage` from globals
+    let onMessage = null;
+    Object.defineProperty(exports, "onMessage", {
+      get: function () onMessage,
+      set: function (v) {
+        if (onMessage)
+          self.removeListener("message", onMessage);
+        console.warn("The global `onMessage` function in content scripts " +
+                     "is deprecated in favor of the `self.on()` function. " +
+                     "Replace `onMessage = function (data){}` definitions " +
+                     "with calls to `self.on('message', function (data){})`. " +
+                     "For more info on `self.on`, see " +
+                     "<https://addons.mozilla.org/en-US/developers/docs/sdk/latest/dev-guide/addon-development/web-content.html>.");
+        onMessage = v;
+        if (typeof onMessage == "function")
+          self.on("message", onMessage);
+      }
+    });
+  },
+
+  inject: function (exports, chromeAPI, emitToChrome) {
+    let { pipe, onChromeEvent, hasListenerFor } =
+      ContentWorker.createPipe(emitToChrome);
+    ContentWorker.injectConsole(exports, pipe);
+    ContentWorker.injectTimers(exports, chromeAPI, pipe, exports.console);
+    ContentWorker.injectMessageAPI(exports, pipe);
+    return {
+      emitToContent: onChromeEvent,
+      hasListenerFor: hasListenerFor
+    };
+  }
+});

--- a/packages/api-utils/lib/content/worker.js
+++ b/packages/api-utils/lib/content/worker.js
@@ -13,12 +13,12 @@ const { URL } = require('../url');
 const unload = require('../unload');
 const observers = require('../observer-service');
 const { Cortex } = require('../cortex');
-const { defer } = require('../functional');
 const self = require("self");
 const { sandbox, evaluate, load } = require("../sandbox");
 const { merge } = require('../utils/object');
 
 const CONTENT_PROXY_URL = self.data.url("content-proxy.js");
+const CONTENT_WORKER_URL = self.data.url("worker.js");
 
 const JS_VERSION = '1.8';
 
@@ -34,179 +34,86 @@ const ERR_DESTROYED =
  */
 const PRIVATE_KEY = {};
 
-function ensureArgumentsAreJSON(array, window) {
-  // JSON.stringify is buggy with cross-sandbox values,
-  // it may return "{}" on functions. Use a replacer to match them correctly.
-  function replacer(k, v) {
-    return typeof v === "function" ? undefined : v;
-  }
-  // If a window is given, we use its `JSON.parse` object in order to
-  // create JS objects for its compartments (See bug 714891)
-  let parse = JSON.parse;
-  if (window) {
-    // As we can't directly rely on `window.wrappedJSObject.JSON`, we create
-    // a temporary sandbox in order to get access to a safe `JSON` object:
-    parse = Cu.Sandbox(window).JSON.parse;
-  }
-  return parse(JSON.stringify(array, replacer));
-}
 
-/**
- * Extended `EventEmitter` allowing us to emit events asynchronously.
- */
-const AsyncEventEmitter = EventEmitter.compose({
-  /**
-   * Emits event in the next turn of event loop.
-   */
-  _asyncEmit: function _asyncEmit() {
-    timer.setTimeout(function emitter(emit, scope, params) {
-      emit.apply(scope, params);
-    }, 0, this._emit, this, arguments)
-  }
-});
-
-/**
- * Local trait providing implementation of the workers global scope.
- * Used to configure global object in the sandbox.
- * @see http://www.w3.org/TR/workers/#workerglobalscope
- */
-const WorkerGlobalScope = AsyncEventEmitter.compose({
-  on: Trait.required,
-  _removeAllListeners: Trait.required,
-
-  // wrapped functions from `'timer'` module.
-  // Wrapper adds `try catch` blocks to the callbacks in order to
-  // emit `error` event on a symbiont if exception is thrown in
-  // the Worker global scope.
-  // @see http://www.w3.org/TR/workers/#workerutils
-
-  // List of all living timeouts/intervals
-  _timers: null,
-
-  setTimeout: function setTimeout(callback, delay) {
-    let params = Array.slice(arguments, 2);
-    let id = timer.setTimeout(function(self) {
-      try {
-        delete self._timers[id];
-        callback.apply(null, params);
-      } catch(e) {
-        self._addonWorker._asyncEmit('error', e);
-      }
-    }, delay, this);
-    this._timers[id] = true;
-    return id;
-  },
-  clearTimeout: function clearTimeout(id){
-    delete this._timers[id];
-    return timer.clearTimeout(id);
-  },
-
-  setInterval: function setInterval(callback, delay) {
-    let params = Array.slice(arguments, 2);
-    let id = timer.setInterval(function(self) {
-      try {
-        callback.apply(null, params); 
-      } catch(e) {
-        self._addonWorker._asyncEmit('error', e);
-      }
-    }, delay, this);
-    this._timers[id] = true;
-    return id;
-  },
-  clearInterval: function clearInterval(id) {
-    delete this._timers[id];
-    return timer.clearInterval(id);
-  },
+const WorkerSandbox = EventEmitter.compose({
 
   /**
-   * `onMessage` function defined in the global scope of the worker context.
+   * Emit a message to the worker content sandbox
    */
-  get _onMessage() this.__onMessage,
-  set _onMessage(value) {
-    let listener = this.__onMessage;
-    if (listener && value !== listener) {
-      this.removeListener('message', listener);
-      this.__onMessage = undefined;
+  emit: function emit() {
+    // First ensure having a regular array
+    // (otherwise, `arguments` would be mapped to an object by `stringify`)
+    let array = Array.slice(arguments);
+    // JSON.stringify is buggy with cross-sandbox values,
+    // it may return "{}" on functions. Use a replacer to match them correctly.
+    function replacer(k, v) {
+      return typeof v === "function" ? undefined : v;
     }
-    if (value)
-      this.on('message', this.__onMessage = value);
+    // Ensure having an asynchronous behavior
+    let self = this;
+    timer.setTimeout(function () {
+      self._emitToContent(JSON.stringify(array, replacer));
+    }, 0);
   },
-  __onMessage: undefined,
 
   /**
-   * Function for sending data to the addon side.
-   * Validates that data is a `JSON` or primitive value and emits
-   * 'message' event on the worker in the next turn of the event loop.
-   * _Later this will be sending data across process boundaries._
-   * @param {JSON|String|Number|Boolean} data
+   * Synchronous version of `emit`.
+   * /!\ Should only be used when it is strictly mandatory /!\
+   *     Doesn't ensure passing only JSON values.
+   *     Mainly used by context-menu in order to avoid breaking it.
    */
-  postMessage: function postMessage(data) {
-    if (!this._addonWorker)
-      throw new Error(ERR_DESTROYED);
-    this._addonWorker._asyncEmit('message', ensureArgumentsAreJSON(data));
+  emitSync: function emitSync() {
+    return this._emitToContent(Array.slice(arguments));
   },
-  
-  /**
-   * EventEmitter, that behaves (calls listeners) asynchronously.
-   * A way to send customized messages to / from the worker.
-   * Events from in the worker can be observed / emitted via self.on / self.emit 
-   */
-  get port() this._port._public,
-  
-  /**
-   * Same object than this.port but private API.
-   * Allow access to _asyncEmit, in order to send event to port.
-   */
-  _port: null,
 
   /**
-   * Alias to the global scope in the context of worker. Similar to
-   * `window` concept.
+   * Tells if content script has at least one listener registered for one event,
+   * through `self.on('xxx', ...)`.
+   * /!\ Shouldn't be used. Implemented to avoid breaking context-menu API.
    */
-  get self() this._public,
+  hasListenerFor: function hasListenerFor(name) {
+    return this._hasListenerFor(name);
+  },
+
+  /**
+   * Method called by the worker sandbox when it needs to send a message
+   */
+  _onContentEvent: function onContentEvent(args) {
+    // As `emit`, we ensure having an asynchronous behavior
+    let self = this;
+    timer.setTimeout(function () {
+      // We emit event to chrome/addon listeners
+      self._emit.apply(self, JSON.parse(args));
+    }, 0);
+  },
 
   /**
    * Configures sandbox and loads content scripts into it.
    * @param {Worker} worker
    *    content worker
    */
-  constructor: function WorkerGlobalScope(worker) {
+  constructor: function WorkerSandbox(worker) {
     this._addonWorker = worker;
-    
-    // Hack in order to allow addon worker to access _asyncEmit
-    // as this is the private object of WorkerGlobalScope
-    worker._contentWorker = this;
-    
-    // create an event emitter that receive and send events from/to the addon
-    let contentWorker = this;
-    this._port = EventEmitterTrait.create({
-      emit: function () {
-        let addonWorker = contentWorker._addonWorker;
-        if (!addonWorker)
-          throw new Error(ERR_DESTROYED);
-        addonWorker._onContentScriptEvent.apply(addonWorker, arguments);
-      }
-    });
-    // create emit that executes in next turn of event loop.
-    this._port._asyncEmit = defer(this._port._emit);
-    // expose wrapped port, that exposes only public properties. 
-    this._port._public = Cortex(this._port);
-    
-    // We receive an unwrapped window, with raw js access
+
+    // Ensure that `emit` has always the right `this`
+    this.emit = this.emit.bind(this);
+    this.emitSync = this.emitSync.bind(this);
+
+    // We receive a wrapped window, that may be an xraywrapper if it's content
     let window = worker._window;
-    
     let proto = window;
-    let proxySandbox = null;
+
+    // Instantiate trusted code in another Sandbox in order to prevent content
+    // script from messing with standard classes used by proxy and API code.
+    let apiSanbox = sandbox(window, { wantXrays: true });
+
     // Build content proxies only if the document has a non-system principal
     if (window.wrappedJSObject) {
-      // Instantiate the proxy code in another Sandbox in order to prevent
-      // content script from polluting globals used by proxy code
-      proxySandbox = sandbox(window, { wantXrays: true });
-      proxySandbox.console = console;
+      apiSanbox.console = console;
       // Execute the proxy code
-      load(proxySandbox, CONTENT_PROXY_URL);
+      load(apiSanbox, CONTENT_PROXY_URL);
       // Get a reference of the window's proxy
-      proto = proxySandbox.create(window);
+      proto = apiSanbox.create(window);
     }
 
     // Create the sandbox and bind it to window in order for content scripts to
@@ -227,75 +134,58 @@ const WorkerGlobalScope = AsyncEventEmitter.compose({
       get unsafeWindow() window.wrappedJSObject
     });
 
+    // Load trusted code that will inject content script API.
+    // We need to expose JS objects defined in same principal in order to
+    // avoid having any kind of wrapper.
+    load(apiSanbox, CONTENT_WORKER_URL);
+
+    // Then call `inject` method and communicate with this script
+    // by trading two methods that allow to send events to the other side:
+    //   - `onEvent` called by content script
+    //   - `result.emitToContent` called by addon script
+    let chromeAPI = {
+      timers: {
+        setTimeout: timer.setTimeout,
+        setInterval: timer.setInterval,
+        clearTimeout: timer.clearTimeout,
+        clearInterval: timer.clearInterval
+      }
+    };
+    let onEvent = this._onContentEvent.bind(this);
+    // `ContentWorker` is defined in CONTENT_WORKER_URL file
+    let result = apiSanbox.ContentWorker.inject(content, chromeAPI, onEvent);
+    this._emitToContent = result.emitToContent;
+    this._hasListenerFor = result.hasListenerFor;
+
+    // Handle messages send by this script:
+    let self = this;
+    // console.xxx calls
+    this.on("console", function consoleListener(kind) {
+      console[kind].apply(console, Array.slice(arguments, 1));
+    });
+
+    // self.postMessage calls
+    this.on("message", function postMessage(data) {
+      self._addonWorker._emit('message', data);
+    });
+
+    // self.port.emit calls
+    this.on("event", function portEmit(name, args) {
+      self._addonWorker._onContentScriptEvent.apply(self._addonWorker, arguments);
+    });
+
     // Internal feature that is only used by SDK tests:
     // Expose unlock key to content script context.
     // See `PRIVATE_KEY` definition for more information.
-    if (proxySandbox && worker._expose_key)
-      content.UNWRAP_ACCESS_KEY = proxySandbox.UNWRAP_ACCESS_KEY;
-
-    // Initialize timer lists
-    this._timers = {};
-
-    let self = this;
-    let publicAPI = this._public;
-
-    merge(content, {
-      console: console,
-      self: publicAPI.self,
-      setTimeout: publicAPI.setTimeout,
-      clearTimeout: publicAPI.clearTimeout,
-      setInterval: publicAPI.setInterval,
-      clearInterval: publicAPI.clearInterval,
-      get onMessage() self._onMessage,
-      set onMessage(value) {
-        console.warn("The global `onMessage` function in content scripts " +
-                     "is deprecated in favor of the `self.on()` function. " +
-                     "Replace `onMessage = function (data){}` definitions " +
-                     "with calls to `self.on('message', function (data){})`. " +
-                     "For more info on `self.on`, see " +
-                     "<https://addons.mozilla.org/en-US/developers/docs/sdk/latest/dev-guide/addon-development/web-content.html>.");
-        self._onMessage = value;
-      },
-      // Deprecated use of on/postMessage from globals
-      postMessage: function postMessage() {
-        console.warn("The global `postMessage()` function in content " +
-                     "scripts is deprecated in favor of the " +
-                     "`self.postMessage()` function, which works the same. " +
-                     "Replace calls to `postMessage()` with calls to " +
-                     "`self.postMessage()`." +
-                     "For more info on `self.on`, see " +
-                     "<https://addons.mozilla.org/en-US/developers/docs/sdk/latest/dev-guide/addon-development/web-content.html>.");
-        publicAPI.postMessage.apply(publicAPI, arguments);
-      },
-      on: function on() {
-        console.warn("The global `on()` function in content scripts is " +
-                     "deprecated in favor of the `self.on()` function, " +
-                     "which works the same. Replace calls to `on()` with " +
-                     "calls to `self.on()`" +
-                     "For more info on `self.on`, see " +
-                     "<https://addons.mozilla.org/en-US/developers/docs/sdk/latest/dev-guide/addon-development/web-content.html>.");
-        publicAPI.on.apply(publicAPI, arguments);
-      }
-    });
-
-    // Temporary fix for test-widget, that pass self.postMessage to proxy code
-    // that first try to access to `___proxy` and then call it through `apply`.
-    // We need to move function given to content script to a sandbox
-    // with same principal than the content script.
-    // In the meantime, we need to allow such access explicitly
-    // by using `__exposedProps__` property, documented here:
-    // https://developer.mozilla.org/en/XPConnect_wrappers
-    content.self.postMessage.__exposedProps__ = {
-      ___proxy: 'rw',
-      apply: 'rw'
-    }
+    if (apiSanbox && worker._expose_key)
+      content.UNWRAP_ACCESS_KEY = apiSanbox.UNWRAP_ACCESS_KEY;
 
     // Inject `addon` global into target document if document is trusted,
     // `addon` in document is equivalent to `self` in content script.
     if (worker._injectInDocument) {
       let win = window.wrappedJSObject ? window.wrappedJSObject : window;
       Object.defineProperty(win, "addon", {
-          get: function () publicAPI
+          value: content.self
         }
       );
     }
@@ -319,16 +209,10 @@ const WorkerGlobalScope = AsyncEventEmitter.compose({
       );
     }
   },
-  _destructor: function _destructor() {
-    this._removeAllListeners();
-    // Unregister all setTimeout/setInterval
-    // We can use `clearTimeout` for both setTimeout/setInterval
-    // as internal implementation of timer module use same method for both.
-    for (let id in this._timers)
-      timer.clearTimeout(id);
+  destroy: function destroy() {
+    this.emitSync("destroy");
     this._sandbox = null;
     this._addonWorker = null;
-    this.__onMessage = undefined;
   },
   
   /**
@@ -355,7 +239,7 @@ const WorkerGlobalScope = AsyncEventEmitter.compose({
       evaluate(this._sandbox, code, filename || 'javascript:' + code);
     }
     catch(e) {
-      this._addonWorker._asyncEmit('error', e);
+      this._addonWorker._emit('error', e);
     }
   },
   /**
@@ -378,7 +262,7 @@ const WorkerGlobalScope = AsyncEventEmitter.compose({
           throw Error("Unsupported `contentScriptFile` url: " + String(uri));
       }
       catch(e) {
-        this._addonWorker._asyncEmit('error', e)
+        this._addonWorker._emit('error', e);
       }
     }
   }
@@ -389,9 +273,8 @@ const WorkerGlobalScope = AsyncEventEmitter.compose({
  * in the content and add-on process.
  * @see https://jetpack.mozillalabs.com/sdk/latest/docs/#module/api-utils/content/worker
  */
-const Worker = AsyncEventEmitter.compose({
+const Worker = EventEmitter.compose({
   on: Trait.required,
-  _asyncEmit: Trait.required,
   _removeAllListeners: Trait.required,
   
   /**
@@ -409,8 +292,7 @@ const Worker = AsyncEventEmitter.compose({
   postMessage: function postMessage(data) {
     if (!this._contentWorker)
       throw new Error(ERR_DESTROYED);
-    this._contentWorker._asyncEmit('message',
-                                   ensureArgumentsAreJSON(data, this._window));
+    this._contentWorker.emit("message", data);
   },
   
   /**
@@ -426,10 +308,9 @@ const Worker = AsyncEventEmitter.compose({
     // create an event emitter that receive and send events from/to the worker
     let self = this;
     this._port = EventEmitterTrait.create({
-      emit: function () self._emitEventToContent(arguments)
+      emit: function () self._emitEventToContent(Array.slice(arguments))
     });
-    // create emit that executes in next turn of event loop.
-    this._port._asyncEmit = defer(this._port._emit);
+
     // expose wrapped port, that exposes only public properties:
     // We need to destroy this getter in order to be able to set the
     // final value. We need to update only public port attribute as we never 
@@ -445,7 +326,7 @@ const Worker = AsyncEventEmitter.compose({
   
   /**
    * Same object than this.port but private API.
-   * Allow access to _asyncEmit, in order to send event to port.
+   * Allow access to _emit, in order to send event to port.
    */
   _port: null,
   
@@ -460,19 +341,17 @@ const Worker = AsyncEventEmitter.compose({
       this._earlyEvents.push(args);
       return;
     }
-    
+
     // We throw exception when the worker has been destroyed
     if (!this._contentWorker) {
       throw new Error(ERR_DESTROYED);
     }
-    
-    let scope = this._contentWorker._port;
-    // Ensure that we pass only JSON values
-    let array = Array.prototype.slice.call(args);
-    scope._asyncEmit.apply(scope, ensureArgumentsAreJSON(array, this._window));
+
+    // Forward the event to the WorkerSandbox object
+    this._contentWorker.emit.apply(null, ["event"].concat(args));
   },
   
-  // Is worker connected to the content worker (i.e. WorkerGlobalScope) ?
+  // Is worker connected to the content worker sandbox ?
   _inited: false,
   
   // List of custom events fired before worker is initialized
@@ -517,11 +396,11 @@ const Worker = AsyncEventEmitter.compose({
     unload.ensure(this._public, "destroy");
     
     // Ensure that worker._port is initialized for contentWorker to be able
-    // to send use event during WorkerGlobalScope(this)
+    // to send use event during WorkerSandbox(this)
     this.port;
     
     // will set this._contentWorker pointing to the private API:
-    WorkerGlobalScope(this);  
+    this._contentWorker = WorkerSandbox(this);
     
     // Mainly enable worker.port.emit to send event to the content worker
     this._inited = true;
@@ -569,7 +448,7 @@ const Worker = AsyncEventEmitter.compose({
     // maybe unloaded before content side is created
     // As Symbiont call worker.constructor on document load
     if (this._contentWorker) 
-      this._contentWorker._destructor();
+      this._contentWorker.destroy();
     this._contentWorker = null;
     this._window = null;
     // This method may be called multiple times,
@@ -587,9 +466,7 @@ const Worker = AsyncEventEmitter.compose({
    * worker.port. Provide a way for composed object to catch all events.
    */
   _onContentScriptEvent: function _onContentScriptEvent() {
-    // Ensure that we pass only JSON values
-    let array = Array.prototype.slice.call(arguments);
-    this._port._asyncEmit.apply(this._port, ensureArgumentsAreJSON(array));
+    this._port._emit.apply(this._port, arguments);
   },
   
   /**


### PR DESCRIPTION
...than the content script. In order to:
- avoid having any kind of wrapper.
  Prevents bug 679363 comment 2 about `apply` method and any side effect of wrappers
- avoid sharing complex objects between chrome and content sandboxes.
  Improves overall security by passing only strings.

https://bugzilla.mozilla.org/show_bug.cgi?id=718666
