### PR TITLE
Small fixes for scratch-kit

### DIFF
--- a/packages/addon-kit/lib/context-menu.js
+++ b/packages/addon-kit/lib/context-menu.js
@@ -28,7 +28,7 @@ const winUtils = require("api-utils/window-utils");
 const { getInnerId } = require("api-utils/window/utils");
 const { Trait } = require("api-utils/light-traits");
 const { Cortex } = require("api-utils/cortex");
-const timer = require("timer");
+const timer = require("timers");
 
 // All user items we add have this class name.
 const ITEM_CLASS = "jetpack-context-menu-item";

--- a/packages/addon-kit/lib/simple-prefs.js
+++ b/packages/addon-kit/lib/simple-prefs.js
@@ -15,7 +15,7 @@ const ADDON_BRANCH = "extensions." + id + ".";
 const BUTTON_PRESSED = id + "-cmdPressed";
 
 // XXX Currently, only Firefox implements the inline preferences.
-if (!require("xul-app").is("Firefox"))
+if (!require("api-utils/xul-app").is("Firefox"))
   throw Error("This API is only supported in Firefox");
 
 const branch = Cc["@mozilla.org/preferences-service;1"].


### PR DESCRIPTION
scratchkit does not does all the fancy module search that cfx does and implements simplified `require` form described we're moving towards https://github.com/mozilla/addon-sdk/wiki/Spring-cleaning-2012

Few SDK modules were using form that depends on search making it impossible to use them in scratchkit. This changes fix that making scratchkit compatible with all the sdk APIs.

Associated issues gozala/scratch-kit#3
