### PR TITLE
Bug 730641 - Increment timer to use bigger number then accuracy implemented across diff platforms

### DIFF
--- a/packages/api-utils/tests/test-functional.js
+++ b/packages/api-utils/tests/test-functional.js
@@ -137,7 +137,7 @@ exports['test delay'] = function(assert, done) {
   delay(function() {
     assert.ok(Date.now() - start, 'delayed the function');
     done();
-  }, 1);
+  }, 50);
 };
 
 exports['test delay with this'] = function(assert, done) {


### PR DESCRIPTION
For details see bug 730507
