### PR TITLE
request.md: add a missing .get()

### DIFF
--- a/packages/addon-kit/docs/request.md
+++ b/packages/addon-kit/docs/request.md
@@ -41,7 +41,7 @@ The example below shows how to use Request to get the most recent public tweet.
         console.log("User: " + tweet.user.screen_name);
         console.log("Tweet: " + tweet.text);
       }
-    });
+    }).get();
 
     // Be a good consumer and check for rate limiting before doing more.
     Request({


### PR DESCRIPTION
I could be wrong, but I think the first example in request.md won't actually do anything, since it's missing a .get() at the end
