### PR TITLE
Fixed link to 3rd party modules

### DIFF
--- a/doc/dev-guide-source/tutorials/adding-menus.md
+++ b/doc/dev-guide-source/tutorials/adding-menus.md
@@ -110,8 +110,8 @@ be aware of:
 
 * our support for third party packages is still fairly immature. One
 consequence of this is that it's not always obvious where to find third-party
-packages, although some are collected in the
-[Jetpack Wiki](https://wiki.mozilla.org/Jetpack/Modules)
+packages, although some are collected in a github wiki page
+[Community Developed Modules](https://github.com/mozilla/addon-sdk/wiki/Community-developed-modules)
 
 * because third party modules typically use low-level APIs, they may be broken
 by new releases of Firefox.


### PR DESCRIPTION
This file has a link to the old wiki page. We moved this to a github wiki - updated the text and link
