### PR TITLE
Bug 773723 - Make `define` and `console` configurable so it can be redefined in module scope.

### DIFF
--- a/packages/api-utils/lib/globals!.js
+++ b/packages/api-utils/lib/globals!.js
@@ -60,21 +60,11 @@ Object.defineProperty(exports, 'define', {
   // function to the module scope, so that require, exports and module
   // variables remain accessible.
   configurable: true,
-  get: (function() {
-    function define(factory) {
+  get: function() {
+    let sandbox = this;
+    return function define(factory) {
       factory = Array.slice(arguments).pop();
-      factory.call(this, this.require, this.exports, this.module);
+      factory.call(sandbox, sandbox.require, sandbox.exports, sandbox.module);
     }
-
-    return function getter() {
-      // Redefine `define` as a static property to make sure that module
-      // gets access to the same function so that `define === define` is
-      // `true`.
-      Object.defineProperty(this, 'define', {
-        configurable: false,
-        value: define.bind(this)
-      });
-      return this.define;
-    }
-  })()
+  }
 });

--- a/packages/test-harness/lib/harness.js
+++ b/packages/test-harness/lib/harness.js
@@ -313,8 +313,10 @@ var runTests = exports.runTests = function runTests(options) {
       // Copy globals to fresh object (as globals will be frozen and can't be
       // overridden. And then we override, global console to expose one designed
       // for tests.
-      globals: override(override({}, globals), {
-        console: new TestRunnerConsole(new ptc.PlainTextConsole(print), options)
+      globals: Object.create(override({}, globals), {
+        console: {
+          value: new TestRunnerConsole(new ptc.PlainTextConsole(print), options)
+        }
       })
     }));
 


### PR DESCRIPTION
This backports fix from #490 and some other changes that were made to a loader. That being said while it solves this issues there are still bunch of test failures in Aurora so I'm not sure it's even worth including.
