### PR TITLE
Bug 721363 - Improve cfx experience on mobile:

### DIFF
--- a/python-lib/cuddlefish/__init__.py
+++ b/python-lib/cuddlefish/__init__.py
@@ -147,6 +147,10 @@ parser_groups = (
                                       "fennec-on-device, xulrunner or "
                                       "thunderbird"),
                                 metavar=None,
+                                type="choice",
+                                choices=["firefox", "fennec",
+                                         "fennec-on-device", "thunderbird",
+                                         "xulrunner"],
                                 default="firefox",
                                 cmds=['test', 'run', 'testex', 'testpkgs',
                                       'testall'])),
@@ -767,6 +771,11 @@ def run(arguments=sys.argv[1:], target_cfg=None, pkg_cfg=None,
                              used_files=used_files,
                              enable_mobile=options.enable_mobile,
                              mobile_app_name=options.mobile_app_name)
+        except ValueError, e:
+            print ""
+            print "A given cfx option has an inappropriate value:"
+            print >>sys.stderr, "  " + "  \n  ".join(str(e).split("\n"))
+            retval = -1
         except Exception, e:
             if str(e).startswith(MOZRUNNER_BIN_NOT_FOUND):
                 print >>sys.stderr, MOZRUNNER_BIN_NOT_FOUND_HELP.strip()

--- a/python-lib/cuddlefish/runner.py
+++ b/python-lib/cuddlefish/runner.py
@@ -165,7 +165,9 @@ class RemoteFennecRunner(mozrunner.Runner):
         elif mobile_app_name:
             if not mobile_app_name in intents:
                 raise ValueError("Unable to found Firefox application "
-                                "with intent name '%s'", mobile_app_name)
+                                 "with intent name '%s'\n"
+                                 "Available ones are: %s" %
+                                 (mobile_app_name, ", ".join(intents)))
             self._intent_name = self._INTENT_PREFIX + mobile_app_name
         else:
             if "firefox" in intents:
@@ -388,6 +390,15 @@ def run_app(harness_root_dir, manifest_rdf, harness_options,
     cmdargs = []
     preferences = dict(DEFAULT_COMMON_PREFS)
 
+    # For now, only allow running on Mobile with --force-mobile argument
+    if app_type in ["fennec", "fennec-on-device"] and not enable_mobile:
+        print """
+  WARNING: Firefox Mobile support is still experimental.
+  If you would like to run an addon on this platform, use --force-mobile flag:
+
+    cfx --force-mobile"""
+        return 0
+
     if app_type == "fennec-on-device":
         profile_class = FennecProfile
         preferences.update(DEFAULT_FENNEC_PREFS)
@@ -516,6 +527,14 @@ def run_app(harness_root_dir, manifest_rdf, harness_options,
     sys.stdout.flush(); sys.stderr.flush()
 
     if app_type == "fennec-on-device":
+        if not enable_mobile:
+            print >>sys.stderr, """
+  WARNING: Firefox Mobile support is still experimental.
+  If you would like to run an addon on this platform, use --force-mobile flag:
+
+    cfx --force-mobile"""
+            return 0
+
         # In case of mobile device, we need to get stdio from `adb logcat` cmd:
 
         # First flush logs in order to avoid catching previous ones


### PR DESCRIPTION
1/ Print only the error message, instead of the full stack trace.
2/ Prints detected mobile app name on the device, when we pass an inexisting one.
3/ Prints available option for -a/-app when we give a wrong value.
4/ Print error message in order to add --force-mobile when we pass -a/--app fennec/fennec-on-device.

https://bugzilla.mozilla.org/show_bug.cgi?id=721363
