### PR TITLE
Bug 754514 - Get rid off undeclared charest errors in nightly.

### DIFF
--- a/packages/addon-kit/data/index.html
+++ b/packages/addon-kit/data/index.html
@@ -4,6 +4,7 @@
 
 <html>
   <head>
+    <meta charset="UTF-8">
     <title>Add-on Page</title>
   </head>
   <body>

--- a/packages/addon-kit/data/test-localization.html
+++ b/packages/addon-kit/data/test-localization.html
@@ -4,6 +4,7 @@
 
 <html>
   <head>
+    <meta charset="UTF-8">
     <title>HTML Localization</title>
   </head>
   <body>

--- a/packages/addon-kit/data/test-page-mod.html
+++ b/packages/addon-kit/data/test-page-mod.html
@@ -1,9 +1,9 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-
 <html>
 <head>
+    <meta charset="UTF-8">
     <title>Page Mod test</title>
 </head>
 <body>

--- a/packages/addon-kit/data/test-page-worker.html
+++ b/packages/addon-kit/data/test-page-worker.html
@@ -4,6 +4,7 @@
 
 <html>
 <head>
+    <meta charset="UTF-8">
     <title>Page Worker test</title>
 </head>
 <body>

--- a/packages/addon-kit/data/test.html
+++ b/packages/addon-kit/data/test.html
@@ -4,6 +4,7 @@
 
 <html>
   <head>
+    <meta charset="UTF-8">
     <title>foo</title>
   </head>
   <body>

--- a/packages/addon-kit/lib/page-mod.js
+++ b/packages/addon-kit/lib/page-mod.js
@@ -260,7 +260,7 @@ const PageMod = Loader.compose(EventEmitter, {
       }
     }
 
-    let uri = "data:text/css,";
+    let uri = "data:text/css;charset=utf-8,";
     if (documentRules.length > 0)
       uri += encodeURIComponent("@-moz-document " +
         documentRules.join(",") + " {" + styleRules + "}");

--- a/packages/addon-kit/lib/panel.js
+++ b/packages/addon-kit/lib/panel.js
@@ -118,25 +118,25 @@ const Panel = Symbiont.resolve({
     if (!xulPanel) {
       xulPanel = this._xulPanel = document.createElementNS(XUL_NS, 'panel');
       xulPanel.setAttribute("type", "arrow");
-      
-      // One anonymous node has a big padding that doesn't work well with 
-      // Jetpack, as we would like to display an iframe that completely fills 
-      // the panel. 
+
+      // One anonymous node has a big padding that doesn't work well with
+      // Jetpack, as we would like to display an iframe that completely fills
+      // the panel.
       // -> Use a XBL wrapper with inner stylesheet to remove this padding.
       let css = ".panel-inner-arrowcontent, .panel-arrowcontent {padding: 0;}";
       let originalXBL = "chrome://global/content/bindings/popup.xml#arrowpanel";
-      let binding = 
+      let binding =
       '<bindings xmlns="http://www.mozilla.org/xbl">' +
-        '<binding id="id" extends="' + originalXBL + '">' + 
-          '<resources>' + 
-            '<stylesheet src="data:text/css,' + 
+        '<binding id="id" extends="' + originalXBL + '">' +
+          '<resources>' +
+            '<stylesheet src="data:text/css;charset=utf-8,' +
               document.defaultView.encodeURIComponent(css) + '"/>' +
           '</resources>' +
         '</binding>' +
       '</bindings>';
-      xulPanel.style.MozBinding = 'url("data:text/xml,' + 
+      xulPanel.style.MozBinding = 'url("data:text/xml;charset=utf-8,' +
         document.defaultView.encodeURIComponent(binding) + '")';
-      
+
       let frame = document.createElementNS(XUL_NS, 'iframe');
       frame.setAttribute('type', 'content');
       frame.setAttribute('flex', '1');
@@ -145,32 +145,32 @@ const Panel = Symbiont.resolve({
         frame.style.borderRadius = "6px";
         frame.style.padding = "1px";
       }
-      
-      // Load an empty document in order to have an immediatly loaded iframe, 
+
+      // Load an empty document in order to have an immediatly loaded iframe,
       // so swapFrameLoaders is going to work without having to wait for load.
-      frame.setAttribute("src","data:,"); 
-      
+      frame.setAttribute("src","data:;charset=utf-8,");
+
       xulPanel.appendChild(frame);
       document.getElementById("mainPopupSet").appendChild(xulPanel);
     }
     let { width, height } = this, x, y, position;
-    
+
     if (!anchor) {
       // Open the popup in the middle of the window.
       x = document.documentElement.clientWidth / 2 - width / 2;
       y = document.documentElement.clientHeight / 2 - height / 2;
       position = null;
-    } 
+    }
     else {
       // Open the popup by the anchor.
       let rect = anchor.getBoundingClientRect();
-      
+
       let window = anchor.ownerDocument.defaultView;
-      
+
       let zoom = window.mozScreenPixelsPerCSSPixel;
       let screenX = rect.left + window.mozInnerScreenX * zoom;
       let screenY = rect.top + window.mozInnerScreenY * zoom;
-      
+
       // Set up the vertical position of the popup relative to the anchor
       // (always display the arrow on anchor center)
       let horizontal, vertical;
@@ -178,26 +178,26 @@ const Panel = Symbiont.resolve({
         vertical = "top";
       else
         vertical = "bottom";
-      
+
       if (screenY > window.screen.availWidth / 2 + width)
         horizontal = "left";
       else
         horizontal = "right";
-      
+
       let verticalInverse = vertical == "top" ? "bottom" : "top";
       position = vertical + "center " + verticalInverse + horizontal;
-      
+
       // Allow panel to flip itself if the panel can't be displayed at the
-      // specified position (useful if we compute a bad position or if the 
+      // specified position (useful if we compute a bad position or if the
       // user moves the window and panel remains visible)
       xulPanel.setAttribute("flip","both");
     }
-    
+
     // Resize the iframe instead of using panel.sizeTo
     // because sizeTo doesn't work with arrow panels
     xulPanel.firstChild.style.width = width + "px";
     xulPanel.firstChild.style.height = height + "px";
-    
+
     // Wait for the XBL binding to be constructed
     function waitForBinding() {
       if (!xulPanel.openPopup) {
@@ -207,7 +207,7 @@ const Panel = Symbiont.resolve({
       xulPanel.openPopup(anchor, position, x, y);
     }
     waitForBinding();
-    
+
     return this._public;
   },
   /* Public API: Panel.hide */
@@ -256,7 +256,7 @@ const Panel = Symbiont.resolve({
     this.__xulPanel = value;
   },
   __xulPanel: null,
-  get _viewFrame() this.__xulPanel.children[0], 
+  get _viewFrame() this.__xulPanel.children[0],
   /**
    * When the XUL panel becomes hidden, we swap frame loaders back to move
    * the content of the panel to the hidden frame & remove panel element.

--- a/packages/addon-kit/lib/widget.js
+++ b/packages/addon-kit/lib/widget.js
@@ -768,14 +768,14 @@ WidgetChrome.prototype.setContent = function WC_setContent() {
 
   switch (type) {
     case CONTENT_TYPE_HTML:
-      contentURL = "data:text/html," + encodeURIComponent(this._widget.content);
+      contentURL = "data:text/html;charset=utf-8," + encodeURIComponent(this._widget.content);
       break;
     case CONTENT_TYPE_URI:
       contentURL = this._widget.contentURL;
       break;
     case CONTENT_TYPE_IMAGE:
       let imageURL = this._widget.contentURL;
-      contentURL = "data:text/html,<html><body><img src='" +
+      contentURL = "data:text/html;charset=utf-8,<html><body><img src='" +
                    encodeURI(imageURL) + "'></body></html>";
       break;
     default:

--- a/packages/addon-kit/tests/test-context-menu.html
+++ b/packages/addon-kit/tests/test-context-menu.html
@@ -4,6 +4,7 @@
 
 <html>
   <head>
+    <meta charset="UTF-8">
     <title>Context menu test</title>
   </head>
   <body>
@@ -37,7 +38,7 @@
     </p>
 
     <p>
-      <iframe id="iframe" src="data:text/html,An iframe."
+      <iframe id="iframe" src="data:text/html;charset=utf-8,An iframe."
               width="200" height="100">
       </iframe>
     </p>

--- a/packages/addon-kit/tests/test-page-mod.js
+++ b/packages/addon-kit/tests/test-page-mod.js
@@ -267,7 +267,7 @@ exports.testMixedContext = function(test) {
   let doneCallback = null;
   let messages = 0;
   let modObject = {
-    include: "data:text/html,",
+    include: "data:text/html;charset=utf-8,",
     contentScript: 'new ' + function WorkerScope() {
       // Both scripts will execute this,
       // context is shared if one script see the other one modification.
@@ -288,7 +288,7 @@ exports.testMixedContext = function(test) {
       });
     }
   };
-  testPageMod(test, "data:text/html,", [modObject, modObject],
+  testPageMod(test, "data:text/html;charset=utf-8,", [modObject, modObject],
     function(win, done) {
       doneCallback = done;
     }
@@ -354,12 +354,12 @@ exports['test tab worker on message'] = function(test) {
   let tabs = require("tabs");
   let { PageMod } = require("page-mod");
 
-  let url1 = "data:text/html,<title>tab1</title><h1>worker1.tab</h1>";
-  let url2 = "data:text/html,<title>tab2</title><h1>worker2.tab</h1>";
+  let url1 = "data:text/html;charset=utf-8,<title>tab1</title><h1>worker1.tab</h1>";
+  let url2 = "data:text/html;charset=utf-8,<title>tab2</title><h1>worker2.tab</h1>";
   let worker1 = null;
 
   let mod = PageMod({
-    include: "data:text/html,*",
+    include: "data:text/html*",
     contentScriptWhen: "ready",
     contentScript: "self.postMessage('#1');",
     onAttach: function onAttach(worker) {
@@ -447,7 +447,7 @@ exports.testContentScriptOptionsOption = function(test) {
 
 exports.testPageModCss = function(test) {
   let [pageMod] = testPageMod(test,
-    'data:text/html,<div style="background: silver">css test</div>', [{
+    'data:text/html;charset=utf-8,<div style="background: silver">css test</div>', [{
       include: "data:*",
       contentStyle: "div { height: 100px; }",
       contentStyleFile:
@@ -472,16 +472,16 @@ exports.testPageModCss = function(test) {
 
 exports.testPageModCssList = function(test) {
   let [pageMod] = testPageMod(test,
-    'data:text/html,<div style="width:320px; max-width: 480px!important">css test</div>', [{
+    'data:text/html;charset=utf-8,<div style="width:320px; max-width: 480px!important">css test</div>', [{
       include: "data:*",
       contentStyleFile: [
         // Highlight evaluation order in this list
-        "data:text/css,div { border: 1px solid black; }",
-        "data:text/css,div { border: 10px solid black; }",
+        "data:text/css;charset=utf-8,div { border: 1px solid black; }",
+        "data:text/css;charset=utf-8,div { border: 10px solid black; }",
         // Highlight evaluation order between contentStylesheet & contentStylesheetFile
-        "data:text/css,div { height: 1000px; }",
+        "data:text/cs;charset=utf-8s,div { height: 1000px; }",
         // Highlight precedence between the author and user style sheet
-        "data:text/css,div { width: 200px; max-width: 640px!important}",
+        "data:text/css;charset=utf-8,div { width: 200px; max-width: 640px!important}",
       ],
       contentStyle: [
         "div { height: 10px; }",
@@ -523,7 +523,7 @@ exports.testPageModCssList = function(test) {
 
 exports.testPageModCssDestroy = function(test) {
   let [pageMod] = testPageMod(test,
-    'data:text/html,<div style="width:200px">css test</div>', [{
+    'data:text/html;charset=utf-8,<div style="width:200px">css test</div>', [{
       include: "data:*",
       contentStyle: "div { width: 100px!important; }"
     }],

--- a/packages/addon-kit/tests/test-page-worker.js
+++ b/packages/addon-kit/tests/test-page-worker.js
@@ -32,7 +32,7 @@ tests.testWrappedDOM = function(test) {
 
   let page = Page({
     allow: { script: true },
-    contentURL: "data:text/html,<script>document.getElementById=3;window.scrollTo=3;</script>",
+    contentURL: "data:text/html;charset=utf-8,<script>document.getElementById=3;window.scrollTo=3;</script>",
     contentScript: "window.addEventListener('load', function () " +
                    "self.postMessage([typeof(document.getElementById), " +
                    "typeof(window.scrollTo)]), true)",
@@ -58,7 +58,7 @@ tests.testUnwrappedDOM = function(test) {
 
   let page = Page({
     allow: { script: true },
-    contentURL: "data:text/html,<script>document.getElementById=3;window.scrollTo=3;</script>",
+    contentURL: "data:text/html;charset=utf-8,<script>document.getElementById=3;window.scrollTo=3;</script>",
     contentScript: "window.addEventListener('load', function () " +
                    "self.postMessage([typeof(unsafeWindow.document.getElementById), " +
                    "typeof(unsafeWindow.scrollTo)]), true)",
@@ -162,7 +162,7 @@ tests.testValidateOptions = function(test) {
 
 tests.testContentAndAllowGettersAndSetters = function(test) {
   test.waitUntilDone();
-  let content = "data:text/html,<script>window.localStorage.allowScript=3;</script>";
+  let content = "data:text/html;charset=utf-8,<script>window.localStorage.allowScript=3;</script>";
   let page = Page({
     contentURL: content,
     contentScript: "self.postMessage(window.localStorage.allowScript)",
@@ -179,7 +179,7 @@ tests.testContentAndAllowGettersAndSetters = function(test) {
     page.on('message', step1);
     page.allow = { script: false };
     page.contentURL = content = 
-      "data:text/html,<script>window.localStorage.allowScript='f'</script>";
+      "data:text/html;charset=utf-8,<script>window.localStorage.allowScript='f'</script>";
   }
 
   function step1(message) {
@@ -190,7 +190,7 @@ tests.testContentAndAllowGettersAndSetters = function(test) {
     page.on('message', step2);
     page.allow = { script: true };
     page.contentURL = content =
-      "data:text/html,<script>window.localStorage.allowScript='g'</script>";
+      "data:text/html;charset=utf-8,<script>window.localStorage.allowScript='g'</script>";
   }
 
   function step2(message) {
@@ -201,7 +201,7 @@ tests.testContentAndAllowGettersAndSetters = function(test) {
     page.on('message', step3);
     page.allow.script = false;
     page.contentURL = content = 
-      "data:text/html,<script>window.localStorage.allowScript=3</script>";
+      "data:text/html;charset=utf-8,<script>window.localStorage.allowScript=3</script>";
   }
 
   function step3(message) {
@@ -212,7 +212,7 @@ tests.testContentAndAllowGettersAndSetters = function(test) {
     page.on('message', step4);
     page.allow.script = true;
     page.contentURL = content = 
-      "data:text/html,<script>window.localStorage.allowScript=4</script>";
+      "data:text/html;charset=utf-8,<script>window.localStorage.allowScript=4</script>";
   }
 
   function step4(message) {
@@ -280,7 +280,7 @@ tests.testAllowScriptDefault = function(test) {
       test.assert(message, "Script is allowed to run by default.");
       test.done();
     },
-    contentURL: "data:text/html,<script>document.documentElement.setAttribute('foo', 3);</script>",
+    contentURL: "data:text/html;charset=utf-8,<script>document.documentElement.setAttribute('foo', 3);</script>",
     contentScript: "self.postMessage(document.documentElement.getAttribute('foo'))",
     contentScriptWhen: "ready"
   });
@@ -296,7 +296,7 @@ tests.testAllowScript = function(test) {
       test.done();
     },
     allow: { script: true },
-    contentURL: "data:text/html,<script>document.documentElement.setAttribute('foo', 3);</script>",
+    contentURL: "data:text/html;charset=utf-8,<script>document.documentElement.setAttribute('foo', 3);</script>",
     contentScript: "self.postMessage(document.documentElement.hasAttribute('foo') && " +
                    "                 document.documentElement.getAttribute('foo') == 3)",
     contentScriptWhen: "ready"
@@ -306,7 +306,7 @@ tests.testAllowScript = function(test) {
 tests.testPingPong = function(test) {
   test.waitUntilDone();
   let page = Page({
-    contentURL: 'data:text/html,ping-pong',
+    contentURL: 'data:text/html;charset=utf-8,ping-pong',
     contentScript: 'self.on("message", function(message) self.postMessage("pong"));'
       + 'self.postMessage("ready");',
     onMessage: function(message) {

--- a/packages/addon-kit/tests/test-panel.js
+++ b/packages/addon-kit/tests/test-panel.js
@@ -97,12 +97,12 @@ tests.testDocumentReload = function(test) {
     "</script>";
   let messageCount = 0;
   let panel = Panel({
-    contentURL: "data:text/html," + encodeURIComponent(content),
+    contentURL: "data:text/html;charset=utf-8," + encodeURIComponent(content),
     contentScript: "self.postMessage(window.location.href)",
     onMessage: function (message) {
       messageCount++;
       if (messageCount == 1) {
-        test.assertMatches(message, /data:text\/html,/, "First document had a content script");
+        test.assertMatches(message, /data:text\/html/, "First document had a content script");
       }
       else if (messageCount == 2) {
         test.assertEqual(message, "about:blank", "Second document too");
@@ -139,7 +139,7 @@ tests.testParentResizeHack = function(test) {
                 "</script>" +
                 "Try to resize browser window";
   let panel = Panel({
-    contentURL: "data:text/html," + encodeURIComponent(content),
+    contentURL: "data:text/html;charset=utf-8," + encodeURIComponent(content),
     contentScript: "self.on('message', function(message){" +
                    "  if (message=='resize') " +
                    "    unsafeWindow.contentResize();" +
@@ -178,8 +178,8 @@ tests.testResizePanel = function(test) {
   let browserWindow = Cc["@mozilla.org/appshell/window-mediator;1"].
                       getService(Ci.nsIWindowMediator).
                       getMostRecentWindow("navigator:browser");
-  
-  
+
+
   function onFocus() {
     browserWindow.removeEventListener("focus", onFocus, true);
 
@@ -259,7 +259,7 @@ tests.testAnchorAndArrow = function(test) {
   let count = 0;
   function newPanel(tab, anchor) {
     let panel = panels.Panel({
-      contentURL: "data:text/html,<html><body style='padding: 0; margin: 0; " +
+      contentURL: "data:text/html;charset=utf-8,<html><body style='padding: 0; margin: 0; " +
                   "background: gray; text-align: center;'>Anchor: " +
                   anchor.id + "</body></html>",
       width: 200,
@@ -277,10 +277,10 @@ tests.testAnchorAndArrow = function(test) {
     });
     panel.show(anchor);
   }
-  
+
   let tabs= require("tabs");
-  let url = 'data:text/html,' +
-    '<html><head><title>foo</title></head><body>' + 
+  let url = 'data:text/html;charset=utf-8,' +
+    '<html><head><title>foo</title></head><body>' +
     '<style>div {background: gray; position: absolute; width: 300px; ' +
            'border: 2px solid black;}</style>' +
     '<div id="tl" style="top: 0px; left: 0px;">Top Left</div>' +
@@ -288,7 +288,7 @@ tests.testAnchorAndArrow = function(test) {
     '<div id="bl" style="bottom: 0px; left: 0px;">Bottom Left</div>' +
     '<div id="br" style="bottom: 0px; right: 0px;">Bottom right</div>' +
     '</body></html>';
-  
+
   tabs.open({
     url: url,
     onReady: function(tab) {
@@ -304,9 +304,9 @@ tests.testAnchorAndArrow = function(test) {
       newPanel(tab, anchor);
     }
   });
-  
-  
-  
+
+
+
 };
 
 tests.testPanelTextColor = function(test) {
@@ -314,7 +314,7 @@ tests.testPanelTextColor = function(test) {
   let html = "<html><head><style>body {color: yellow}</style></head>" +
              "<body><p>Foo</p></body></html>";
   let panel = Panel({
-    contentURL: "data:text/html," + encodeURI(html),
+    contentURL: "data:text/html;charset=utf-8," + encodeURI(html),
     contentScript: "self.port.emit('color', " +
                    "window.getComputedStyle(document.body.firstChild, null). " +
                    "       getPropertyValue('color'));"
@@ -377,12 +377,12 @@ tests.testAutomaticDestroy = function(test) {
   let loader = Loader(module);
   let panel = loader.require("panel").Panel({
     contentURL: "about:buildconfig",
-    contentScript: 
+    contentScript:
       "self.port.on('event', function() self.port.emit('event-back'));"
   });
-  
+
   loader.unload();
-  
+
   panel.port.on("event-back", function () {
     test.fail("Panel should have been destroyed on module unload");
   });
@@ -425,7 +425,7 @@ tests.testContentURLOption = function(test) {
                 "contentURL is the string to which it was set.");
   }
 
-  let dataURL = "data:text/html," + encodeURIComponent(HTML_CONTENT);
+  let dataURL = "data:text/html;charset=utf-8," + encodeURIComponent(HTML_CONTENT);
   let (panel = Panel({ contentURL: dataURL })) {
     test.pass("contentURL accepts a data: URL.");
   }

--- a/packages/addon-kit/tests/test-request.js
+++ b/packages/addon-kit/tests/test-request.js
@@ -34,7 +34,7 @@ exports.testOptionsValidator = function(test) {
 exports.testContentValidator = function(test) {
   test.waitUntilDone();
   Request({
-    url: "data:text/html,response",
+    url: "data:text/html;charset=utf-8,response",
     content: { 'key1' : null, 'key2' : 'some value' },
     onComplete: function(response) {
       test.assertEqual(response.text, "response?key1=null&key2=some+value");

--- a/packages/addon-kit/tests/test-selection.js
+++ b/packages/addon-kit/tests/test-selection.js
@@ -35,7 +35,7 @@ function selectTextarea(window, from, to) {
 
 function primeTestCase(html, test, callback) {
   let tabBrowser = require("tab-browser");
-  let dataURL = "data:text/html," + encodeURI(html);
+  let dataURL = "data:text/html;charset=utf-8," + encodeURI(html);
   let tracker = tabBrowser.whenContentLoaded(
     function(window) {
       if (window.document.location.href != dataURL)

--- a/packages/addon-kit/tests/test-tabs.js
+++ b/packages/addon-kit/tests/test-tabs.js
@@ -13,7 +13,7 @@ exports.testActiveTab_getter = function(test) {
   openBrowserWindow(function(window, browser) {
     let tabs = require("tabs");
 
-    let url = "data:text/html,<html><head><title>foo</title></head></html>";
+    let url = "data:text/html;charset=utf-8,<html><head><title>foo</title></head></html>";
     require("tab-browser").addTab(
       url,
       {
@@ -55,7 +55,7 @@ exports.testActiveTab_setter = function(test) {
 
   openBrowserWindow(function(window, browser) {
     let tabs = require("tabs");
-    let url = "data:text/html,<html><head><title>foo</title></head></html>";
+    let url = "data:text/html;charset=utf-8,<html><head><title>foo</title></head></html>";
 
     tabs.on('ready', function onReady(tab) {
       tabs.removeListener('ready', onReady);
@@ -103,7 +103,7 @@ exports.testAutomaticDestroy = function(test) {
       }, 0);
     });
     
-    tabs.open("data:text/html,foo");
+    tabs.open("data:text/html;charset=utf-8,foo");
     
   });
 };
@@ -113,7 +113,7 @@ exports.testTabProperties = function(test) {
   test.waitUntilDone();
   openBrowserWindow(function(window, browser) {
     let tabs= require("tabs");
-    let url = "data:text/html,<html><head><title>foo</title></head><body>foo</body></html>";
+    let url = "data:text/html;charset=utf-8,<html><head><title>foo</title></head><body>foo</body></html>";
     tabs.open({
       url: url,
       onReady: function(tab) {
@@ -137,7 +137,7 @@ exports.testTabsIteratorAndLength = function(test) {
     let startCount = 0;
     for each (let t in tabs) startCount++;
     test.assertEqual(startCount, tabs.length, "length property is correct");
-    let url = "data:text/html,default";
+    let url = "data:text/html;charset=utf-8,default";
     tabs.open(url);
     tabs.open(url);
     tabs.open({
@@ -158,8 +158,8 @@ exports.testTabLocation = function(test) {
   test.waitUntilDone();
   openBrowserWindow(function(window, browser) {
     let tabs = require("tabs");
-    let url1 = "data:text/html,foo";
-    let url2 = "data:text/html,bar";
+    let url1 = "data:text/html;charset=utf-8,foo";
+    let url2 = "data:text/html;charset=utf-8,bar";
 
     tabs.on('ready', function onReady(tab) {
       if (tab.url != url2)
@@ -183,7 +183,7 @@ exports.testTabClose = function(test) {
   test.waitUntilDone();
   openBrowserWindow(function(window, browser) {
     let tabs = require("tabs");
-    let url = "data:text/html,foo";
+    let url = "data:text/html;charset=utf-8,foo";
 
     test.assertNotEqual(tabs.activeTab.url, url, "tab is now the active tab");
     tabs.on('ready', function onReady(tab) {
@@ -204,7 +204,7 @@ exports.testTabReload = function(test) {
   test.waitUntilDone();
   openBrowserWindow(function(window, browser) {
     let tabs = require("tabs");
-    let url = "data:text/html,<!doctype%20html><title></title>";
+    let url = "data:text/html;charset=utf-8,<!doctype%20html><title></title>";
 
     tabs.open({ url: url, onReady: function onReady(tab) {
       tab.removeListener("ready", onReady);
@@ -237,7 +237,7 @@ exports.testTabMove = function(test) {
   test.waitUntilDone();
   openBrowserWindow(function(window, browser) {
     let tabs = require("tabs");
-    let url = "data:text/html,foo";
+    let url = "data:text/html;charset=utf-8,foo";
 
     tabs.open({
       url: url,
@@ -256,7 +256,7 @@ exports.testOpen = function(test) {
   test.waitUntilDone();
   openBrowserWindow(function(window, browser) {
     let tabs = require("tabs");
-    let url = "data:text/html,default";
+    let url = "data:text/html;charset=utf-8,default";
     tabs.open({
       url: url,
       onReady: function(tab) {
@@ -276,7 +276,7 @@ exports.testOpenPinned = function(test) {
     test.waitUntilDone();
     openBrowserWindow(function(window, browser) {
       let tabs = require("tabs");
-      let url = "data:text/html,default";
+      let url = "data:text/html;charset=utf-8,default";
       tabs.open({
         url: url,
         isPinned: true,
@@ -299,7 +299,7 @@ exports.testPinUnpin = function(test) {
     test.waitUntilDone();
     openBrowserWindow(function(window, browser) {
       let tabs = require("tabs");
-      let url = "data:text/html,default";
+      let url = "data:text/html;charset=utf-8,default";
       tabs.open({
         url: url,
         onOpen: function(tab) {
@@ -323,7 +323,7 @@ exports.testInBackground = function(test) {
   openBrowserWindow(function(window, browser) {
     let tabs = require("tabs");
     let activeUrl = tabs.activeTab.url;
-    let url = "data:text/html,background";
+    let url = "data:text/html;charset=utf-8,background";
     test.assertEqual(activeWindow, window, "activeWindow matches this window");
     tabs.on('ready', function onReady(tab) {
       tabs.removeListener('ready', onReady);
@@ -358,7 +358,7 @@ exports.testOpenInNewWindow = function(test) {
     });
     let startWindowCount = cache.length;
 
-    let url = "data:text/html,newwindow";
+    let url = "data:text/html;charset=utf-8,newwindow";
     tabs.open({
       url: url,
       inNewWindow: true,
@@ -384,7 +384,7 @@ exports.testTabsEvent_onOpen = function(test) {
   test.waitUntilDone();
   openBrowserWindow(function(window, browser) {
     var tabs = require("tabs");
-    let url = "data:text/html,1";
+    let url = "data:text/html;charset=utf-8,1";
     let eventCount = 0;
 
     // add listener via property assignment
@@ -410,7 +410,7 @@ exports.testTabsEvent_onClose = function(test) {
   test.waitUntilDone();
   openBrowserWindow(function(window, browser) {
     var tabs = require("tabs");
-    let url = "data:text/html,onclose";
+    let url = "data:text/html;charset=utf-8,onclose";
     let eventCount = 0;
 
     // add listener via property assignment
@@ -458,19 +458,19 @@ exports.testTabsEvent_onCloseWindow = function(test) {
     }
 
     tabs.open({
-      url: "data:text/html,tab2",
+      url: "data:text/html;charset=utf-8,tab2",
       onOpen: function() testCasePossiblyLoaded(),
       onClose: function() individualCloseCount++
     });
 
     tabs.open({
-      url: "data:text/html,tab3",
+      url: "data:text/html;charset=utf-8,tab3",
       onOpen: function() testCasePossiblyLoaded(),
       onClose: function() individualCloseCount++
     });
 
     tabs.open({
-      url: "data:text/html,tab4",
+      url: "data:text/html;charset=utf-8,tab4",
       onOpen: function() testCasePossiblyLoaded(),
       onClose: function() individualCloseCount++
     });
@@ -496,7 +496,7 @@ exports.testTabsEvent_onReady = function(test) {
   test.waitUntilDone();
   openBrowserWindow(function(window, browser) {
     var tabs = require("tabs");
-    let url = "data:text/html,onready";
+    let url = "data:text/html;charset=utf-8,onready";
     let eventCount = 0;
 
     // add listener via property assignment
@@ -522,7 +522,7 @@ exports.testTabsEvent_onActivate = function(test) {
   test.waitUntilDone();
   openBrowserWindow(function(window, browser) {
     var tabs = require("tabs");
-    let url = "data:text/html,onactivate";
+    let url = "data:text/html;charset=utf-8,onactivate";
     let eventCount = 0;
 
     // add listener via property assignment
@@ -548,7 +548,7 @@ exports.testTabsEvent_onDeactivate = function(test) {
   test.waitUntilDone();
   openBrowserWindow(function(window, browser) {
     var tabs = require("tabs");
-    let url = "data:text/html,ondeactivate";
+    let url = "data:text/html;charset=utf-8,ondeactivate";
     let eventCount = 0;
 
     // add listener via property assignment
@@ -567,7 +567,7 @@ exports.testTabsEvent_onDeactivate = function(test) {
 
     tabs.on('open', function onOpen(tab) {
       tabs.removeListener('open', onOpen);
-      tabs.open("data:text/html,foo");
+      tabs.open("data:text/html;charset=utf-8,foo");
     });
 
     tabs.open(url);
@@ -578,7 +578,7 @@ exports.testTabsEvent_pinning = function(test) {
   test.waitUntilDone();
   openBrowserWindow(function(window, browser) {
     var tabs = require("tabs");
-    let url = "data:text/html,1";
+    let url = "data:text/html;charset=utf-8,1";
 
     tabs.on('open', function onOpen(tab) {
       tabs.removeListener('open', onOpen);
@@ -609,7 +609,7 @@ exports.testPerTabEvents = function(test) {
     let eventCount = 0;
 
     tabs.open({
-      url: "data:text/html,foo",
+      url: "data:text/html;charset=utf-8,foo",
       onOpen: function(tab) {
         // add listener via property assignment
         function listener1() {
@@ -636,7 +636,7 @@ exports.testAttachOnOpen = function (test) {
     let tabs = require("tabs");
     
     tabs.open({
-      url: "data:text/html,foobar",
+      url: "data:text/html;charset=utf-8,foobar",
       onOpen: function (tab) {
         let worker = tab.attach({
           contentScript: 'self.postMessage(document.location.href); ',
@@ -658,9 +658,9 @@ exports.testAttachOnMultipleDocuments = function (test) {
   test.waitUntilDone();
   openBrowserWindow(function(window, browser) {
     let tabs = require("tabs");
-    let firstLocation = "data:text/html,foobar";
-    let secondLocation = "data:text/html,bar";
-    let thirdLocation = "data:text/html,fox";
+    let firstLocation = "data:text/html;charset=utf-8,foobar";
+    let secondLocation = "data:text/html;charset=utf-8,bar";
+    let thirdLocation = "data:text/html;charset=utf-8,fox";
     let onReadyCount = 0;
     let worker1 = null;
     let worker2 = null;
@@ -743,7 +743,7 @@ exports.testAttachWrappers = function (test) {
   test.waitUntilDone();
   openBrowserWindow(function(window, browser) {
     let tabs = require("tabs");
-    let document = "data:text/html,<script>var globalJSVar = true; " +
+    let document = "data:text/html;charset=utf-8,<script>var globalJSVar = true; " +
                    "                       document.getElementById = 3;</script>";
     let count = 0;
     
@@ -777,7 +777,7 @@ exports.testAttachUnwrapped = function (test) {
   test.waitUntilDone();
   openBrowserWindow(function(window, browser) {
     let tabs = require("tabs");
-    let document = "data:text/html,<script>var globalJSVar=true;</script>";
+    let document = "data:text/html;charset=utf-8,<script>var globalJSVar=true;</script>";
     let count = 0;
     
     tabs.open({
@@ -814,13 +814,13 @@ exports['test window focus changes active tab'] = function(test) {
         });
       });
       win1.focus();
-    }, "data:text/html,test window focus changes active tab</br><h1>Window #2");
-  }, "data:text/html,test window focus changes active tab</br><h1>Window #1");
+    }, "data:text/html;charset=utf-8,test window focus changes active tab</br><h1>Window #2");
+  }, "data:text/html;charset=utf-8,test window focus changes active tab</br><h1>Window #1");
 };
 
 exports['test ready event on new window tab'] = function(test) {
   test.waitUntilDone();
-  let uri = encodeURI("data:text/html,Waiting for ready event!");
+  let uri = encodeURI("data:text/html;charset=utf-8,Waiting for ready event!");
 
   require("tabs").on("ready", function onReady(tab) {
     if (tab.url === uri) {

--- a/packages/addon-kit/tests/test-widget.js
+++ b/packages/addon-kit/tests/test-widget.js
@@ -378,8 +378,8 @@ exports.testConstructor = function(test) {
   }));
 
   // test updating widget contentURL
-  let url1 = "data:text/html,<body>foodle</body>";
-  let url2 = "data:text/html,<body>nistel</body>";
+  let url1 = "data:text/html;charset=utf-8,<body>foodle</body>";
+  let url2 = "data:text/html;charset=utf-8,<body>nistel</body>";
 
   tests.push(function testUpdatingContentURL() testSingleWidget({
     id: "content",
@@ -668,7 +668,7 @@ exports.testPanelWidget1 = function testPanelWidget1(test) {
                    "document.body.dispatchEvent(evt);",
     contentScriptWhen: "end",
     panel: require("panel").Panel({
-      contentURL: "data:text/html,<body>Look ma, a panel!</body>",
+      contentURL: "data:text/html;charset=utf-8,<body>Look ma, a panel!</body>",
       onShow: function() {
         widget1.destroy();
         test.pass("panel displayed on click");
@@ -710,7 +710,7 @@ exports.testPanelWidget3 = function testPanelWidget3(test) {
       this.panel.show();
     },
     panel: require("panel").Panel({
-      contentURL: "data:text/html,<body>Look ma, a panel!</body>",
+      contentURL: "data:text/html;charset=utf-8,<body>Look ma, a panel!</body>",
       onShow: function() {
         test.assert(
           onClickCalled,

--- a/packages/addon-kit/tests/test-windows.js
+++ b/packages/addon-kit/tests/test-windows.js
@@ -17,7 +17,7 @@ exports.testOpenAndCloseWindow = function(test) {
   test.assertEqual(browserWindows.length, 1, "Only one window open");
 
   browserWindows.open({
-    url: "data:text/html,<title>windows API test</title>",
+    url: "data:text/html;charset=utf-8,<title>windows API test</title>",
     onOpen: function(window) {
       test.assertEqual(this, browserWindows,
                        "The 'this' object is the windows object.");
@@ -55,7 +55,7 @@ exports.testAutomaticDestroy = function(test) {
   
   // Fire a windows event and check that this unloaded instance is inactive
   windows.open({
-    url: "data:text/html,foo",
+    url: "data:text/html;charset=utf-8,foo",
     onOpen: function(window) {
       setTimeout(function () {
         test.assert(!called, 
@@ -128,7 +128,7 @@ exports.testOnOpenOnCloseListeners = function(test) {
 
 
   windows.open({
-    url: "data:text/html,foo",
+    url: "data:text/html;charset=utf-8,foo",
     onOpen: function(window) {
       window.close(verify);
     }
@@ -139,12 +139,12 @@ exports.testWindowTabsObject = function(test) {
   test.waitUntilDone();
 
   browserWindows.open({
-    url: "data:text/html,<title>tab 1</title>",
+    url: "data:text/html;charset=utf-8,<title>tab 1</title>",
     onOpen: function onOpen(window) {
       test.assertEqual(window.tabs.length, 1, "Only 1 tab open");
 
       window.tabs.open({
-        url: "data:text/html,<title>tab 2</title>",
+        url: "data:text/html;charset=utf-8,<title>tab 2</title>",
         inBackground: true,
         onReady: function onReady(newTab) {
           test.assertEqual(window.tabs.length, 2, "New tab open");
@@ -228,13 +228,13 @@ exports.testActiveWindow = function(test) {
   ];
 
   windows.open({
-    url: "data:text/html,<title>window 2</title>",
+    url: "data:text/html;charset=utf-8,<title>window 2</title>",
     onOpen: function(window) {
       window2 = window;
       rawWindow2 = wm.getMostRecentWindow("navigator:browser");
 
       windows.open({
-        url: "data:text/html,<title>window 3</title>",
+        url: "data:text/html;charset=utf-8,<title>window 3</title>",
         onOpen: function(window) {
           window.tabs.activeTab.on('ready', function onReady() {
             window3 = window;

--- a/packages/api-utils/data/test-trusted-document.html
+++ b/packages/api-utils/data/test-trusted-document.html
@@ -4,6 +4,7 @@
 
 <html>
 <head>
+    <meta charset="UTF-8">
     <title>Worker test</title>
 </head>
 <body>

--- a/packages/api-utils/tests/test-content-proxy.js
+++ b/packages/api-utils/tests/test-content-proxy.js
@@ -15,7 +15,7 @@ function createProxyTest(html, callback) {
   return function (test) {
     test.waitUntilDone();
 
-    let url = 'data:text/html,' + encodeURI(html);
+    let url = 'data:text/html;charset=utf-8,' + encodeURI(html);
 
     let hiddenFrame = hiddenFrames.add(hiddenFrames.HiddenFrame({
       onReady: function () {
@@ -155,7 +155,7 @@ exports.testSharedToStringProxies = createProxyTest("", function(helper) {
       //document.location.toString = function foo() {};
       document.location.toString.foo = "bar";
       assert(!("foo" in document.location.toString), "document.location.toString can't be modified");
-      assert(document.location.toString() == "data:text/html,",
+      assert(document.location.toString() == "data:text/html;charset=utf-8,",
              "First document.location.toString()");
       self.postMessage("next");
     }
@@ -165,7 +165,7 @@ exports.testSharedToStringProxies = createProxyTest("", function(helper) {
       'new ' + function ContentScriptScope2() {
         assert(!("foo" in document.location.toString),
                "document.location.toString is different for each content script");
-        assert(document.location.toString() == "data:text/html,",
+        assert(document.location.toString() == "data:text/html;charset=utf-8,",
                "Second document.location.toString()");
         done();
       }
@@ -175,7 +175,7 @@ exports.testSharedToStringProxies = createProxyTest("", function(helper) {
 
 
 // Ensure that postMessage is working correctly across documents with an iframe
-let html = '<iframe id="iframe" name="test" src="data:text/html," />';
+let html = '<iframe id="iframe" name="test" src="data:text/html;charset=utf-8," />';
 exports.testPostMessage = createProxyTest(html, function (helper, test) {
   let ifWindow = helper.xrayWindow.document.getElementById("iframe").contentWindow;
   // Listen without proxies, to check that it will work in regular case
@@ -507,7 +507,7 @@ exports.testDocumentTagName = createProxyTest("", function (helper) {
 
 });
 
-let html = '<iframe id="iframe" name="test" src="data:text/html," />';
+let html = '<iframe id="iframe" name="test" src="data:text/html;charset=utf-8," />';
 exports.testWindowFrames = createProxyTest(html, function (helper) {
 
   helper.createWorker(

--- a/packages/api-utils/tests/test-content-symbiont.js
+++ b/packages/api-utils/tests/test-content-symbiont.js
@@ -15,7 +15,7 @@ function makeWindow() {
     'xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">' +
     '<iframe id="content" type="content"/>' +
     '</window>';
-  var url = "data:application/vnd.mozilla.xul+xml," +
+  var url = "data:application/vnd.mozilla.xul+xml;charset=utf-8," +
             encodeURIComponent(content);
   var features = ["chrome", "width=10", "height=10"];
 
@@ -103,7 +103,7 @@ exports["test:communication with worker global scope"] = function(test) {
       onMessage: onMessage1
     });
     
-    frame.setAttribute("src", "data:text/html,<html><body></body></html>");
+    frame.setAttribute("src", "data:text/html;charset=utf-8,<html><body></body></html>");
   }, false);
   test.waitUntilDone();
 };

--- a/packages/api-utils/tests/test-content-worker.js
+++ b/packages/api-utils/tests/test-content-worker.js
@@ -19,7 +19,7 @@ function makeWindow(contentURL) {
       encodeURIComponent(contentURL) + '"/>' +
     '<script>var documentValue=true;</script>' +
     '</window>';
-  var url = "data:application/vnd.mozilla.xul+xml," +
+  var url = "data:application/vnd.mozilla.xul+xml;charset=utf-8," +
             encodeURIComponent(content);
   var features = ["chrome", "width=10", "height=10"];
 
@@ -167,7 +167,7 @@ exports['test:n-arguments emit'] = function(test) {
 }
 
 exports['test:post-json-values-only'] = function(test) {
-  let window = makeWindow("data:text/html,");
+  let window = makeWindow("data:text/html;charset=utf-8,");
   test.waitUntilDone();
   
   window.addEventListener("load", function onload() {
@@ -209,7 +209,7 @@ exports['test:post-json-values-only'] = function(test) {
 
 
 exports['test:emit-json-values-only'] = function(test) {
-  let window = makeWindow("data:text/html,");
+  let window = makeWindow("data:text/html;charset=utf-8,");
   test.waitUntilDone();
   
   window.addEventListener("load", function onload() {
@@ -262,7 +262,7 @@ exports['test:emit-json-values-only'] = function(test) {
 }
 
 exports['test:content is wrapped'] = function(test) {
-  let contentURL = 'data:text/html,<script>var documentValue=true;</script>';
+  let contentURL = 'data:text/html;charset=utf-8,<script>var documentValue=true;</script>';
   let window = makeWindow(contentURL);
   test.waitUntilDone();
 
@@ -399,7 +399,7 @@ exports['test:ensure console.xxx works in cs'] = function(test) {
 
 
 exports['test:setTimeout can\'t be cancelled by content'] = function(test) {
-  let contentURL = 'data:text/html,<script>var documentValue=true;</script>';
+  let contentURL = 'data:text/html;charset=utf-8,<script>var documentValue=true;</script>';
   let window = makeWindow(contentURL);
   test.waitUntilDone();
 
@@ -428,7 +428,7 @@ exports['test:setTimeout can\'t be cancelled by content'] = function(test) {
 }
 
 exports['test:setTimeout are unregistered on content unload'] = function(test) {
-  let contentURL = 'data:text/html,foo';
+  let contentURL = 'data:text/html;charset=utf-8,foo';
   let window = makeWindow(contentURL);
   test.waitUntilDone();
 
@@ -469,7 +469,7 @@ exports['test:setTimeout are unregistered on content unload'] = function(test) {
           test.done();
         }, 100);
       }, true);
-      iframe.setAttribute("src", "data:text/html,<title>final</title>");
+      iframe.setAttribute("src", "data:text/html;charset=utf-8,<title>final</title>");
     }, 100);
 
   }, true);

--- a/packages/api-utils/tests/test-frame-utils.js
+++ b/packages/api-utils/tests/test-frame-utils.js
@@ -8,7 +8,7 @@ const { open } = require('api-utils/window/utils');
 const { create } = require('api-utils/frame/utils');
 
 exports['test frame creation'] = function(assert) {
-  let window = open('data:text/html,Window');
+  let window = open('data:text/html;charset=utf-8,Window');
   let frame = create(window.document);
 
   assert.equal(frame.getAttribute('type'), 'content',
@@ -24,11 +24,11 @@ exports['test frame creation'] = function(assert) {
 };
 
 exports['test fram has js disabled by default'] = function(assert, done) {
-  let window = open('data:text/html,window');
+  let window = open('data:text/html;charset=utf-8,window');
   window.addEventListener('DOMContentLoaded', function windowReady() {
     window.removeEventListener('DOMContentLoaded', windowReady, false);
     let frame = create(window.document, {
-      uri: 'data:text/html,<script>document.documentElement.innerHTML' +
+      uri: 'data:text/html;charset=utf-8,<script>document.documentElement.innerHTML' +
            '= "J" + "S"</script>',
     });
     frame.contentWindow.addEventListener('DOMContentLoaded', function ready() {
@@ -44,11 +44,11 @@ exports['test fram has js disabled by default'] = function(assert, done) {
 };
 
 exports['test frame with js enabled'] = function(assert, done) {
-  let window = open('data:text/html,window');
+  let window = open('data:text/html;charset=utf-8,window');
   window.addEventListener('DOMContentLoaded', function windowReady() {
     window.removeEventListener('DOMContentLoaded', windowReady, false);
     let frame = create(window.document, {
-      uri: 'data:text/html,<script>document.documentElement.innerHTML' +
+      uri: 'data:text/html;charset=utf-8,<script>document.documentElement.innerHTML' +
            '= "J" + "S"</script>',
       allowJavascript: true
     });

--- a/packages/api-utils/tests/test-hidden-frame.js
+++ b/packages/api-utils/tests/test-hidden-frame.js
@@ -5,7 +5,7 @@
 let tests = {}, hiddenFrames, HiddenFrame;
 
 tests.testFrame = function(test) {
-  let url = "data:text/html,<!DOCTYPE%20html>";
+  let url = "data:text/html;charset=utf-8,<!DOCTYPE%20html>";
   test.waitUntilDone();
   let hiddenFrame = hiddenFrames.add(HiddenFrame({
     onReady: function () {

--- a/packages/api-utils/tests/test-tab-browser.js
+++ b/packages/api-utils/tests/test-tab-browser.js
@@ -76,14 +76,14 @@ exports.testAddTab = function(test) {
     let startWindowCount = cache.length;
 
     // Test 1: add a tab
-    let firstUrl = "data:text/html,one";
+    let firstUrl = "data:text/html;charset=utf-8,one";
     tabBrowser.addTab(firstUrl, {
       onLoad: function(e) {
         let win1 = cache[startWindowCount - 1];
         test.assertEqual(win1.content.location, firstUrl, "URL of new tab in first window matches");
 
         // Test 2: add a tab in a new window
-        let secondUrl = "data:text/html,two";
+        let secondUrl = "data:text/html;charset=utf-8,two";
         tabBrowser.addTab(secondUrl, {
           inNewWindow: true,
           onLoad: function(e) {
@@ -163,7 +163,7 @@ exports.testWhenContentLoaded = function(test) {
 
   openBrowserWindow(function(browserWindow, browser) {
     var html = '<div id="foo">bar</div>';
-    browser.addTab("data:text/html," + html);
+    browser.addTab("data:text/html;charset=utf-8," + html);
   });
 };
 
@@ -214,9 +214,9 @@ exports.testTabTracker = function(test) {
     let tabTracker = tabBrowser.TabTracker(delegate);
 
     let tracked = delegate.tracked;
-    let url1 = "data:text/html,1";
-    let url2 = "data:text/html,2";
-    let url3 = "data:text/html,3";
+    let url1 = "data:text/html;charset=utf-8,1";
+    let url2 = "data:text/html;charset=utf-8,2";
+    let url3 = "data:text/html;charset=utf-8,3";
     let tabCount = 0; 
 
     function tabLoadListener(e) {
@@ -256,8 +256,8 @@ exports.testActiveTab = function(test) {
     const TabModule = require("tab-browser").TabModule;
     let tm = new TabModule(browserWindow);
     test.assertEqual(tm.length, 1);
-    let url1 = "data:text/html,foo";
-    let url2 = "data:text/html,bar";
+    let url1 = "data:text/html;charset=utf-8,foo";
+    let url2 = "data:text/html;charset=utf-8,bar";
 
     function tabURL(tab) tab.ownerDocument.defaultView.content.location.toString()
 
@@ -315,7 +315,7 @@ exports.testEventsAndLengthStayInModule = function(test) {
     tm1.onOpen = function() ++counter1 && onOpenListener();
     tm2.onOpen = function() ++counter2 && onOpenListener();
 
-    let url = "data:text/html,default";
+    let url = "data:text/html;charset=utf-8,default";
     tm1.open(url);
     tm1.open(url);
 
@@ -335,10 +335,10 @@ exports.testTabModuleActiveTab_getterAndSetter = function(test) {
 
     let tab1 = null;
     tm1.open({
-      url: "data:text/html,<title>window1,tab1</title>",
+      url: "data:text/html;charset=utf-8,<title>window1,tab1</title>",
       onOpen: function(tab) tab1 = tab,
     });
-    tm1.open("data:text/html,<title>window1,tab2</title>");
+    tm1.open("data:text/html;charset=utf-8,<title>window1,tab2</title>");
 
     tm1.onActivate = function onActivate() {
       tm1.onActivate.remove(onActivate);
@@ -348,9 +348,9 @@ exports.testTabModuleActiveTab_getterAndSetter = function(test) {
       }, 1000);
     }
 
-    tm2.open("data:text/html,<title>window2,tab1</title>");
+    tm2.open("data:text/html;charset=utf-8,<title>window2,tab1</title>");
     tm2.open({
-      url: "data:text/html,<title>window2,tab2</title>",
+      url: "data:text/html;charset=utf-8,<title>window2,tab2</title>",
       onOpen: function(tab4) {
         test.assertEqual(tm1.activeTab.title, "window1,tab2", "Correct active tab on window 1");
         test.assertEqual(tm2.activeTab.title, "window2,tab2", "Correct active tab on window 2");
@@ -369,7 +369,7 @@ exports.testTabModuleTabsIterator = function(test) {
 
   openBrowserWindow(function(window) {
     let tm1 = new TabModule(window);
-    let url = "data:text/html,default";
+    let url = "data:text/html;charset=utf-8,default";
     tm1.open(url);
     tm1.open(url);
     tm1.open({
@@ -392,7 +392,7 @@ exports.testTabModuleCantOpenInNewWindow = function(test) {
 
   openBrowserWindow(function(window) {
     let tm = new TabModule(window);
-    let url = "data:text/html,default";
+    let url = "data:text/html;charset=utf-8,default";
     tm.open({
       url: url,
       inNewWindow: true,
@@ -414,7 +414,7 @@ exports.testModuleListenersDontInteract = function(test) {
     let tm1 = new TabModule(window);
     let tm2 = new TabModule(window);
 
-    let url = "data:text/html,foo";
+    let url = "data:text/html;charset=utf-8,foo";
     let eventCount = 0, eventModule1 = 0, eventModule2 = 0;
 
     

--- a/packages/api-utils/tests/test-tab-observer.js
+++ b/packages/api-utils/tests/test-tab-observer.js
@@ -20,13 +20,13 @@ exports["test unload tab observer"] = function(assert, done) {
   observer.on("close", function onClose(window) { closed++; });
 
   // Open and close tab to trigger observers.
-  closeTab(openTab(window, "data:text/html,tab-1"));
+  closeTab(openTab(window, "data:text/html;charset=utf-8,tab-1"));
 
   // Unload the module so that all listeners set by observer are removed.
   loader.unload();
 
   // Open and close tab once again.
-  closeTab(openTab(window, "data:text/html,tab-2"));
+  closeTab(openTab(window, "data:text/html;charset=utf-8,tab-2"));
 
   // Enqueuing asserts to make sure that assertion is not performed early.
   setTimeout(function () {

--- a/packages/api-utils/tests/test-tab.js
+++ b/packages/api-utils/tests/test-tab.js
@@ -25,12 +25,12 @@ exports.testGetTabForWindow = function(test) {
 
   let subSubDocument = encodeURIComponent(
     'Sub iframe<br/>'+
-    '<iframe id="sub-sub-iframe" src="data:text/html,SubSubIframe" />');
+    '<iframe id="sub-sub-iframe" src="data:text/html;charset=utf-8,SubSubIframe" />');
   let subDocument = encodeURIComponent(
     'Iframe<br/>'+
-    '<iframe id="sub-iframe" src="data:text/html,'+subSubDocument+'" />');
-  let url = 'data:text/html,' + encodeURIComponent(
-    'Content<br/><iframe id="iframe" src="data:text/html,'+subDocument+'" />');
+    '<iframe id="sub-iframe" src="data:text/html;charset=utf-8,'+subSubDocument+'" />');
+  let url = 'data:text/html;charset=utf-8,' + encodeURIComponent(
+    'Content<br/><iframe id="iframe" src="data:text/html;charset=utf-8,'+subDocument+'" />');
 
   // Open up a new tab in the background.
   //

--- a/packages/api-utils/tests/test-window-utils.js
+++ b/packages/api-utils/tests/test-window-utils.js
@@ -23,7 +23,7 @@ function makeEmptyWindow() {
                   '                 type="text/css"?>' +
                   '<window xmlns="' + xulNs + '" windowtype="test:window">' +
                   '</window>');
-  var url = "data:application/vnd.mozilla.xul+xml," + escape(blankXul);
+  var url = "data:application/vnd.mozilla.xul+xml;charset=utf-8," + escape(blankXul);
   var features = ["chrome", "width=10", "height=10"];
 
   var ww = Cc["@mozilla.org/embedcomp/window-watcher;1"]

--- a/packages/api-utils/tests/test-window-utils2.js
+++ b/packages/api-utils/tests/test-window-utils2.js
@@ -35,13 +35,13 @@ exports['test get nsIXULWindow from nsIDomWindow'] = function(assert) {
 };
 
 exports['test top window creation'] = function(assert) {
-  let window = open('data:text/html,Hello top window');
+  let window = open('data:text/html;charset=utf-8,Hello top window');
   assert.ok(~windows().indexOf(window), 'window was opened');
   window.close();
 };
 
 exports['test new top window with options'] = function(assert) {
-  let window = open('data:text/html,Hi custom top window', {
+  let window = open('data:text/html;charset=utf-8,Hi custom top window', {
     name: 'test',
     features: { height: 100, width: 200, toolbar: true }
   });
@@ -54,7 +54,7 @@ exports['test new top window with options'] = function(assert) {
 };
 
 exports['test backgroundify'] = function(assert) {
-  let window = open('data:text/html,backgroundy');
+  let window = open('data:text/html;charset=utf-8,backgroundy');
   assert.ok(~windows().indexOf(window),
             'window is in the list of windows');
   let backgroundy = backgroundify(window);

--- a/packages/api-utils/tests/test-xpcom.js
+++ b/packages/api-utils/tests/test-xpcom.js
@@ -133,7 +133,7 @@ function testRegister(assert, text) {
                   getService(Ci.nsIIOService);
 
         var channel = ios.newChannel(
-          "data:text/plain," + text,
+          "data:text/plain;charset=utf-8," + text,
           null,
           null
         );

--- a/packages/test-harness/lib/run-tests.js
+++ b/packages/test-harness/lib/run-tests.js
@@ -17,7 +17,7 @@ function runTests(iterations, filter, profileMemory, stopOnError, verbose, exit,
   let msg = 'Running tests...';
   let markup = '<?xml version="1.0"?><window xmlns="' + ns +
                '" windowtype="test:runner"><label>' + msg + '</label></window>';
-  let url = "data:application/vnd.mozilla.xul+xml," + escape(markup);
+  let url = "data:application/vnd.mozilla.xul+xml;charset=utf-8," + escape(markup);
 
 
   var window = ww.openWindow(null, url, "harness", "centerscreen", null);


### PR DESCRIPTION
This changes adds charest for all data URIs and html documents used by SDK to avoid generating lots of errors in the console:

> Error: The character encoding of the HTML document was not declared. The document will render with garbled text in some browser configurations if the document contains characters from outside the US-ASCII range. The character encoding of the page must to be declared in the document or in the transfer protocol.
> Source File: data:text/html,foo
> Line: 0
