### PR TITLE
Bug 718015 - Extend add-on bar's text style to widgets

### DIFF
--- a/packages/addon-kit/lib/widget.js
+++ b/packages/addon-kit/lib/widget.js
@@ -815,7 +815,6 @@ WidgetChrome._isImageDoc = function WC__isImageDoc(doc) {
 WidgetChrome.prototype.addEventHandlers = function WC_addEventHandlers() {
   let contentType = this.getContentType();
 
-  let container = this._doc.getElementById("addon-bar");
   let self = this;
   let listener = function(e) {
     // Ignore event firings that target the iframe.
@@ -845,7 +844,7 @@ WidgetChrome.prototype.addEventHandlers = function WC_addEventHandlers() {
   // On document load, make modifications required for nice default
   // presentation.
   function loadListener(e) {
-    let containerStyle = self.window.getComputedStyle(container);
+    let containerStyle = self.window.getComputedStyle(self.node.parentNode);
     // Ignore event firings that target the iframe
     if (e.target == iframe)
       return;


### PR DESCRIPTION
Currently does not take effect when the persona is changed, but on the next load. I couldn't find an event that works best with persona changes and did not want to create overhead with mutation events.
