### PR TITLE
Bug 734858: accept non-ASCII in package.json preferences field

### DIFF
--- a/python-lib/cuddlefish/options_defaults.py
+++ b/python-lib/cuddlefish/options_defaults.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 def parse_options_defaults(options, jetpack_id):
+    # this returns a unicode string
     pref_list = []
 
     for pref in options:
@@ -10,14 +11,14 @@ def parse_options_defaults(options, jetpack_id):
             value = pref["value"]
             vtype = str(type(value))
 
-            if ("<type 'float'>" == vtype):
+            if isinstance(value, float):
                 continue
-            elif ("<type 'bool'>" == vtype):
+            elif isinstance(value, bool):
                 value = str(pref["value"]).lower()
-            elif ("<type 'str'>" == vtype):
-                value = "\"" + str(pref["value"]) + "\""
-            elif ("<type 'unicode'>" == vtype):
-                value = "\"" + str(pref["value"]) + "\""
+            elif isinstance(value, str): # presumably ASCII
+                value = "\"" + unicode(pref["value"]) + "\""
+            elif isinstance(value, unicode):
+                value = "\"" + pref["value"] + "\""
             else:
                 value = str(pref["value"])
 

--- a/python-lib/cuddlefish/tests/preferences-files/packages/simple-prefs/package.json
+++ b/python-lib/cuddlefish/tests/preferences-files/packages/simple-prefs/package.json
@@ -4,8 +4,15 @@
     "author": "Erik Vold",
     "preferences": [{
         "name": "test",
-        "type": "bool", 
-        "title": "test"
+        "type": "bool",
+        "title": "tëst",
+        "value": false
+    },
+    {
+        "name": "test2",
+        "type": "string",
+        "title": "tëst",
+        "value": "ünicødé"
     }],
     "loader": "lib/main.js"
 }

--- a/python-lib/cuddlefish/tests/test_xpi.py
+++ b/python-lib/cuddlefish/tests/test_xpi.py
@@ -39,19 +39,26 @@ class PrefsTests(unittest.TestCase):
     def testPackageWithSimplePrefs(self):
         self.makexpi('simple-prefs')
         self.failUnless('options.xul' in self.xpi.namelist())
-        prefs = self.xpi.read('options.xul')
+        optsxul = self.xpi.read('options.xul').decode("utf-8")
         self.failUnless('pref="extensions.jid1-fZHqN9JfrDBa8A@jetpack.test"'
-                        in prefs, prefs)
-        self.failUnless('type="bool"' in prefs, prefs)
-        self.failUnless('title="test"' in prefs, prefs)
+                        in optsxul, optsxul)
+        self.failUnless('type="bool"' in optsxul, optsxul)
+        self.failUnless(u'title="t\u00EBst"' in optsxul, repr(optsxul))
         self.failUnlessEqual(self.xpi_harness_options["jetpackID"],
                              "jid1-fZHqN9JfrDBa8A@jetpack")
+        prefsjs = self.xpi.read('defaults/preferences/prefs.js').decode("utf-8")
+        exp = [u'pref("extensions.jid1-fZHqN9JfrDBa8A@jetpack.test", false);',
+               u'pref("extensions.jid1-fZHqN9JfrDBa8A@jetpack.test2", "\u00FCnic\u00F8d\u00E9");',
+               ]
+        self.failUnlessEqual(prefsjs, "\n".join(exp)+"\n")
 
     def testPackageWithNoPrefs(self):
         self.makexpi('no-prefs')
         self.failIf('options.xul' in self.xpi.namelist())
         self.failUnlessEqual(self.xpi_harness_options["jetpackID"],
                              "jid1-fZHqN9JfrDBa8A@jetpack")
+        prefsjs = self.xpi.read('defaults/preferences/prefs.js').decode("utf-8")
+        self.failUnlessEqual(prefsjs, "")
 
 
 class Bug588119Tests(unittest.TestCase):

--- a/python-lib/cuddlefish/xpi.py
+++ b/python-lib/cuddlefish/xpi.py
@@ -42,15 +42,19 @@ def build_xpi(template_root_dir, manifest, xpi_path,
 
         validate_prefs(harness_options["preferences"])
 
-        open('.options.xul', 'w').write(parse_options(harness_options["preferences"], harness_options["jetpackID"]))
+        opts_xul = parse_options(harness_options["preferences"],
+                                 harness_options["jetpackID"])
+        open('.options.xul', 'wb').write(opts_xul.encode("utf-8"))
         zf.write('.options.xul', 'options.xul')
         os.remove('.options.xul')
 
         from options_defaults import parse_options_defaults
-        open('.prefs.js', 'w').write(parse_options_defaults(harness_options["preferences"], harness_options["jetpackID"]))
+        prefs_js = parse_options_defaults(harness_options["preferences"],
+                                          harness_options["jetpackID"])
+        open('.prefs.js', 'wb').write(prefs_js.encode("utf-8"))
 
     else:
-        open('.prefs.js', 'w').write("")
+        open('.prefs.js', 'wb').write("")
 
     zf.write('.prefs.js', 'defaults/preferences/prefs.js')
     os.remove('.prefs.js')


### PR DESCRIPTION
This should clean up the unicode handling in prefs

@ochameau, could you review?
