### PR TITLE
fix testcases for findClosestLocale() of api-utils/l10n/locale

### DIFF
--- a/packages/api-utils/tests/test-l10n-locale.js
+++ b/packages/api-utils/tests/test-l10n-locale.js
@@ -101,36 +101,41 @@ exports.testPreferedOsLocale = function(test) {
 }
 
 exports.testFindClosestLocale = function(test) {
+  // Second param of findClosestLocale (aMatchLocales) have to be in lowercase
   test.assertEqual(findClosestLocale([], []), null,
                    "When everything is empty we get null");
 
-  test.assertEqual(findClosestLocale(["en-US", "en"], ["en"]),
-                   "en", "We ignore more specialized locale, when there is a more generic locale");
-  test.assertEqual(findClosestLocale(["ja-JP"], ["ja"]),
-                   "ja-JP", "We accept more specialized locale, when there is no exact match nor more generic 1/2");
-  test.assertEqual(findClosestLocale(["ja-JP-mac", "ja"], ["ja-JP"]),
-                   "ja", "We accept more specialized locale, when there is no exact match nor more generic 2/2");
-  test.assertEqual(findClosestLocale(["en", "en-US"], ["en-US"]),
-                   "en", "We accept more generic locale first, even over exact match 1/2");
-  test.assertEqual(findClosestLocale(["ja-JP-mac", "ja", "ja-JP"], ["ja-JP"]),
-                   "ja", "We accept more generic locale first, even over exact match 2/2");
-
-  test.assertEqual(findClosestLocale(["en-US", "en"], ["en"]),
-                   "en", "But we accept more specialized first 1/2");
   test.assertEqual(findClosestLocale(["en", "en-US"], ["en"]),
-                   "en", "But we accept more specialized first 2/2");
+                   "en", "We always accept exact match first 1/5");
+  test.assertEqual(findClosestLocale(["en-US", "en"], ["en"]),
+                   "en", "We always accept exact match first 2/5");
+  test.assertEqual(findClosestLocale(["en", "en-US"], ["en-us"]),
+                   "en-US", "We always accept exact match first 3/5");
+  test.assertEqual(findClosestLocale(["ja-JP-mac", "ja", "ja-JP"], ["ja-jp"]),
+                   "ja-JP", "We always accept exact match first 4/5");
+  test.assertEqual(findClosestLocale(["ja-JP-mac", "ja", "ja-JP"], ["ja-jp-mac"]),
+                   "ja-JP-mac", "We always accept exact match first 5/5");
 
-  test.assertEqual(findClosestLocale(["en-US"], ["en-US"]),
-                   "en-US", "Case doesn't matter, but we keep the original one as result 1/3");
+  test.assertEqual(findClosestLocale(["en", "en-GB"], ["en-us"]),
+                   "en", "We accept more generic locale, when there is no exact match 1/2");
+  test.assertEqual(findClosestLocale(["en-ZA", "en"], ["en-gb"]),
+                   "en", "We accept more generic locale, when there is no exact match 2/2");
+
+  test.assertEqual(findClosestLocale(["ja-JP"], ["ja"]),
+                   "ja-JP", "We accept more specialized locale, when there is no exact match 1/2");
+  // Better to select "ja" in this case but behave same as current AddonManager
+  test.assertEqual(findClosestLocale(["ja-JP-mac", "ja"], ["ja-jp"]),
+                   "ja-JP-mac", "We accept more specialized locale, when there is no exact match 2/2");
+
   test.assertEqual(findClosestLocale(["en-US"], ["en-us"]),
-                   "en-US", "Case doesn't matter, but we keep the original one as result 2/3");
-  test.assertEqual(findClosestLocale(["en-us"], ["en-US"]),
-                   "en-us", "Case doesn't matter, but we keep the original one as result 3/3");
+                   "en-US", "We keep the original one as result 1/2");
+  test.assertEqual(findClosestLocale(["en-us"], ["en-us"]),
+                   "en-us", "We keep the original one as result 2/2");
 
-  test.assertEqual(findClosestLocale(["ja-JP-mac"], ["ja-JP-mac"]),
+  test.assertEqual(findClosestLocale(["ja-JP-mac"], ["ja-jp-mac"]),
                    "ja-JP-mac", "We accept locale with 3 parts");
-  test.assertEqual(findClosestLocale(["ja-JP"], ["ja-JP-mac"]),
+  test.assertEqual(findClosestLocale(["ja-JP"], ["ja-jp-mac"]),
                    "ja-JP", "We accept locale with 2 parts from locale with 3 parts");
-  test.assertEqual(findClosestLocale(["ja"], ["ja-JP-mac"]),
+  test.assertEqual(findClosestLocale(["ja"], ["ja-jp-mac"]),
                    "ja", "We accept locale with 1 part from locale with 3 parts");
 }


### PR DESCRIPTION
As I add comment in the file, second param of findClosestLocale() have to be in lowercase.

Current testcates and it's comments are wrong and this pull request will fix/updated them.
