### PR TITLE
temporary mitigation of bug 551604

### DIFF
--- a/packages/api-utils/lib/loader.js
+++ b/packages/api-utils/lib/loader.js
@@ -166,7 +166,7 @@ const evaluate = iced(function evaluate(sandbox, uri, options) {
   try {
     return source ? Cu.evalInSandbox(source, sandbox, version, uri, line)
                   : loadSubScript(uri, sandbox, encoding);
-  } catch (exc if exc instanceof SyntaxError) {
+  } catch (exc if exc.name === "SyntaxError") {
     // see https://bugzilla.mozilla.org/show_bug.cgi?id=551604
     throw SyntaxError(exc.message+' at '+exc.fileName+':'+exc.lineNumber,
                       exc.fileName, exc.lineNumber);


### PR DESCRIPTION
The file name and line number _are_ included the `SyntaxError` object thrown from `require()`. The problem is that the information isn't included in the stack trace nor in the error message. This commit appends that info to the error message. It's sort of a hack, but it gets the job done for now and will hold until something better is implemented.
