### PR TITLE
Bug 752108 Prefswildcard (v2)

### DIFF
--- a/doc/module-source/sdk/simple-prefs.md
+++ b/doc/module-source/sdk/simple-prefs.md
@@ -346,6 +346,8 @@ for more details.
     require("simple-prefs").on("somePreference", onPrefChange);
     require("simple-prefs").on("someOtherPreference", onPrefChange);
 
+    // `""` listens to all changes in the extension's branch
+    require("simple-prefs").on("", onPrefChange);
 
 @param prefName {String}
   The name of the preference to watch for changes.

--- a/lib/sdk/preferences/event-target.js
+++ b/lib/sdk/preferences/event-target.js
@@ -47,6 +47,7 @@ exports.PrefsTarget = PrefsTarget;
 function onChange(subject, topic, name) {
   if (topic === 'nsPref:changed')
     emit(this, name, name);
+    emit(this, '', name);
 }
 
 function destroy() {


### PR DESCRIPTION
Solution:

add a special "*" emitter for any prefs change in the addon branch.

No other wildcards are supported.  This is similar to what happens with the global observer service.  
