### PR TITLE
Bug 725954 - Use `about:credits` instead of `about:` as former one seems to break test on nighly.

### DIFF
--- a/packages/addon-kit/tests/test-page-mod.js
+++ b/packages/addon-kit/tests/test-page-mod.js
@@ -180,7 +180,7 @@ exports.testCommunication2 = function(test) {
   let callbackDone = null,
       window;
 
-  testPageMod(test, "about:", [{
+  testPageMod(test, "about:credits", [{
       include: "about:*",
       contentScriptWhen: 'start',
       contentScript: 'new ' + function WorkerScope() {


### PR DESCRIPTION
Currently [tinderbox](https://tbpl.mozilla.org/?usetinderbox=1&tree=Jetpack) is orange as there is some strange issue with window when setting event listener on it. It also seems than issues only happens on about: page, using `about:credits` does not seems to have similar issues, so this change uses that url for test to make tree go green again. Proper investigation / fix can come in a separate patch.
