### PR TITLE
Prevent leaking sandboxes by using Cu.nukeSandbox.

### DIFF
--- a/python-lib/cuddlefish/app-extension/bootstrap.js
+++ b/python-lib/cuddlefish/app-extension/bootstrap.js
@@ -222,6 +222,9 @@ function nukeModules() {
   for (let key in loader.sandboxes) {
     let sandbox = loader.sandboxes[key];
     delete loader.sandboxes[key];
+    // Bug 775067: From FF17 we can kill all CCW from a given sandbox
+    if ("nukeSandbox" in Cu)
+      Cu.nukeSandbox(sandbox);
   }
   loader = null;
 }


### PR DESCRIPTION
**Not meant to be reviewed immediatly**

This patch is on top of PR #464

We should wait for platform bug to be r+ before landing this patch.
Currently it only call this method to module sandboxes, but we would like to call it for cuddlefish.js and loader.js too.

https://bugzilla.mozilla.org/show_bug.cgi?id=769273
