### PR TITLE
Bug 769483: Fix exception when using data:URI documents instanciated with nsIDOMParser.

### DIFF
--- a/packages/api-utils/lib/l10n/html.js
+++ b/packages/api-utils/lib/l10n/html.js
@@ -46,6 +46,11 @@ function onContentWindow(event) {
   if (!(document instanceof Ci.nsIDOMHTMLDocument))
     return;
 
+  // Bug 769483: data:URI documents instanciated with nsIDOMParser
+  // have a null `location` attribute at this time
+  if (!document.location)
+    return;
+
   // Accept only document from this addon
   if (document.location.href.indexOf(assetsURI) !== 0)
     return;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=769483
