### PR TITLE
Remove iconURL/icon64URL from install.rdf template

### DIFF
--- a/python-lib/cuddlefish/app-extension/install.rdf
+++ b/python-lib/cuddlefish/app-extension/install.rdf
@@ -26,8 +26,6 @@
     <em:name>Test App</em:name>
     <em:description>Harness for tests.</em:description>
     <em:creator>Mozilla Corporation</em:creator>
-    <em:iconURL></em:iconURL>
-    <em:icon64URL></em:icon64URL>
     <em:homepageURL></em:homepageURL>
     <em:optionsType></em:optionsType>
     <em:updateURL></em:updateURL>


### PR DESCRIPTION
iconURL/iconURL64 are never set to a value. cuddlefish will package any
icons using the default location (/icon.png, ...)

This is actually something a lot of AMO editors used to nag authors about (when it was unclear that the markup was entirely generated).
