### PR TITLE
Move all 'timer' requires to the top of test files to help prevent setTimeouts from being garbage collected

### DIFF
--- a/packages/addon-kit/tests/test-context-menu.js
+++ b/packages/addon-kit/tests/test-context-menu.js
@@ -6,6 +6,7 @@
 
 let {Cc,Ci} = require("chrome");
 const { Loader } = require('test-harness/loader');
+const timer = require("timer");
 
 // These should match the same constants in the module.
 const ITEM_CLASS = "jetpack-context-menu-item";
@@ -1867,7 +1868,7 @@ TestHelper.prototype = {
     const self = this;
     node.addEventListener(event, function handler(evt) {
       node.removeEventListener(event, handler, useCapture);
-      require("timer").setTimeout(function () {
+      timer.setTimeout(function () {
         try {
           callback.call(self, evt);
         }

--- a/packages/addon-kit/tests/test-hotkeys.js
+++ b/packages/addon-kit/tests/test-hotkeys.js
@@ -7,6 +7,7 @@
 const { Hotkey } = require("hotkeys");
 const { keyDown } = require("dom/events/keys");
 const { Loader } = require('test-harness/loader');
+const timer = require("timer");
 
 exports["test hotkey: function key"] = function(assert, done) {
   var element = require("window-utils").activeBrowserWindow.document.documentElement;
@@ -151,7 +152,7 @@ exports["test hotkey: automatic destroy"] = function(assert, done) {
   // Ensure that the hotkey is really destroyed
   keyDown(element, "accel-shift-x");
   
-  require("timer").setTimeout(function () {
+  timer.setTimeout(function () {
     assert.ok(!called, "Hotkey is destroyed and not called.");
     done();
   }, 0);

--- a/packages/addon-kit/tests/test-page-mod.js
+++ b/packages/addon-kit/tests/test-page-mod.js
@@ -8,6 +8,7 @@ var pageMod = require("page-mod");
 var testPageMod = require("pagemod-test-helpers").testPageMod;
 const { Loader } = require('test-harness/loader');
 const tabs = require("tabs");
+const timer = require("timer");
 
 /* XXX This can be used to delay closing the test Firefox instance for interactive
  * testing or visual inspection. This test is registered first so that it runs
@@ -15,7 +16,7 @@ const tabs = require("tabs");
 exports.delay = function(test) {
   if (false) {
     test.waitUntilDone(60000);
-    require("timer").setTimeout(function() {test.done();}, 4000);
+    timer.setTimeout(function() {test.done();}, 4000);
   } else
     test.pass();
 }

--- a/packages/addon-kit/tests/test-panel.js
+++ b/packages/addon-kit/tests/test-panel.js
@@ -6,6 +6,7 @@ let { Cc, Ci } = require("chrome");
 let panels = require('panel');
 let tests = {}, panels, Panel;
 const { Loader } = require('test-harness/loader');
+const timer = require("timer");
 
 tests.testPanel = function(test) {
   test.waitUntilDone();
@@ -150,7 +151,7 @@ tests.testParentResizeHack = function(test) {
     },
     onShow: function () {
       panel.postMessage('resize');
-      require("timer").setTimeout(function () {
+      timer.setTimeout(function () {
         test.assertEqual(previousWidth,browserWindow.outerWidth,"Size doesn't change by calling resizeTo/By/...");
         test.assertEqual(previousHeight,browserWindow.outerHeight,"Size doesn't change by calling resizeTo/By/...");
         panel.destroy();
@@ -363,7 +364,7 @@ function makeEventOrderTest(options) {
       panel.on(event, function() {
         test.assertEqual(event, expectedEvents.shift());
         if (cb)
-          require("timer").setTimeout(cb, 1);
+          timer.setTimeout(cb, 1);
       });
       return {then: expect};
     }

--- a/packages/addon-kit/tests/test-private-browsing.js
+++ b/packages/addon-kit/tests/test-private-browsing.js
@@ -5,6 +5,7 @@
 let pb = require("private-browsing");
 let {Cc,Ci} = require("chrome");
 const { Loader } = require('test-harness/loader');
+const timer = require("timer");
 
 let pbService;
 // Currently, only Firefox implements the private browsing service.
@@ -90,7 +91,7 @@ if (pbService) {
     // is correctly destroyed
     pb.activate();
     pb.once("start", function onStart() {
-      require("timer").setTimeout(function () {
+      timer.setTimeout(function () {
         test.assert(!called, 
           "First private browsing instance is destroyed and inactive");
 

--- a/packages/addon-kit/tests/test-tabs.js
+++ b/packages/addon-kit/tests/test-tabs.js
@@ -5,6 +5,7 @@
 
 var {Cc,Ci} = require("chrome");
 const { Loader } = require("test-harness/loader");
+const timer = require("timer");
 
 // test tab.activeTab getter
 exports.testActiveTab_getter = function(test) {
@@ -97,7 +98,7 @@ exports.testAutomaticDestroy = function(test) {
     
     // Fire a tab event an ensure that this destroyed tab is inactive
     tabs.once('open', function () {
-      require("timer").setTimeout(function () {
+      timer.setTimeout(function () {
         test.assert(!called, "Unloaded tab module is destroyed and inactive");
         closeBrowserWindow(window, function() test.done());
       }, 0);
@@ -859,7 +860,7 @@ function openBrowserWindow(callback, url) {
         window.removeEventListener("load", onLoad, true);
         let browsers = window.document.getElementsByTagName("tabbrowser");
         try {
-          require("timer").setTimeout(function () {
+          timer.setTimeout(function () {
             callback(window, browsers[0]);
           }, 10);
         } catch (e) { console.exception(e); }

--- a/packages/addon-kit/tests/test-widget.js
+++ b/packages/addon-kit/tests/test-widget.js
@@ -10,6 +10,7 @@ const widgets = require("widget");
 const url = require("url");
 const windowUtils = require("window-utils");
 const tabBrowser = require("tab-browser");
+const timer = require("timer");
 
 exports.testConstructor = function(test) {
   test.waitUntilDone(30000);
@@ -181,7 +182,7 @@ exports.testConstructor = function(test) {
     if (!tests.length)
       test.done();
     else
-      require("timer").setTimeout(tests.shift(), 0);
+      timer.setTimeout(tests.shift(), 0);
   }
   function doneTest() nextTest();
 
@@ -999,7 +1000,7 @@ exports.testNavigationBarWidgets = function testNavigationBarWidgets(test) {
 
 // Helper for calling code at window close
 function closeBrowserWindow(window, callback) {
-  require("timer").setTimeout(function() {
+  timer.setTimeout(function() {
     window.addEventListener("unload", function onUnload() {
       window.removeEventListener("unload", onUnload, false);
       callback();

--- a/packages/api-utils/tests/test-keyboard-observer.js
+++ b/packages/api-utils/tests/test-keyboard-observer.js
@@ -6,6 +6,7 @@
 
 const { keyPress } = require("api-utils/dom/events/keys");
 const { Loader } = require("test-harness/loader");
+const timer = require("timer");
 
 exports["test unload keyboard observer"] = function(assert, done) {
   let loader = Loader(module);
@@ -27,7 +28,7 @@ exports["test unload keyboard observer"] = function(assert, done) {
   keyPress(element, "accel-%");
 
   // Enqueuing asserts to make sure that assertion is not performed early.
-  require("timer").setTimeout(function () {
+  timer.setTimeout(function () {
     assert.equal(called, 1, "observer was called before unload only.");
     done();
   }, 0);

--- a/packages/api-utils/tests/test-tab-browser.js
+++ b/packages/api-utils/tests/test-tab-browser.js
@@ -10,7 +10,7 @@ function onBrowserLoad(callback, event) {
     this.removeEventListener("load", onBrowserLoad, true);
     let browsers = this.document.getElementsByTagName("tabbrowser");
     try {
-      require("timer").setTimeout(function (window) {
+      timer.setTimeout(function (window) {
         callback(window, browsers[0]);
       }, 10, this);
     } catch (e) { console.exception(e); }
@@ -33,7 +33,7 @@ function openBrowserWindow(callback, url) {
 
 // Helper for calling code at window close
 function closeBrowserWindow(window, callback) {
-  require("timer").setTimeout(function() {
+  timer.setTimeout(function() {
     window.addEventListener("unload", function onUnload() {
       window.removeEventListener("unload", onUnload, false);
       callback();
@@ -119,7 +119,7 @@ exports.testTrackerWithDelegate = function(test) {
       }
       else if (this.state == "waiting for browser window to open") {
         this.state = "waiting for browser window to close";
-        require("timer").setTimeout(function() {
+        timer.setTimeout(function() {
           closeBrowserWindow(browser.ownerDocument.defaultView, function() {
             test.assertEqual(delegate.state, "deinitializing");
             tb.unload();
@@ -232,7 +232,7 @@ exports.testTabTracker = function(test) {
         test.assertEqual(delegate.tracked, tracked + 3, "delegate tracked tabs matched count");
         tabTracker.unload();
         closeBrowserWindow(browserWindow, function() {
-          require("timer").setTimeout(function() test.done(), 0);
+          timer.setTimeout(function() test.done(), 0);
         });
       }
     }
@@ -342,7 +342,7 @@ exports.testTabModuleActiveTab_getterAndSetter = function(test) {
 
     tm1.onActivate = function onActivate() {
       tm1.onActivate.remove(onActivate);
-      require("timer").setTimeout(function() {
+      timer.setTimeout(function() {
         test.assertEqual(tm1.activeTab.title, "window1,tab1", "activeTab setter works");
         closeTwoWindows(window1, window2, function() test.done());
       }, 1000);

--- a/packages/api-utils/tests/test-window-observer.js
+++ b/packages/api-utils/tests/test-window-observer.js
@@ -5,6 +5,7 @@
 "use strict";
 
 const { Loader } = require("test-harness/loader");
+const timer = require("timer");
 
 exports["test unload window observer"] = function(assert, done) {
   // Hacky way to be able to create unloadable modules via makeSandboxedLoader.
@@ -38,7 +39,7 @@ exports["test unload window observer"] = function(assert, done) {
   activeWindow.open().close();
 
   // Enqueuing asserts to make sure that assertion is not performed early.
-  require("timer").setTimeout(function () {
+  timer.setTimeout(function () {
     assert.equal(1, opened, "observer open was called before unload only");
     assert.equal(1, closed, "observer close was called before unload only");
     done();


### PR DESCRIPTION
From IRC between me and Philor:

10:22:54 PM - KWierso: philor: so on aurora, win debug's results are always orange, and they all seem to be the same issue: https://tbpl.mozilla.org/?noignore=1&tree=Mozilla-Aurora&jobname=jetpack
10:47:05 PM - philor: I _think_ maybe what that means is that you aren't protecting your timer against GC
10:50:08 PM - philor: having a setTimeout(0) get GCed before it fires is pretty awesome, but that's where you would be, and it's dead
11:05:30 PM - KWierso: philor: how does one protect against that?
11:06:50 PM - philor: there was a big push to put getting the timer service at the top level, not inside a function, in mochitests I think, because otherwise the timer could go away, that's the extent of my knowledge

So this pull request moves all instances of require("timer") to the top of the file so it's not wrapped inside a function. Hopefully this would prevent the random and/or almost-constant timeouts from occurring.
