### PR TITLE
Fennec update version

### DIFF
--- a/python-lib/cuddlefish/rdf.py
+++ b/python-lib/cuddlefish/rdf.py
@@ -164,7 +164,7 @@ def gen_manifest(template_root_dir, target_cfg, jid,
         ta_desc.appendChild(elem)
 
         elem = dom.createElement("em:maxVersion")
-        elem.appendChild(dom.createTextNode("11.0a1"))
+        elem.appendChild(dom.createTextNode("13.0a1"))
         ta_desc.appendChild(elem)
 
     if target_cfg.get("homepage"):


### PR DESCRIPTION
Even with "compatibility" turned on by default, it's preferable keep up to date the max-version of Fennec. I already faced a couple of regressions (in Fennec application).
