### PR TITLE
removing some unnecessary code in api-utils/windows/observer

### DIFF
--- a/packages/api-utils/lib/windows/observer.js
+++ b/packages/api-utils/lib/windows/observer.js
@@ -46,8 +46,4 @@ WindowTracker({
   }
 });
 
-// Making observer aware of already opened windows.
-for each (let window in windowIterator())
-  observer.observe(window);
-
 exports.observer = observer;


### PR DESCRIPTION
@Gozala I didn't make a bug for this, let me know if I should.  The code I am removing is harmless I think, because the `handleEvent` isn't being called twice afaict from testing, but the code does appear to be unnecessary.

I'm guessing that some deeper internal code is smartly not emitting the same event on the same object's `handleEvent`, because that would be pointless.
