### PR TITLE
Add property to provide JSON set of global variables for initial state of content scripts

### DIFF
--- a/doc/dev-guide-source/guides/content-scripts/loading.md
+++ b/doc/dev-guide-source/guides/content-scripts/loading.md
@@ -9,9 +9,10 @@ The constructors for content-script-using objects such as panel and page-mod
 define a group of options for loading content scripts:
 
 <pre>
-  contentScript      string, array
-  contentScriptFile  string, array
-  contentScriptWhen  string
+  contentScript         string, array
+  contentScriptFile     string, array
+  contentScriptWhen     string
+  contentScriptOptions  object
 </pre>
 
 We have already seen the `contentScript` option, which enables you to pass
@@ -71,3 +72,8 @@ has been loaded, at the time the
 fires.
 
 The default value is "end".
+
+The `contentScriptOptions` is a json that is exposed to content scripts as a read
+only value under `self.options` property.
+
+Any kind of jsonable value (object, array, string, etc.) can be used here.

--- a/packages/addon-kit/docs/page-mod.md
+++ b/packages/addon-kit/docs/page-mod.md
@@ -352,6 +352,11 @@ Creates a PageMod.
     fires
 
     This property is optional and defaults to "end".
+  @prop [contentScriptOptions] {object}
+    Read-only value exposed to content scripts under `self.options` property.
+
+    Any kind of jsonable value (object, array, string, etc.) can be used here.
+    Optional.
 
   @prop [contentStyleFile] {string,array}
     The local file URLs of stylesheet to load. Content style specified by this

--- a/packages/addon-kit/docs/page-worker.md
+++ b/packages/addon-kit/docs/page-worker.md
@@ -187,6 +187,11 @@ loaded until its `destroy` method is called or the add-on is unloaded.
     fires
 
     This property is optional and defaults to "end".
+  @prop [contentScriptOptions] {object}
+    Read-only value exposed to content scripts under `self.options` property.
+
+    Any kind of jsonable value (object, array, string, etc.) can be used here.
+    Optional.
 
   @prop [onMessage] {function}
     Use this to add a listener to the page worker's `message` event.
@@ -244,6 +249,14 @@ load.
   [window.onload event](https://developer.mozilla.org/en/DOM/window.onload)
   fires
 
+</api>
+
+<api name="contentScriptOptions">
+@property {object}
+Read-only value exposed to content scripts under `self.options` property.
+
+Any kind of jsonable value (object, array, string, etc.) can be used here.
+Optional.
 </api>
 
 <api name="destroy">

--- a/packages/addon-kit/docs/panel.md
+++ b/packages/addon-kit/docs/panel.md
@@ -399,6 +399,11 @@ Creates a panel.
     fires
 
     This property is optional and defaults to "end".
+  @prop [contentScriptOptions] {object}
+    Read-only value exposed to content scripts under `self.options` property.
+
+    Any kind of jsonable value (object, array, string, etc.) can be used here.
+    Optional.
 
   @prop [onMessage] {function}
     Include this to listen to the panel's `message` event.
@@ -478,6 +483,14 @@ images) for the panel has been loaded, at the time the
 [window.onload event](https://developer.mozilla.org/en/DOM/window.onload)
 fires
 
+</api>
+
+<api name="contentScriptOptions">
+@property {object}
+Read-only value exposed to content scripts under `self.options` property.
+
+Any kind of jsonable value (object, array, string, etc.) can be used here.
+Optional.
 </api>
 
 <api name="destroy">

--- a/packages/addon-kit/docs/widget.md
+++ b/packages/addon-kit/docs/widget.md
@@ -527,22 +527,27 @@ Represents a widget object.
     specified by the `contentScriptFile` property.
 
   @prop [contentScriptWhen="end"] {string}
-  When to load the content scripts. This may take one of the following
-  values:
+    When to load the content scripts. This may take one of the following
+    values:
 
-  * "start": load content scripts immediately after the document
-  element for the widget is inserted into the DOM, but before the DOM content
-  itself has been loaded
-  * "ready": load content scripts once DOM content has been loaded,
-  corresponding to the
-  [DOMContentLoaded](https://developer.mozilla.org/en/Gecko-Specific_DOM_Events)
-  event
-  * "end": load content scripts once all the content (DOM, JS, CSS,
-  images) for the widget has been loaded, at the time the
-  [window.onload event](https://developer.mozilla.org/en/DOM/window.onload)
-  fires
+    * "start": load content scripts immediately after the document
+    element for the widget is inserted into the DOM, but before the DOM content
+    itself has been loaded
+    * "ready": load content scripts once DOM content has been loaded,
+    corresponding to the
+    [DOMContentLoaded](https://developer.mozilla.org/en/Gecko-Specific_DOM_Events)
+    event
+    * "end": load content scripts once all the content (DOM, JS, CSS,
+    images) for the widget has been loaded, at the time the
+    [window.onload event](https://developer.mozilla.org/en/DOM/window.onload)
+    fires
 
-  This property is optional and defaults to "end".
+    This property is optional and defaults to "end".
+  @prop [contentScriptOptions] {object}
+    Read-only value exposed to content scripts under `self.options` property.
+
+    Any kind of jsonable value (object, array, string, etc.) can be used here.
+    Optional.
 
 </api>
 
@@ -663,6 +668,14 @@ Represents a widget object.
   [window.onload event](https://developer.mozilla.org/en/DOM/window.onload)
   fires
 
+</api>
+
+<api name="contentScriptOptions">
+@property {object}
+Read-only value exposed to content scripts under `self.options` property.
+
+Any kind of jsonable value (object, array, string, etc.) can be used here.
+Optional.
 </api>
 
 <api name="port">
@@ -856,6 +869,14 @@ In this example `WidgetView` is used to display different content for
   [window.onload event](https://developer.mozilla.org/en/DOM/window.onload)
   fires
 
+</api>
+
+<api name="contentScriptOptions">
+@property {object}
+Read-only value exposed to content scripts under `self.options` property.
+
+Any kind of jsonable value (object, array, string, etc.) can be used here.
+Optional.
 </api>
 
 <api name="port">

--- a/packages/addon-kit/lib/page-mod.js
+++ b/packages/addon-kit/lib/page-mod.js
@@ -101,6 +101,7 @@ const PageMod = Loader.compose(EventEmitter, {
   contentScript: Loader.required,
   contentScriptFile: Loader.required,
   contentScriptWhen: Loader.required,
+  contentScriptOptions: Loader.required,
   include: null,
   constructor: function PageMod(options) {
     this._onContent = this._onContent.bind(this);
@@ -112,6 +113,8 @@ const PageMod = Loader.compose(EventEmitter, {
       this.contentScript = options.contentScript;
     if ('contentScriptFile' in options)
       this.contentScriptFile = options.contentScriptFile;
+    if ('contentScriptOptions' in options)
+      this.contentScriptOptions = options.contentScriptOptions;
     if ('contentScriptWhen' in options)
       this.contentScriptWhen = options.contentScriptWhen;
     if ('onAttach' in options)
@@ -200,6 +203,7 @@ const PageMod = Loader.compose(EventEmitter, {
       window: window,
       contentScript: this.contentScript,
       contentScriptFile: this.contentScriptFile,
+      contentScriptOptions: this.contentScriptOptions,
       onError: this._onUncaughtError
     });
     this._emit('attach', worker);

--- a/packages/addon-kit/lib/page-worker.js
+++ b/packages/addon-kit/lib/page-worker.js
@@ -37,6 +37,8 @@ const Page = Trait.compose(
         this.contentScriptWhen = options.contentScriptWhen;
       if ('contentScriptFile' in options)
         this.contentScriptFile = options.contentScriptFile;
+      if ('contentScriptOptions' in options)
+        this.contentScriptOptions = options.contentScriptOptions;
       if ('contentScript' in options)
         this.contentScript = options.contentScript;
       if ('allow' in options)

--- a/packages/addon-kit/lib/widget.js
+++ b/packages/addon-kit/lib/widget.js
@@ -802,6 +802,7 @@ WidgetChrome.prototype.setContent = function WC_setContent() {
     contentScriptFile: this._widget.contentScriptFile,
     contentScript: this._widget.contentScript,
     contentScriptWhen: this._widget.contentScriptWhen,
+    contentScriptOptions: this._widget.contentScriptOptions,
     allow: this._widget.allow,
     onMessage: function(message) {
       setTimeout(function() {

--- a/packages/addon-kit/tests/pagemod-test-helpers.js
+++ b/packages/addon-kit/tests/pagemod-test-helpers.js
@@ -59,7 +59,8 @@ exports.testPageMod = function testPageMod(test, testURL, pageModOptions,
         tabBrowser.removeTab(newTab);
         loader.unload();
         test.done();
-      });
+      }
+    );
   }
   b.addEventListener("load", onPageLoad, true);
 

--- a/packages/addon-kit/tests/test-page-mod.js
+++ b/packages/addon-kit/tests/test-page-mod.js
@@ -520,7 +520,32 @@ exports.testPageModCssDestroy = function(test) {
       );
 
       done();
+    }
+  );
+};
 
+exports.testContentScriptOptionsOption = function(test) {
+	test.waitUntilDone();
+
+  let callbackDone = null;
+  testPageMod(test, "about:", [{
+      include: "about:*",
+      contentScript: "self.postMessage( [typeof self.options.d, self.options] );",
+      contentScriptWhen: "end",
+      contentScriptOptions: {a: true, b: [1,2,3], c: "string", d: function(){ return 'test'}},
+      onAttach: function(worker) {
+      	worker.on('message', function(msg) {
+          test.assertEqual( msg[0], 'undefined', 'functions are stripped from contentScriptOptions' );
+          test.assertEqual( typeof msg[1], 'object', 'object as contentScriptOptions' );
+          test.assertEqual( msg[1].a, true, 'boolean in contentScriptOptions' );
+          test.assertEqual( msg[1].b.join(), '1,2,3', 'array and numbers in contentScriptOptions' );
+          test.assertEqual( msg[1].c, 'string', 'string in contentScriptOptions' );
+          callbackDone();
+        });
+      }
+    }],
+    function(win, done) {
+      callbackDone = done;
     }
   );
 };

--- a/packages/addon-kit/tests/test-page-worker.js
+++ b/packages/addon-kit/tests/test-page-worker.js
@@ -328,6 +328,23 @@ tests.testMultipleDestroys = function(test) {
   test.pass("Multiple destroys should not cause an error");
 };
 
+exports.testContentScriptOptionsOption = function(test) {
+	test.waitUntilDone();
+
+  let page = new Page({
+      contentScript: "self.postMessage( [typeof self.options.d, self.options] );",
+      contentScriptWhen: "end",
+      contentScriptOptions: {a: true, b: [1,2,3], c: "string", d: function(){ return 'test'}},
+      onMessage: function(msg) {
+      	test.assertEqual( msg[0], 'undefined', 'functions are stripped from contentScriptOptions' );
+        test.assertEqual( typeof msg[1], 'object', 'object as contentScriptOptions' );
+        test.assertEqual( msg[1].a, true, 'boolean in contentScriptOptions' );
+        test.assertEqual( msg[1].b.join(), '1,2,3', 'array and numbers in contentScriptOptions' );
+        test.assertEqual( msg[1].c, 'string', 'string in contentScriptOptions' );
+        test.done();
+      }
+    });
+};
 
 function isDestroyed(page) {
   try {

--- a/packages/addon-kit/tests/test-panel.js
+++ b/packages/addon-kit/tests/test-panel.js
@@ -440,6 +440,25 @@ tests.testContentURLOption = function(test) {
                     "Panel throws an exception if contentURL is not a URL.");
 };
 
+exports.testContentScriptOptionsOption = function(test) {
+	test.waitUntilDone();
+
+  let loader = Loader(module);
+  let panel = loader.require("panel").Panel({
+      contentScript: "self.postMessage( [typeof self.options.d, self.options] );",
+      contentScriptWhen: "end",
+      contentScriptOptions: {a: true, b: [1,2,3], c: "string", d: function(){ return 'test'}},
+      onMessage: function(msg) {
+      	test.assertEqual( msg[0], 'undefined', 'functions are stripped from contentScriptOptions' );
+        test.assertEqual( typeof msg[1], 'object', 'object as contentScriptOptions' );
+        test.assertEqual( msg[1].a, true, 'boolean in contentScriptOptions' );
+        test.assertEqual( msg[1].b.join(), '1,2,3', 'array and numbers in contentScriptOptions' );
+        test.assertEqual( msg[1].c, 'string', 'string in contentScriptOptions' );
+        test.done();
+      }
+    });
+};
+
 let panelSupported = true;
 
 try {

--- a/packages/addon-kit/tests/test-widget.js
+++ b/packages/addon-kit/tests/test-widget.js
@@ -973,6 +973,28 @@ exports.testNavigationBarWidgets = function testNavigationBarWidgets(test) {
   }});
 };
 
+exports.testContentScriptOptionsOption = function(test) {
+	test.waitUntilDone();
+
+  let widget = require("widget").Widget({
+      id: "fooz",
+      label: "fooz",
+      content: "fooz",
+      contentScript: "self.postMessage( [typeof self.options.d, self.options] );",
+      contentScriptWhen: "end",
+      contentScriptOptions: {a: true, b: [1,2,3], c: "string", d: function(){ return 'test'}},
+      onMessage: function(msg) {
+      	test.assertEqual( msg[0], 'undefined', 'functions are stripped from contentScriptOptions' );
+        test.assertEqual( typeof msg[1], 'object', 'object as contentScriptOptions' );
+        test.assertEqual( msg[1].a, true, 'boolean in contentScriptOptions' );
+        test.assertEqual( msg[1].b.join(), '1,2,3', 'array and numbers in contentScriptOptions' );
+        test.assertEqual( msg[1].c, 'string', 'string in contentScriptOptions' );
+        widget.destroy();
+        test.done();
+      }
+    });
+};
+
 /******************* helpers *********************/
 
 // Helper for calling code at window close

--- a/packages/api-utils/data/worker.js
+++ b/packages/api-utils/data/worker.js
@@ -181,13 +181,13 @@ const ContentWorker = Object.freeze({
       ContentWorker.createEventEmitter(pipe.emit.bind(null, "event"));
     pipe.on("event", portEmit);
 
-    let self = Object.freeze({
+    let self = {
       port: port,
       postMessage: pipe.emit.bind(null, "message"),
       on: pipe.on.bind(null),
       once: pipe.once.bind(null),
       removeListener: pipe.removeListener.bind(null),
-    });
+    };
     Object.defineProperty(exports, "self", {
       value: self
     });
@@ -233,12 +233,23 @@ const ContentWorker = Object.freeze({
     });
   },
 
-  inject: function (exports, chromeAPI, emitToChrome) {
+  injectOptions: function (exports, options) {
+  	if ( options !== undefined ) {
+      Object.defineProperty( exports.self, "options", { value: JSON.parse( options ) }); 
+    }
+  },
+
+  inject: function (exports, chromeAPI, emitToChrome, options) {
     let { pipe, onChromeEvent, hasListenerFor } =
       ContentWorker.createPipe(emitToChrome);
+
     ContentWorker.injectConsole(exports, pipe);
     ContentWorker.injectTimers(exports, chromeAPI, pipe, exports.console);
     ContentWorker.injectMessageAPI(exports, pipe);
+    ContentWorker.injectOptions(exports, options);
+
+    Object.freeze( exports.self );
+
     return {
       emitToContent: onChromeEvent,
       hasListenerFor: hasListenerFor

--- a/packages/api-utils/docs/content/loader.md
+++ b/packages/api-utils/docs/content/loader.md
@@ -77,6 +77,14 @@ fires
 
 </api>
 
+<api name="contentScriptOptions">
+@property {object}
+Read-only value exposed to content scripts under `self.options` property.
+
+Any kind of jsonable value (object, array, string, etc.) can be used here.
+Optional.
+</api>
+
 <api name="contentURL">
 @property {string}
 The URL of the content loaded.

--- a/packages/api-utils/docs/content/symbiont.md
+++ b/packages/api-utils/docs/content/symbiont.md
@@ -82,6 +82,11 @@ constructor accepts and a few more:
     fires
 
     This property is optional and defaults to "end".
+  @prop [contentScriptOptions] {object}
+    Read-only value exposed to content scripts under `self.options` property.
+
+    Any kind of jsonable value (object, array, string, etc.) can be used here.
+    Optional.
 
   @prop [allow] {object}
     Permissions for the content, with the following keys:
@@ -121,6 +126,14 @@ images) for the page has been loaded, at the time the
 [window.onload event](https://developer.mozilla.org/en/DOM/window.onload)
 fires
 
+</api>
+
+<api name="contentScriptOptions">
+@property {object}
+Read-only value exposed to content scripts under `self.options` property.
+
+Any kind of jsonable value (object, array, string, etc.) can be used here.
+Optional.
 </api>
 
 <api name="contentURL">

--- a/packages/api-utils/lib/content/loader.js
+++ b/packages/api-utils/lib/content/loader.js
@@ -71,6 +71,15 @@ const valid = {
       return value || 'end';
     },
     msg: 'The `contentScriptWhen` option must be either "start", "ready" or "end".'
+  },
+  contentScriptOptions: {
+    ok: function(value) {
+      if ( value === undefined ) { return true; }
+      try { JSON.parse( JSON.stringify( value ) ); } catch(e) { return false; }
+      return true;
+    },
+    map: function(value) 'undefined' === getTypeOf(value) ? null : value,
+    msg: 'The contentScriptOptions should be a jsonable value.'
   }
 };
 exports.validationAttributes = valid;
@@ -143,6 +152,18 @@ const Loader = EventEmitter.compose({
     }
   },
   _contentScriptWhen: 'end',
+  /**
+   * Options avalaible from the content script as `self.options`.
+   * The value of options can be of any type (object, array, string, etc.)
+   * but only jsonable values will be available as frozen objects from the
+   * content script.
+   * Property change emits `propertyChange` event on instance with this key
+   * and new value.
+   * @type {Object}
+   */
+  get contentScriptOptions() this._contentScriptOptions,
+  set contentScriptOptions(value) this._contentScriptOptions = value,
+  _contentScriptOptions: null,
   /**
    * The URLs of content scripts.
    * Property change emits `propertyChange` event on instance with this key

--- a/packages/api-utils/lib/content/symbiont.js
+++ b/packages/api-utils/lib/content/symbiont.js
@@ -40,6 +40,8 @@ const Symbiont = Worker.resolve({
         this.contentURL = options.contentURL;
     if ('contentScriptWhen' in options)
       this.contentScriptWhen = options.contentScriptWhen;
+    if ('contentScriptOptions' in options)
+      this.contentScriptOptions = options.contentScriptOptions;
     if ('contentScriptFile' in options)
       this.contentScriptFile = options.contentScriptFile;
     if ('contentScript' in options)

--- a/packages/api-utils/lib/content/worker.js
+++ b/packages/api-utils/lib/content/worker.js
@@ -139,6 +139,11 @@ const WorkerSandbox = EventEmitter.compose({
     // avoid having any kind of wrapper.
     load(apiSanbox, CONTENT_WORKER_URL);
 
+    // prepare a clean `self.options`
+    let options = 'contentScriptOptions' in worker ?
+      JSON.stringify( worker.contentScriptOptions ) :
+      undefined;
+
     // Then call `inject` method and communicate with this script
     // by trading two methods that allow to send events to the other side:
     //   - `onEvent` called by content script
@@ -153,7 +158,7 @@ const WorkerSandbox = EventEmitter.compose({
     };
     let onEvent = this._onContentEvent.bind(this);
     // `ContentWorker` is defined in CONTENT_WORKER_URL file
-    let result = apiSanbox.ContentWorker.inject(content, chromeAPI, onEvent);
+    let result = apiSanbox.ContentWorker.inject(content, chromeAPI, onEvent, options);
     this._emitToContent = result.emitToContent;
     this._hasListenerFor = result.hasListenerFor;
 
@@ -368,6 +373,8 @@ const Worker = EventEmitter.compose({
       this._window = options.window;
     if ('contentScriptFile' in options)
       this.contentScriptFile = options.contentScriptFile;
+    if ('contentScriptOptions' in options)
+      this.contentScriptOptions = options.contentScriptOptions;
     if ('contentScript' in options)
       this.contentScript = options.contentScript;
     if ('onError' in options)


### PR DESCRIPTION
Here's a naïve tentative to fix [#688127](https://bugzilla.mozilla.org/show_bug.cgi?id=688127)

It doesn't exactly follows the API proposed in the bug because I thought it would be cleaner to create a single global var.

I didn't know how to sanitize that global object so I used `JSON.parse( JSON.stringify( state ) )`, although I'm pretty sure there's a better way to do that.

I'm willing to write unit tests but I thought I should send you the code for review beforehand.

Thank you in advance!
