### PR TITLE
Factorize uses of `isBrowser` method from api-utils/window-utils`.

### DIFF
--- a/packages/addon-kit/lib/addon-page.js
+++ b/packages/addon-kit/lib/addon-page.js
@@ -4,7 +4,8 @@
 
 'use strict';
 
-const { WindowTracker, isBrowser } = require('api-utils/window-utils');
+const { WindowTracker } = require('api-utils/window-utils');
+const { isBrowser } = require('api-utils/window/utils');
 const { add, remove } = require('api-utils/array');
 const { getTabs, closeTab, getURI } = require('api-utils/tabs/utils');
 const { data } = require('self');

--- a/packages/addon-kit/lib/context-menu.js
+++ b/packages/addon-kit/lib/context-menu.js
@@ -24,8 +24,8 @@ const { MatchPattern } = require("api-utils/match-pattern");
 const { EventEmitterTrait: EventEmitter } = require("api-utils/events");
 const observerServ = require("api-utils/observer-service");
 const jpSelf = require("self");
-const winUtils = require("api-utils/window-utils");
-const { getInnerId } = require("api-utils/window/utils");
+const { WindowTracker } = require("api-utils/window-utils");
+const { getInnerId, isBrowser } = require("api-utils/window/utils");
 const { Trait } = require("api-utils/light-traits");
 const { Cortex } = require("api-utils/cortex");
 const timer = require("timers");
@@ -839,7 +839,7 @@ let browserManager = {
   // for each currently open browser window.
   init: function BM_init() {
     require("api-utils/unload").ensure(this);
-    let windowTracker = winUtils.WindowTracker(this);
+    let windowTracker = WindowTracker(this);
 
     // Register content windows on content-document-global-created and
     // unregister them on inner-window-destroyed.  For rationale, see bug 667957
@@ -914,7 +914,7 @@ let browserManager = {
   // chrome window, and for each chrome window that is open when the loader
   // loads this module.
   onTrack: function BM_onTrack(window) {
-    if (!this._isBrowserWindow(window))
+    if (!isBrowser(window))
       return;
 
     let browserWin = new BrowserWindow(window);
@@ -955,7 +955,7 @@ let browserManager = {
   // chrome window, and for each chrome window that is open when this module is
   // unloaded.
   onUntrack: function BM_onUntrack(window) {
-    if (!this._isBrowserWindow(window))
+    if (!isBrowser(window))
       return;
 
     // Remove the window from the window list.
@@ -970,11 +970,6 @@ let browserManager = {
     // Remove all top-level items from the window.
     this.topLevelItems.forEach(function (i) browserWin.removeTopLevelItem(i));
     browserWin.destroy();
-  },
-
-  _isBrowserWindow: function BM__isBrowserWindow(win) {
-    let winType = win.document.documentElement.getAttribute("windowtype");
-    return winType === "navigator:browser";
   }
 };
 

--- a/packages/addon-kit/lib/widget.js
+++ b/packages/addon-kit/lib/widget.js
@@ -42,6 +42,8 @@ const LightTrait = require('api-utils/light-traits').Trait;
 const { Loader, Symbiont } = require("api-utils/content");
 const { Cortex } = require('api-utils/cortex');
 const windowsAPI = require("./windows");
+const { WindowTracker } = require("api-utils/window-utils");
+const { isBrowser } = require("api-utils/window/utils");
 const { setTimeout } = require("api-utils/timer");
 const unload = require("api-utils/unload");
 const { uuid } = require("api-utils/uuid");
@@ -487,13 +489,13 @@ let browserManager = {
   // that calling this method can cause onTrack to be called immediately if
   // there are open windows.
   init: function () {
-    let windowTracker = new (require("api-utils/window-utils").WindowTracker)(this);
+    let windowTracker = new WindowTracker(this);
     unload.ensure(windowTracker);
   },
 
   // Registers a window with the manager.  This is a WindowTracker callback.
   onTrack: function browserManager_onTrack(window) {
-    if (this._isBrowserWindow(window)) {
+    if (isBrowser(window)) {
       let win = new BrowserWindow(window);
       win.addItems(this.items);
       this.windows.push(win);
@@ -507,7 +509,7 @@ let browserManager = {
   // unload itself, since unloading the browserManager means untracking all
   // currently opened windows.
   onUntrack: function browserManager_onUntrack(window) {
-    if (this._isBrowserWindow(window)) {
+    if (isBrowser(window)) {
       this.items.forEach(function(i) i._onWindowClosed(window));
       for (let i = 0; i < this.windows.length; i++) {
         if (this.windows[i].window == window) {
@@ -547,11 +549,6 @@ let browserManager = {
     let idx = this.items.indexOf(item);
     if (idx > -1)
       this.items.splice(idx, 1);
-  },
-
-  _isBrowserWindow: function browserManager__isBrowserWindow(win) {
-    let winType = win.document.documentElement.getAttribute("windowtype");
-    return winType === "navigator:browser";
   }
 };
 

--- a/packages/addon-kit/lib/windows.js
+++ b/packages/addon-kit/lib/windows.js
@@ -18,11 +18,12 @@ const { Cc, Ci } = require('chrome'),
       { WindowTabs, WindowTabTracker } = require('api-utils/windows/tabs'),
       { WindowDom } = require('api-utils/windows/dom'),
       { WindowLoader } = require('api-utils/windows/loader'),
+      { isBrowser } = require('api-utils/window/utils'),
       { Options } = require('api-utils/tabs/tab'),
       apiUtils = require('api-utils/api-utils'),
       unload = require('api-utils/unload'),
       windowUtils = require('api-utils/window-utils'),
-      { WindowTrackerTrait, isBrowser } = windowUtils,
+      { WindowTrackerTrait } = windowUtils,
       { ns } = require('api-utils/namespace'),
       { observer: windowObserver } = require("api-utils/windows/observer");
 
@@ -210,6 +211,7 @@ const browserWindows = Trait.resolve({ toString: null }).compose(
         options = { tabs: [Options(options)] };
       return BrowserWindow(options);
     },
+
      /**
       * Internal listener which is called whenever new window gets open.
       * Creates wrapper and adds to this list.

--- a/packages/api-utils/docs/window/utils.md
+++ b/packages/api-utils/docs/window/utils.md
@@ -88,3 +88,8 @@ is possible you should make sure to close all such windows manually:
     let bgwin = backgroundify(open('data:text/html,Foo'), {
       close: false
     });
+
+### isBrowser
+
+Returns true if the given window is a Firefox browser window.
+(i.e windows with chrome://browser/content/browser.xul document)

--- a/packages/api-utils/lib/keyboard/observer.js
+++ b/packages/api-utils/lib/keyboard/observer.js
@@ -8,7 +8,8 @@
 const { Trait } = require("../light-traits");
 const { EventEmitterTrait: EventEmitter } = require("../events");
 const { DOMEventAssembler } = require("../events/assembler");
-const { browserWindowIterator, isBrowser } = require('../window-utils');
+const { browserWindowIterator } = require('../window-utils');
+const { isBrowser } = require('../window/utils');
 const { observer: windowObserver } = require("../windows/observer");
 
 // Event emitter objects used to register listeners and emit events on them

--- a/packages/api-utils/lib/tabs/observer.js
+++ b/packages/api-utils/lib/tabs/observer.js
@@ -9,7 +9,8 @@ const { EventEmitterTrait: EventEmitter } = require("../events");
 const { DOMEventAssembler } = require("../events/assembler");
 const { Trait } = require("../light-traits");
 const { getActiveTab, getTabs, getTabContainers } = require("./utils");
-const { browserWindowIterator, isBrowser } = require("../window-utils");
+const { browserWindowIterator } = require("../window-utils");
+const { isBrowser } = require('../window/utils');
 const { observer: windowObserver } = require("../windows/observer");
 
 const EVENTS = {

--- a/packages/api-utils/lib/window-utils.js
+++ b/packages/api-utils/lib/window-utils.js
@@ -8,7 +8,8 @@ const { Cc, Ci } = require("chrome");
 const { EventEmitter } = require('./events');
 const { Trait } = require('./traits');
 const { when } = require('./unload');
-const { getInnerId, getOuterId, windows, isDocumentLoaded } = require('./window/utils');
+const { getInnerId, getOuterId, windows, isDocumentLoaded, isBrowser } =
+  require('./window/utils');
 const errors = require("./errors");
 
 const windowWatcher = Cc["@mozilla.org/embedcomp/window-watcher;1"].
@@ -188,11 +189,11 @@ exports.getOuterId = function(window) {
   return getOuterId(window);
 };
 
-function isBrowser(window) {
-  return window.document.documentElement.getAttribute("windowtype") ===
-         "navigator:browser";
+exports.isBrowser = function(window) {
+  console.warn('require("window-utils").isBrowser is deprecated, ' +
+               'please use require("window/utils").isBrowser instead');
+  return isBrowser(window);
 };
-exports.isBrowser = isBrowser;
 
 exports.hiddenWindow = appShellService.hiddenDOMWindow;
 

--- a/packages/api-utils/lib/window/utils.js
+++ b/packages/api-utils/lib/window/utils.js
@@ -134,3 +134,9 @@ function isDocumentLoaded(window) {
   return window.document.readyState == "complete";
 }
 exports.isDocumentLoaded = isDocumentLoaded;
+
+function isBrowser(window) {
+  return window.document.documentElement.getAttribute("windowtype") ===
+         "navigator:browser";
+};
+exports.isBrowser = isBrowser;

--- a/packages/api-utils/tests/test-window-observer.js
+++ b/packages/api-utils/tests/test-window-observer.js
@@ -12,7 +12,8 @@ exports["test unload window observer"] = function(assert, done) {
   let loader = Loader(module);
 
   let utils = loader.require("api-utils/window-utils");
-  let { isBrowser, activeBrowserWindow: activeWindow } = utils;
+  let { activeBrowserWindow: activeWindow } = utils;
+  let { isBrowser } = require('api-utils/window/utils');
   let observer = loader.require("api-utils/windows/observer").observer;
   let opened = 0;
   let closed = 0;


### PR DESCRIPTION
While working on https://bugzilla.mozilla.org/show_bug.cgi?id=752631 PR #436, I've noticed that isBrowser method is implemented in many modules.
Here is a patch to use only window-utils.isBrowser implementation.
