### PR TITLE
Bug 751546: Fix "dead object" exception in api-utils/tab/observer.

### DIFF
--- a/packages/api-utils/lib/tabs/observer.js
+++ b/packages/api-utils/lib/tabs/observer.js
@@ -71,6 +71,12 @@ windowObserver.on("open", onWindowOpen);
 
 function onWindowClose(chromeWindow) {
   if (!isBrowser(chromeWindow)) return; // Ignore if it's not a browser window.
+  // Bug 751546: Emit `deactivate` event on window close immediatly
+  // Otherwise we are going to face "dead object" exception on `select` event
+  if (getActiveTab(chromeWindow) == selectedTab) {
+    observer._emit("deactivate", selectedTab);
+    selectedTab = null;
+  }
   getTabContainers(chromeWindow).forEach(function (container) {
     observer.ignore(container);
   });


### PR DESCRIPTION
`deactivate` was fired too lately.

https://bugzilla.mozilla.org/show_bug.cgi?id=751546
