### PR TITLE
test-page-mod.js:testCommunication2 fails without internet connection.

### DIFF
--- a/packages/addon-kit/tests/test-page-mod.js
+++ b/packages/addon-kit/tests/test-page-mod.js
@@ -180,7 +180,7 @@ exports.testCommunication2 = function(test) {
   let callbackDone = null,
       window;
 
-  testPageMod(test, "about:credits", [{
+  testPageMod(test, "about:license", [{
       include: "about:*",
       contentScriptWhen: 'start',
       contentScript: 'new ' + function WorkerScope() {


### PR DESCRIPTION
`about:credits` redirects to `http://mozilla.org/credits` and fails to load.
Use `about:license` instead (low priviledge page that doesn't redirect to some webpage).
