### PR TITLE
Bug 749749: Fix "test-content-worker.test:setTimeout are unregistered on content unload".

### DIFF
--- a/packages/api-utils/lib/content/worker.js
+++ b/packages/api-utils/lib/content/worker.js
@@ -113,7 +113,7 @@ const WorkerSandbox = EventEmitter.compose({
     let apiSanbox = sandbox(window, { wantXrays: true });
 
     // Build content proxies only if the document has a non-system principal
-    if (window.wrappedJSObject) {
+    if (XPCNativeWrapper.unwrap(window) !== window) {
       apiSanbox.console = console;
       // Execute the proxy code
       load(apiSanbox, CONTENT_PROXY_URL);


### PR DESCRIPTION
bug 695480 now prevents using unloaded content document references,
but we still can use outer window reference until it is finally closed.
- Some priviledged document now have `wrappedJSObject`, so instead of checking `node.wrappedJSObject`, we have to check for `XPCNativeWrapper.unwrap(node) !== node`.
- test-content-worker is opening a new top-level window on each test, we forgot to close them.

https://bugzilla.mozilla.org/show_bug.cgi?id=749749
