### PR TITLE
Bug 764866: Avoid leaking all modules when one goes wrong and keep the loader alive.

### DIFF
--- a/packages/api-utils/tests/test-window-utils.js
+++ b/packages/api-utils/tests/test-window-utils.js
@@ -69,6 +69,7 @@ exports['test close on unload'] = function(assert) {
                    "unload event listener removed on module unload");
 
   timesClosed = 0;
+  loader = Loader(module);
   loader.require("window-utils").closeOnUnload(fakeWindow);
   assert.equal(timesClosed, 0,
                    "window not closed when registered.");

--- a/python-lib/cuddlefish/app-extension/bootstrap.js
+++ b/python-lib/cuddlefish/app-extension/bootstrap.js
@@ -22,6 +22,7 @@ const REASON = [ 'unknown', 'startup', 'shutdown', 'enable', 'disable',
 let loader = null;
 let unload = null;
 let cuddlefishURI = null;
+let nukeTimer = null;
 
 // Utility function that synchronously reads local resource from the given
 // `uri` and returns content string.
@@ -186,13 +187,41 @@ function startup(data, reasonCode) {
   }
 };
 
+function setTimeout(callback, delay) {
+  let timer = Cc["@mozilla.org/timer;1"].createInstance(Ci.nsITimer);
+  timer.initWithCallback({ notify: callback }, delay,
+                         Ci.nsITimer.TYPE_ONE_SHOT);
+  return timer;
+}
+
 function shutdown(data, reasonCode) {
   let reason = REASON[reasonCode];
   if (loader) {
     unload(loader, reason);
+    unload = null;
     // Bug 724433: We need to unload JSM otherwise it will stay alive
     // and keep a reference to this compartment.
     Cu.unload(cuddlefishURI);
-    loader = unload = null;
+    // Avoid leaking all modules when something goes wrong with one particular
+    // module. Do not clean it up immadiatly in order to allow executing some
+    // actions on addon disabling.
+    // We need to keep a reference to the timer, otherwise it is collected
+    // and won't ever fire.
+    nukeTimer = setTimeout(nukeModules, 1000);
   }
 };
+
+function nukeModules() {
+  nukeTimer = null;
+  // module objects store `exports` which comes from sandboxes
+  // We should avoid keeping link to these object to avoid leaking sandboxes
+  for (let key in loader.modules) {
+    delete loader.modules[key];
+  }
+  // Direct links to sandboxes should be removed too
+  for (let key in loader.sandboxes) {
+    let sandbox = loader.sandboxes[key];
+    delete loader.sandboxes[key];
+  }
+  loader = null;
+}


### PR DESCRIPTION
See bug for more information:

https://bugzilla.mozilla.org/show_bug.cgi?id=764866
