### PR TITLE
Bug 739957 - More than 2 lines strings in .properties files are broken.

### DIFF
--- a/python-lib/cuddlefish/packaging.py
+++ b/python-lib/cuddlefish/packaging.py
@@ -323,8 +323,12 @@ def generate_build_for_target(pkg_cfg, target, deps,
             if os.path.isfile(fullpath) and filename.endswith('.properties'):
                 language = filename[:-len('.properties')]
 
-                from property_parser import parse_file
-                content = parse_file(fullpath)
+                from property_parser import parse_file, MalformedLocaleFileError
+                try:
+                    content = parse_file(fullpath)
+                except MalformedLocaleFileError, msg:
+                    print msg[0]
+                    sys.exit(1)
 
                 # Merge current locales into global locale hashtable.
                 # Locale files only contains one big JSON object

--- a/python-lib/cuddlefish/tests/test_property_parser.py
+++ b/python-lib/cuddlefish/tests/test_property_parser.py
@@ -9,12 +9,18 @@ from cuddlefish.property_parser import parse, MalformedLocaleFileError
 class TestParser(unittest.TestCase):
 
     def test_parse(self):
-        pairs = parse([
+        lines = [
           # Comments are striped only if `#` is the first non-space character
           "sharp=#can be in value",
           "# comment",
           "#key=value",
           "  # comment2",
+
+          "keyWithNoValue=",
+          "valueWithSpaces=   ",
+          "valueWithMultilineSpaces=  \\",
+          "  \\",
+          "  ",
 
           # All spaces before/after are striped
           " key = value ",
@@ -29,16 +35,23 @@ class TestParser(unittest.TestCase):
           # Multiline string must use backslash at end of lines
           "multi=line\\", "value",
           # With multiline string, left spaces are stripped ...
-          "some= spaces\\", " are\\", " stripped ",
+          "some= spaces\\", " are\\  ", " stripped ",
           # ... but not right spaces, except the last line!
           "but=not \\", "all of \\", " them "
-        ])
+        ]
+        # Ensure that lines end with a `\n`
+        lines = [l + "\n" for l in lines]
+        pairs = parse(lines)
         expected = {
           "sharp": "#can be in value",
 
           "key": "value",
           "key2": "value2",
           "%s key": "%s value",
+
+          "keyWithNoValue": "",
+          "valueWithSpaces": "",
+          "valueWithMultilineSpaces": "",
 
           "multi": "linevalue",
           "some": "spacesarestripped",
@@ -51,6 +64,12 @@ class TestParser(unittest.TestCase):
                               ["invalid line with no key value"])
         self.failUnlessRaises(MalformedLocaleFileError, parse,
                               ["plural[one]=plural with no generic value"])
+        self.failUnlessRaises(MalformedLocaleFileError, parse,
+                              ["multiline with no last empty line=\\"])
+        self.failUnlessRaises(MalformedLocaleFileError, parse,
+                              ["=no key"])
+        self.failUnlessRaises(MalformedLocaleFileError, parse,
+                              ["   =only spaces in key"])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
There is a small error in properties files parser.
The code throws exception when a valid multiline string is longer than 2 lines.
At the same time I improved error logging in packaging.py in order to print a comprehensible error message.

https://bugzilla.mozilla.org/show_bug.cgi?id=739957
