### PR TITLE
Fix regression from bug 743359. 

### DIFF
--- a/packages/api-utils/lib/system.js
+++ b/packages/api-utils/lib/system.js
@@ -52,7 +52,7 @@ exports.env = require('./environment').env;
  */
 exports.exit = function exit(code) {
   // This is used by 'cfx' to find out exit code.
-  if ('resultFile' in options) {
+  if ('resultFile' in options && options.resultFile) {
     let mode = PR_WRONLY | PR_CREATE_FILE | PR_TRUNCATE;
     let stream = openFile(options.resultFile, mode);
     let status = code ? 'FAIL' : 'OK';
@@ -66,7 +66,7 @@ exports.exit = function exit(code) {
 
 exports.stdout = new function() {
   let write = dump
-  if ('logFile' in options) {
+  if ('logFile' in options && options.logFile) {
     let mode = PR_WRONLY | PR_CREATE_FILE | PR_APPEND;
     let stream = openFile(options.logFile, mode);
     write = function write(data) {


### PR DESCRIPTION
`logFile` and `resultFile` are always set but may be empty now.

This regression is due to this new code:
https://github.com/mozilla/addon-sdk/pull/428/files#L27R114
