### PR TITLE
Bug 734131: Fix failing test test-httpd.testBasicHTTPServer.

### DIFF
--- a/packages/api-utils/tests/test-content-proxy.js
+++ b/packages/api-utils/tests/test-content-proxy.js
@@ -759,13 +759,13 @@ exports.testTypedArrays = createProxyTest("", function (helper) {
 
 // Bug 715755: proxy code throw an exception on COW
 // Create an http server in order to simulate real cross domain documents
-let serverPort = 8099;
-let server = require("httpd").startServerAsync(serverPort);
-server.registerPathHandler("/", function handle(request, response) {
-  // Returns an empty webpage
-  response.write("");
-});
 exports.testCrossDomainIframe = createProxyTest("", function (helper) {
+  let serverPort = 8099;
+  let server = require("httpd").startServerAsync(serverPort);
+  server.registerPathHandler("/", function handle(request, response) {
+    // Returns an empty webpage
+    response.write("");
+  });
 
   let worker = helper.createWorker(
     'new ' + function ContentScriptScope() {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=734131
