### PR TITLE
Bug 696552: Implements panel.contentURL modification support.

### DIFF
--- a/packages/addon-kit/lib/panel.js
+++ b/packages/addon-kit/lib/panel.js
@@ -66,6 +66,7 @@ const Panel = Symbiont.resolve({
     this._onShow = this._onShow.bind(this);
     this._onHide = this._onHide.bind(this);
     this.on('inited', this._onSymbiontInit.bind(this));
+    this.on('propertyChange', this._onChange.bind(this));
 
     options = options || {};
     if ('onShow' in options)
@@ -84,6 +85,9 @@ const Panel = Symbiont.resolve({
   _destructor: function _destructor() {
     this.hide();
     this._removeAllListeners('show');
+    this._removeAllListeners('hide');
+    this._removeAllListeners('propertyChange');
+    this._removeAllListeners('inited');
     // defer cleanup to be performed after panel gets hidden
     this._xulPanel = null;
     this._symbiontDestructor(this);
@@ -325,6 +329,15 @@ const Panel = Symbiont.resolve({
       return true;
     }
     return false;
+  },
+
+  _onChange: function _onChange(e) {
+    if ('contentURL' in e && this._frame) {
+      // Cleanup the worker before injecting the content script in the new
+      // document
+      this._workerCleanup();
+      this._initFrame(this._frame);
+    }
   }
 });
 exports.Panel = function(options) Panel(options)

--- a/packages/addon-kit/tests/test-panel.js
+++ b/packages/addon-kit/tests/test-panel.js
@@ -327,6 +327,31 @@ tests.testPanelTextColor = function(test) {
   });
 };
 
+// Bug 696552: Ensure panel.contentURL modification support
+tests.testChangeContentURL = function(test) {
+  test.waitUntilDone();
+
+  let panel = Panel({
+    contentURL: "about:blank",
+    contentScript: "self.port.emit('ready', document.location.href);"
+  });
+  let count = 0;
+  panel.port.on("ready", function (location) {
+    count++;
+    if (count == 1) {
+      test.assertEqual(location, "about:blank");
+      test.assertEqual(panel.contentURL, "about:blank");
+      panel.contentURL = "about:buildconfig";
+    }
+    else {
+      test.assertEqual(location, "about:buildconfig");
+      test.assertEqual(panel.contentURL, "about:buildconfig");
+      panel.destroy();
+      test.done();
+    }
+  });
+};
+
 function makeEventOrderTest(options) {
   let expectedEvents = [];
 


### PR DESCRIPTION
I took patch from https://bugzilla.mozilla.org/show_bug.cgi?id=696552
and put it as PR into to merge it.

I've only adressed review comment by moving the listener registration before init call.
There wasn't particular reason in registering `this.on('propertyChange', this._onChange.bind(this));` after  `_init`. Sometimes these `init/contructor` methods fail and throw exception. I just tried to avoid registering such listener before init, in order to avoid registering it in case of error.
But I went through code, and I haven't seen any case where we throw an exception in this particular case.
