### PR TITLE
Bug 764840: Fix loader.js JSM leak.

### DIFF
--- a/packages/api-utils/lib/cuddlefish.js
+++ b/packages/api-utils/lib/cuddlefish.js
@@ -12,6 +12,9 @@
     factory(function require(uri) {
       var imports = {};
       this['Components'].utils.import(uri, imports);
+      // Bug 764840: Immediatly unload this JSM in order to avoid leaking it on
+      // addon disabling.
+      this['Components'].utils.unload(uri);
       return imports;
     }, this, { uri: __URI__, id: id });
     this.EXPORTED_SYMBOLS = Object.keys(this);


### PR DESCRIPTION
I sent an empty branch to previous PR #465 that closed it. So here is a new one.
You are right, we can make it way more simplier.
We can safely unload the JSM right after loading it.
It basically just remove one strong reference from the JSM cache to the JSM global object.
This reference prevent from collecting the whole JSM on addon disabling,
but doesn't force any other reference to be collected.
So that any existing reference to the JSM or any object from it would still work.

https://bugzilla.mozilla.org/show_bug.cgi?id=764840
