### PR TITLE
Bug 726967: Fix infinite loop when `error` event listener throws.

### DIFF
--- a/packages/api-utils/lib/events.js
+++ b/packages/api-utils/lib/events.js
@@ -148,7 +148,12 @@ const eventEmitter =  {
       try {
         listener.apply(targetObj, params);
       } catch(e) {
-        this._emit('error', e);
+        // Bug 726967: Ignore exceptions being throws while notifying the error
+        // in order to avoid infinite loops.
+        if (type !== ERROR_TYPE)
+          this._emit(ERROR_TYPE, e);
+        else
+          console.exception("Exception in error event listener " + e);
       }
     }
     return true;

--- a/packages/api-utils/tests/test-events.js
+++ b/packages/api-utils/tests/test-events.js
@@ -248,3 +248,20 @@ exports["test:removing once"] = function(test) {
   e.once("error", function() { test.fail("error event was emitted"); });
   e._emit("foo", "bug-656684");
 };
+
+// Bug 726967: Ensure that `emit` doesn't do an infinite loop when `error`
+// listener throws an exception
+exports['test:emitLoop'] = function(test) {
+  let e = new EventEmitter();
+
+  e.on("foo", function() {
+    throw new Error("foo");
+  });
+
+  e.on("error", function() {
+    throw new Error("error");
+  });
+  e.emit("foo");
+
+  test.pass("emit didn't looped");
+};


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=726967
