### PR TITLE
Make console API work in addon/runner module and all its dependencies.

### DIFF
--- a/packages/api-utils/lib/addon/runner.js
+++ b/packages/api-utils/lib/addon/runner.js
@@ -62,6 +62,10 @@ function startup(reason, options) {
   if (reason === 'startup')
     return wait(reason, options);
 
+  // Inject globals ASAP in order to have console API working ASAP
+  let loader = options.loader;
+  override(loader.globals, globals);
+
   // Try initializing localization module before running main module. Just print
   // an exception in case of error, instead of preventing addon to be run.
   try {
@@ -78,8 +82,6 @@ function startup(reason, options) {
     // Always set the default prefs, because they disappear on restart
     setDefaultPrefs();
 
-    let loader = options.loader;
-    override(loader.globals, globals);
     // this is where the addon's main.js finally run.
     let program = load(loader, loader.main).exports;
 


### PR DESCRIPTION
Currently, all calls to console.\* are failing in addon/runner module and any of its dependency.
Here is a way to make these call work and being able to see some exception/error messages again.
