### PR TITLE
Bug 752631: Process only fully loaded window in api-utils/window-utils iterators.

### DIFF
--- a/packages/api-utils/docs/window-utils.md
+++ b/packages/api-utils/docs/window-utils.md
@@ -70,7 +70,8 @@ uninstalled, whichever comes first.)
 
 <api name="windowIterator">
 @function
-  An iterator for windows currently open in the application.
+  An iterator for windows currently open in the application. Only windows whose
+  document is already loaded will be dispatched.
 
 **Example**
 

--- a/packages/api-utils/lib/window/utils.js
+++ b/packages/api-utils/lib/window/utils.js
@@ -108,3 +108,29 @@ function open(uri, options) {
                null);
 }
 exports.open = open;
+
+/**
+ * Returns an array of all currently opened windows.
+ * Note that these windows may still be loading.
+ */
+function windows() {
+  let list = [];
+  let winEnum = windowWatcher.getWindowEnumerator();
+  while (winEnum.hasMoreElements()) {
+    let window = winEnum.getNext().QueryInterface(Ci.nsIDOMWindow);
+    list.push(window);
+  }
+  return list;
+}
+exports.windows = windows;
+
+/**
+ * Check if the given window is completely loaded.
+ * i.e. if its "load" event has already been fired and all possible DOM content
+ * is done loading (the whole DOM document, images content, ...)
+ * @params {nsIDOMWindow} window
+ */
+function isDocumentLoaded(window) {
+  return window.document.readyState == "complete";
+}
+exports.isDocumentLoaded = isDocumentLoaded;

--- a/packages/api-utils/tests/test-window-utils2.js
+++ b/packages/api-utils/tests/test-window-utils2.js
@@ -5,16 +5,9 @@
 'use strict';
 
 const { Ci } = require('chrome');
-const { open, backgroundify,
+const { open, backgroundify, windows,
         getXULWindow, getBaseWindow } = require('api-utils/window/utils');
 const windowUtils = require('api-utils/window-utils');
-
-function windows(iterator) {
-  let array = [];
-  for each (let item in windowUtils.windowIterator())
-    array.push(item);
-  return array;
-}
 
 exports['test get nsIBaseWindow from nsIDomWindow'] = function(assert) {
   let active = windowUtils.activeBrowserWindow;


### PR DESCRIPTION
We need to avoid touching DOM while document is in "uninitialized" state.
This seems to break many stuff as described in bugzilla.

I suggest here to add an option to window iterators in window-utils and make it default to process only fully loaded windows.
https://bugzilla.mozilla.org/show_bug.cgi?id=752631
