### PR TITLE
Bug 748988: Fix some unnecessary warnings in console

### DIFF
--- a/packages/api-utils/lib/cuddlefish.js
+++ b/packages/api-utils/lib/cuddlefish.js
@@ -191,7 +191,7 @@ const Require = iced(function Require(loader, module) {
   let { prefixURI, modules } = loader;
   let base = module.path;                 // base module path.
   let manifest = loader.manifest[base];   // manifest of base module.
-  let requirer = modules[base];           // same module, but from loader cache.
+  let requirer = base in modules ? modules[base] : null; // same module, but from loader cache.
   return iced(override(function require(id) {
     if (!id)
       throw Error("you must provide a module name when calling require() from "

--- a/packages/api-utils/lib/xpcom.js
+++ b/packages/api-utils/lib/xpcom.js
@@ -16,7 +16,7 @@ const { uuid } = require('./uuid');
 // components can be easily implement by extending it.
 const Unknown = new function() {
   function hasInterface(component, iid) {
-    return component &&
+    return component && component.interfaces &&
       ( component.interfaces.some(function(id) iid.equals(Ci[id])) ||
         component.implements.some(function($) hasInterface($, iid)) ||
         hasInterface(Object.getPrototypeOf(component), iid));


### PR DESCRIPTION
In both case the code is sometimes using properties that don't exist.
