### PR TITLE
Fix addon-page unit test which leave an opened tab.

### DIFF
--- a/packages/addon-kit/lib/addon-page.js
+++ b/packages/addon-kit/lib/addon-page.js
@@ -6,7 +6,7 @@
 
 const { WindowTracker, isBrowser } = require('api-utils/window-utils');
 const { add, remove } = require('api-utils/array');
-const { getTabs, closeTab } = require('api-utils/tabs/utils');
+const { getTabs, closeTab, getURI } = require('api-utils/tabs/utils');
 const { data } = require('self');
 
 const addonURL = data.url('index.html');
@@ -18,7 +18,7 @@ WindowTracker({
   },
   onUntrack: function onUntrack(window) {
     getTabs(window).
-      filter(function(tab) tab.linkedBrowser.currentURI.spec === addonURL).
+      filter(function(tab) { return getURI(tab) === addonURL; }).
       forEach(function(tab) {
         // Note: `onUntrack` will be called for all windows on add-on unloads,
         // so we want to clean them up from these URLs.

--- a/packages/api-utils/lib/tabs/utils.js
+++ b/packages/api-utils/lib/tabs/utils.js
@@ -57,3 +57,8 @@ function activateTab(tab) {
   getOwnerWindow(tab).gBrowser.selectedTab = tab;
 }
 exports.activateTab = activateTab;
+
+function getURI(tab) {
+  return tab.linkedBrowser.currentURI.spec;
+}
+exports.getURI = getURI;


### PR DESCRIPTION
This test had a wrong assertion and wasn't waiting for addon page document to be loaded.
