### PR TITLE
Bug 741101 – Makes `contentStyle*` consistent with `contentScript*` about include match pattern

### DIFF
--- a/packages/addon-kit/lib/page-mod.js
+++ b/packages/addon-kit/lib/page-mod.js
@@ -243,15 +243,15 @@ const PageMod = Loader.compose(EventEmitter, {
         continue;
 
       if (pattern.regexp)
-        documentRules.push("regexp(\"" + pattern.regexp.source + "\")")
+        documentRules.push("regexp(\"" + pattern.regexp.source + "\")");
       else if (pattern.exactURL)
-        documentRules.push("url(" + pattern.exactURL + ")")
+        documentRules.push("url(" + pattern.exactURL + ")");
       else if (pattern.domain)
-        documentRules.push("domain(" + pattern.domain + ")")
+        documentRules.push("domain(" + pattern.domain + ")");
       else if (pattern.urlPrefix)
-        documentRules.push("url-prefix(" + pattern.urlPrefix + ")")
+        documentRules.push("url-prefix(" + pattern.urlPrefix + ")");
       else if (pattern.anyWebPage) {
-        documentRules.length = 0;
+        documentRules.push("regexp(\"^(https?|ftp)://.*?\")");
         break;
       }
     }


### PR DESCRIPTION
As described in my previous comment on bugzilla, that's actually don't solve the problem, but limit it, and makes the behavior consistent across `contentStyle*` and `contentScript*`.
