### PR TITLE
Bug 774636: reject all usages of `Components` in favor of require(chrome)

### DIFF
--- a/packages/addon-kit/tests/test-context-menu.js
+++ b/packages/addon-kit/tests/test-context-menu.js
@@ -474,7 +474,7 @@ exports.testContentContextArgs = function (test) {
   let item = new loader.cm.Item({
     label: "item",
     contentScript: 'self.on("context", function (node) {' +
-                   '  let Ci = Components.interfaces;' +
+                   '  let Ci = Components["interfaces"];' +
                    '  self.postMessage(node instanceof Ci.nsIDOMHTMLElement);' +
                    '  return false;' +
                    '});',
@@ -886,7 +886,7 @@ exports.testItemClick = function (test) {
     label: "item",
     data: "item data",
     contentScript: 'self.on("click", function (node, data) {' +
-                   '  let Ci = Components.interfaces;' +
+                   '  let Ci = Components["interfaces"];' +
                    '  self.postMessage({' +
                    '    isElt: node instanceof Ci.nsIDOMHTMLElement,' +
                    '    data: data' +
@@ -932,7 +932,7 @@ exports.testMenuClick = function (test) {
   let topMenu = new loader.cm.Menu({
     label: "top menu",
     contentScript: 'self.on("click", function (node, data) {' +
-                   '  let Ci = Components.interfaces;' +
+                   '  let Ci = Components["interfaces"];' +
                    '  self.postMessage({' +
                    '    isAnchor: node instanceof Ci.nsIDOMHTMLAnchorElement,' +
                    '    data: data' +

--- a/packages/addon-kit/tests/test-selection.js
+++ b/packages/addon-kit/tests/test-selection.js
@@ -392,7 +392,7 @@ exports.testIteratorWithTextareaSelection =
 
 /*
 function sendSelectionSetEvent(window) {
-  const Ci = Components.interfaces;
+  const Ci = Components['interfaces'];
   let utils = window.QueryInterface(Ci.nsIInterfaceRequestor).
                                     getInterface(Ci.nsIDOMWindowUtils);
   if (!utils.sendSelectionSetEvent(0, 1, false))

--- a/packages/api-utils/lib/content/content-proxy.js
+++ b/packages/api-utils/lib/content/content-proxy.js
@@ -5,13 +5,12 @@
 "use strict";
 
 /* Trick the linker in order to avoid error on `Components.interfaces` usage.
-   We are tricking the linking with `require('./content-proxy.js')` in order
-   to ensure shipping it! But then the linker think that this file is going
-   to be used as a CommonJS module where we forbid usage of `Components`.
-   We only allow usage of it through `require('chrome')`:
-  require("chrome");
+   We are tricking the linker with `require('./content-proxy.js')` from
+   worjer.js in order to ensure shipping this file! But then the linker think
+   that this file is going to be used as a CommonJS module where we forbid usage
+   of `Components`.
 */
-let Ci = Components.interfaces;
+let Ci = Components['interfaces'];
 
 /**
  * Access key that allows privileged code to unwrap proxy wrappers through 

--- a/python-lib/cuddlefish/__init__.py
+++ b/python-lib/cuddlefish/__init__.py
@@ -636,7 +636,8 @@ def run(arguments=sys.argv[1:], target_cfg=None, pkg_cfg=None,
 
     deps = packaging.get_deps_for_targets(pkg_cfg, targets)
 
-    from cuddlefish.manifest import build_manifest, ModuleNotFoundError
+    from cuddlefish.manifest import build_manifest, ModuleNotFoundError, \
+                                    BadChromeMarkerError
     # Figure out what loader files should be scanned. This is normally
     # computed inside packaging.generate_build_for_target(), by the first
     # dependent package that defines a "loader" property in its package.json.
@@ -666,6 +667,9 @@ def run(arguments=sys.argv[1:], target_cfg=None, pkg_cfg=None,
                                   loader_modules)
     except ModuleNotFoundError, e:
         print str(e)
+        sys.exit(1)
+    except BadChromeMarkerError, e:
+        # An error had already been displayed on stderr in manifest code
         sys.exit(1)
     used_deps = manifest.get_used_packages()
     if command == "test":

--- a/python-lib/cuddlefish/manifest.py
+++ b/python-lib/cuddlefish/manifest.py
@@ -694,16 +694,10 @@ line somewhat like the following:
 
   const {%(needs)s} = require("chrome");
 
-Then you can use 'Components' as well as any shortcuts to its properties
-that you import from the 'chrome' module ('Cc', 'Ci', 'Cm', 'Cr', and
-'Cu' for the 'classes', 'interfaces', 'manager', 'results', and 'utils'
-properties, respectively).
-
-(Note: once bug 636145 is fixed, to access 'Components' directly you'll
-need to retrieve it from the 'chrome' module by adding it to the list of
-symbols you import from the module. To avoid having to make this change
-in the future, replace all occurrences of 'Components' in your code with
-the equivalent shortcuts now.)
+Then you can use any shortcuts to its properties that you import from the
+'chrome' module ('Cc', 'Ci', 'Cm', 'Cr', and 'Cu' for the 'classes',
+'interfaces', 'manager', 'results', and 'utils' properties, respectively. And
+`components` for `Components` object itself).
 """ % { "fn": fn, "needs": ",".join(sorted(old_chrome)),
         "lines": "\n".join([" %3d: %s" % (lineno,line)
                             for (lineno, line) in old_chrome_lines]),
@@ -716,10 +710,6 @@ def scan_module(fn, lines, stderr=sys.stderr):
     requires, locations = scan_requirements_with_grep(fn, lines)
     if filename == "cuddlefish.js":
         # this is the loader: don't scan for chrome
-        problems = False
-    elif "chrome" in requires:
-        # if they declare require("chrome"), we tolerate the use of
-        # Components (see bug 663541 for rationale)
         problems = False
     else:
         problems = scan_for_bad_chrome(fn, lines, stderr)


### PR DESCRIPTION
I had to modify some files with usages of Components but non of them was real usage of it, i.e. from a CommonJS module. So I just modify them to avoid error in cfx.

So this patch reject Components usage, even if the module uses `require("chrome")`.

https://bugzilla.mozilla.org/show_bug.cgi?id=774636
