### PR TITLE
Bug 753621: Remove explicit test of "dead object" exception

### DIFF
--- a/packages/api-utils/tests/test-content-worker.js
+++ b/packages/api-utils/tests/test-content-worker.js
@@ -469,14 +469,6 @@ exports['test:setTimeout are unregistered on content unload'] = function(test) {
                            "Nor previous one");
 
           window.close();
-          // Ensure that the document is released after outer window close
-          if (xulApp.versionInRange(xulApp.platformVersion, "15.0a1", "*")) {
-            test.assertRaises(function () {
-              // `originalWindow` will be destroyed only when the outer window
-              // is going to be released. See bug 695480
-              originalWindow.document.title;
-            }, "can't access dead object");
-          }
           test.done();
         }, 100);
       }, true);


### PR DESCRIPTION
It is now harder to test and have a better behavior thanks to bug 752877.

https://bugzilla.mozilla.org/show_bug.cgi?id=753621
