### PR TITLE
Avoid strict warnings when a test is failing.

### DIFF
--- a/packages/api-utils/lib/unit-test.js
+++ b/packages/api-utils/lib/unit-test.js
@@ -43,6 +43,8 @@ TestRunner.prototype = {
   PAUSE_DELAY: 500,
 
   _logTestFailed: function _logTestFailed(why) {
+    if (!(why in this.test.errors))
+      this.test.errors[why] = 0;
     this.test.errors[why]++;
     if (!this.testFailureLogged) {
       this.console.error("TEST FAILED: " + this.test.name + " (" + why + ")");


### PR DESCRIPTION
We are currently getting many such warnings when a test is failing:
console: [JavaScript Warning: "reference to undefined property "failure"" {file:
 "resource://731f1373-8740-42db-9f10-db6129a83a67-at-jetpack/api-utils/lib/cuddl
efish.js -> resource://731f1373-8740-42db-9f10-db6129a83a67-at-jetpack/api-utils
/lib/unit-test.js" line: 47}]

Here is a patch to get rid of these messages.
