### PR TITLE
Bug 743359 - Move module overlay logic from bootstrap to cuddlefish.

### DIFF
--- a/packages/api-utils/lib/cuddlefish.js
+++ b/packages/api-utils/lib/cuddlefish.js
@@ -88,7 +88,7 @@ function Loader(options) {
     exports: loaderModule
   };
   loader.modules[module.uri] = {
-    id: module.id,
+    id: 'api-utils/cuddlefish',
     uri: module.uri,
     exports: exports
   };

--- a/python-lib/cuddlefish/app-extension/bootstrap.js
+++ b/python-lib/cuddlefish/app-extension/bootstrap.js
@@ -132,7 +132,7 @@ function startup(data, reasonCode) {
       }
     });
 
-    let module = { uri: cuddlefishURI, id: 'api-utils/cuddlefish' };
+    let module = cuddlefish.Module('api-utils/cuddlefish', cuddlefishURI);
     let require = Require(loader, module);
     require('api-utils/addon/runner').startup(reason, {
       loader: loader,


### PR DESCRIPTION
In  #428  we have incidentally overlayed `api-utils/loader` with `api-utils/cuddlefish`. This change fixes that and does small renames to make code easier to follow.
