### PR TITLE
Add missing license header which broke all tests.

### DIFF
--- a/packages/api-utils/lib/l10n/core.js
+++ b/packages/api-utils/lib/l10n/core.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // Following pseudo module is set by `api-utils/addon/runner` and its load
 // method needs to be called before loading `core` module. But it may have
 // failed, so that this pseudo won't be available


### PR DESCRIPTION
Introduced by PR #409
