### PR TITLE
Updated runner.js with a better observer's topic for Fennec.

### DIFF
--- a/packages/api-utils/lib/addon/runner.js
+++ b/packages/api-utils/lib/addon/runner.js
@@ -14,7 +14,7 @@ const globals = require('../globals');
 
 const NAME2TOPIC = {
   'Firefox': 'sessionstore-windows-restored',
-  'Fennec' : 'sessionstore-windows-restored',
+  'Fennec': 'sessionstore-windows-restored',
   'SeaMonkey': 'sessionstore-windows-restored',
   'Thunderbird': 'mail-startup-done',
   '*': 'final-ui-startup'


### PR DESCRIPTION
Earlier versions of Fennec NativeUI didn't fire `sessionstore-windows-restored` therefore `final-ui-startup` was used.
That caused some trouble with windows related functionality at startup, like windows mediator.
