### PR TITLE
Bug 787072 - Add `module.metadata` with `stability` flags to SDK modules

### DIFF
--- a/packages/api-utils/lib/addon/installer.js
+++ b/packages/api-utils/lib/addon/installer.js
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+module.metadata = {
+  "stability": "experimental"
+};
+
 const { Cc, Ci, Cu } = require("chrome");
 const { AddonManager } = Cu.import("resource://gre/modules/AddonManager.jsm");
 const { defer } = require("api-utils/promise");

--- a/packages/api-utils/lib/addon/runner.js
+++ b/packages/api-utils/lib/addon/runner.js
@@ -4,6 +4,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+module.metadata = {
+  "stability": "experimental"
+};
+
 const { Cc, Ci } = require('chrome');
 const { descriptor, Sandbox, evaluate, main, resolveURI } = require('api-utils/loader');
 const { once } = require('../system/events');

--- a/packages/api-utils/lib/api-utils.js
+++ b/packages/api-utils/lib/api-utils.js
@@ -6,6 +6,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "deprecated"
+};
+
 const memory = require("api-utils/memory");
 // The possible return values of getTypeOf.
 const VALID_TYPES = [

--- a/packages/api-utils/lib/app-strings.js
+++ b/packages/api-utils/lib/app-strings.js
@@ -4,6 +4,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "deprecated"
+};
+
 const {Cc,Ci} = require("chrome");
 const apiUtils = require("./api-utils");
 

--- a/packages/api-utils/lib/array.js
+++ b/packages/api-utils/lib/array.js
@@ -5,6 +5,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "experimental"
+};
+
 /**
  * Returns `true` if given `array` contain given `element` or `false`
  * otherwise.

--- a/packages/api-utils/lib/base64.js
+++ b/packages/api-utils/lib/base64.js
@@ -4,6 +4,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { Cu } = require("chrome");
 
 // If an object is not given as second argument, the JavaScript Module scope is

--- a/packages/api-utils/lib/byte-streams.js
+++ b/packages/api-utils/lib/byte-streams.js
@@ -6,6 +6,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "experimental"
+};
+
 exports.ByteReader = ByteReader;
 exports.ByteWriter = ByteWriter;
 

--- a/packages/api-utils/lib/collection.js
+++ b/packages/api-utils/lib/collection.js
@@ -6,6 +6,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "experimental"
+};
+
 exports.Collection = Collection;
 
 /**

--- a/packages/api-utils/lib/content.js
+++ b/packages/api-utils/lib/content.js
@@ -5,6 +5,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 exports.Loader = require('./content/loader').Loader;
 exports.Symbiont = require('./content/symbiont').Symbiont;
 exports.Worker = require('./content/worker').Worker;

--- a/packages/api-utils/lib/content/loader.js
+++ b/packages/api-utils/lib/content/loader.js
@@ -6,6 +6,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { EventEmitter } = require('../events');
 const { validateOptions } = require('../api-utils');
 const { URL } = require('../url');

--- a/packages/api-utils/lib/content/symbiont.js
+++ b/packages/api-utils/lib/content/symbiont.js
@@ -5,6 +5,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { Worker } = require('./worker');
 const { Loader } = require('./loader');
 const hiddenFrames = require('../hidden-frame');

--- a/packages/api-utils/lib/content/worker.js
+++ b/packages/api-utils/lib/content/worker.js
@@ -5,6 +5,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { Trait } = require('../traits');
 const { EventEmitter, EventEmitterTrait } = require('../events');
 const { Ci, Cu, Cc } = require('chrome');

--- a/packages/api-utils/lib/cortex.js
+++ b/packages/api-utils/lib/cortex.js
@@ -5,6 +5,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "deprecated"
+};
+
 // `var` is being used in the module in order to make it reusable in
 // environments in which `let` and `const` is not yet supported.
 

--- a/packages/api-utils/lib/cuddlefish.js
+++ b/packages/api-utils/lib/cuddlefish.js
@@ -25,6 +25,10 @@
 
 'use strict';
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 /* Workarounds to include dependencies in the manifest
 require('chrome')                 // Otherwise CFX will complain about Components
 require('api-utils/loader')       // Otherwise CFX will stip out loader.js

--- a/packages/api-utils/lib/dom/events.js
+++ b/packages/api-utils/lib/dom/events.js
@@ -5,6 +5,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 // Utility function that returns copy of the given `text` with last character
 // removed if it is `"s"`.
 function singularify(text) {

--- a/packages/api-utils/lib/dom/events/keys.js
+++ b/packages/api-utils/lib/dom/events/keys.js
@@ -5,6 +5,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { emit } = require("../events");
 const { getCodeForKey, toJSON } = require("../../keyboard/utils");
 const { has } = require("../../array");

--- a/packages/api-utils/lib/environment.js
+++ b/packages/api-utils/lib/environment.js
@@ -5,6 +5,10 @@
 
 'use strict';
 
+module.metadata = {
+  "stability": "stable"
+};
+
 const { Cc, Ci } = require('chrome');
 const { get, set, exists } = Cc['@mozilla.org/process/environment;1'].
                              getService(Ci.nsIEnvironment);

--- a/packages/api-utils/lib/errors.js
+++ b/packages/api-utils/lib/errors.js
@@ -4,6 +4,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "deprecated"
+};
+
 function logToConsole(e) {
   console.exception(e);
 }

--- a/packages/api-utils/lib/event/core.js
+++ b/packages/api-utils/lib/event/core.js
@@ -6,6 +6,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const UNCAUGHT_ERROR = 'An error event was emitted for which there was no listener.';
 const BAD_LISTENER = 'The event listener must be a function.';
 

--- a/packages/api-utils/lib/event/target.js
+++ b/packages/api-utils/lib/event/target.js
@@ -6,6 +6,10 @@
 
 'use strict';
 
+module.metadata = {
+  "stability": "stable"
+};
+
 const { on, once, off } = require('./core');
 const { method } = require('../functional');
 const { Class } = require('../heritage');

--- a/packages/api-utils/lib/events.js
+++ b/packages/api-utils/lib/events.js
@@ -4,6 +4,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "deprecated"
+};
+
 const ERROR_TYPE = 'error',
       UNCAUGHT_ERROR = 'An error event was dispatched for which there was'
         + ' no listener.',

--- a/packages/api-utils/lib/file.js
+++ b/packages/api-utils/lib/file.js
@@ -4,6 +4,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "experimental"
+};
+
 const {Cc,Ci,Cr} = require("chrome");
 const byteStreams = require("./byte-streams");
 const textStreams = require("./text-streams");

--- a/packages/api-utils/lib/frame/utils.js
+++ b/packages/api-utils/lib/frame/utils.js
@@ -4,6 +4,10 @@
 
 'use strict';
 
+module.metadata = {
+  "stability": "experimental"
+};
+
 const XUL = 'http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul';
 
 /**

--- a/packages/api-utils/lib/functional.js
+++ b/packages/api-utils/lib/functional.js
@@ -8,6 +8,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { setTimeout } = require("./timer");
 
 /**

--- a/packages/api-utils/lib/globals.js
+++ b/packages/api-utils/lib/globals.js
@@ -5,6 +5,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 let { Cc, Ci, CC } = require('chrome');
 let { PlainTextConsole } = require('./plain-text-console');
 let { stdout } = require('api-utils/system');

--- a/packages/api-utils/lib/heritage.js
+++ b/packages/api-utils/lib/heritage.js
@@ -6,6 +6,10 @@
 
 'use strict';
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 var getPrototypeOf = Object.getPrototypeOf;
 var getNames = Object.getOwnPropertyNames;
 var getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;

--- a/packages/api-utils/lib/hidden-frame.js
+++ b/packages/api-utils/lib/hidden-frame.js
@@ -6,6 +6,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "experimental"
+};
+
 const {Cc, Ci} = require("chrome");
 const errors = require("./errors");
 const apiUtils = require("./api-utils");

--- a/packages/api-utils/lib/httpd.js
+++ b/packages/api-utils/lib/httpd.js
@@ -10,6 +10,9 @@
 * httpd.js.
 */
 
+module.metadata = {
+  "stability": "experimental"
+};
 
 const { components, CC, Cc, Ci, Cr, Cu } = require("chrome");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");

--- a/packages/api-utils/lib/keyboard/hotkeys.js
+++ b/packages/api-utils/lib/keyboard/hotkeys.js
@@ -5,6 +5,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { observer: keyboardObserver } = require("./observer");
 const { getKeyForCode, normalize, isFunctionKey,
         MODIFIERS } = require("./utils");

--- a/packages/api-utils/lib/keyboard/observer.js
+++ b/packages/api-utils/lib/keyboard/observer.js
@@ -5,6 +5,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { Trait } = require("../light-traits");
 const { EventEmitterTrait: EventEmitter } = require("../events");
 const { DOMEventAssembler } = require("../events/assembler");

--- a/packages/api-utils/lib/keyboard/utils.js
+++ b/packages/api-utils/lib/keyboard/utils.js
@@ -5,6 +5,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { Cc, Ci } = require("chrome");
 const runtime = require("../runtime");
 const { isString } = require("../type");

--- a/packages/api-utils/lib/l10n/core.js
+++ b/packages/api-utils/lib/l10n/core.js
@@ -5,6 +5,12 @@
 // Following pseudo module is set by `api-utils/addon/runner` and its load
 // method needs to be called before loading `core` module. But it may have
 // failed, so that this pseudo won't be available
+
+module.metadata = {
+  "stability": "unstable"
+};
+
+
 let hash = {}, bestMatchingLocale = null;
 try {
   let data = require("@l10n/data");

--- a/packages/api-utils/lib/l10n/html.js
+++ b/packages/api-utils/lib/l10n/html.js
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { Ci } = require("chrome");
 const events = require("api-utils/system/events");
 const core = require("api-utils/l10n/core");

--- a/packages/api-utils/lib/l10n/loader.js
+++ b/packages/api-utils/lib/l10n/loader.js
@@ -1,7 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 "use strict";
+
+module.metadata = {
+  "stability": "unstable"
+};
 
 const { Cc, Ci } = require("chrome");
 const { getPreferedLocales, findClosestLocale } = require("api-utils/l10n/locale");

--- a/packages/api-utils/lib/l10n/locale.js
+++ b/packages/api-utils/lib/l10n/locale.js
@@ -3,6 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const prefs = require("preferences-service");
 const { Cu, Cc, Ci } = require("chrome");
 const { Services } = Cu.import("resource://gre/modules/Services.jsm");

--- a/packages/api-utils/lib/l10n/plural-rules.js
+++ b/packages/api-utils/lib/l10n/plural-rules.js
@@ -6,6 +6,11 @@
 // Fetching data from: http://unicode.org/repos/cldr/trunk/common/supplemental/plurals.xml
 
 // Mapping of short locale name == to == > rule index in following list
+
+module.metadata = {
+  "stability": "unstable"
+};
+
 const LOCALES_TO_RULES = {
   "af": 3, 
   "ak": 4, 

--- a/packages/api-utils/lib/light-traits.js
+++ b/packages/api-utils/lib/light-traits.js
@@ -5,6 +5,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "deprecated"
+};
+
 // `var` is being used in the module in order to make it reusable in
 // environments in which `let` is not yet supported.
 

--- a/packages/api-utils/lib/list.js
+++ b/packages/api-utils/lib/list.js
@@ -3,6 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
+module.metadata = {
+  "stability": "experimental"
+};
+
 const { Trait } = require('./traits');
 
 /**

--- a/packages/api-utils/lib/loader.js
+++ b/packages/api-utils/lib/loader.js
@@ -25,6 +25,10 @@
 
 'use strict';
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { classes: Cc, Constructor: CC, interfaces: Ci, utils: Cu,
         results: Cr, manager: Cm } = Components;
 const systemPrincipal = CC('@mozilla.org/systemprincipal;1', 'nsIPrincipal')();

--- a/packages/api-utils/lib/match-pattern.js
+++ b/packages/api-utils/lib/match-pattern.js
@@ -5,6 +5,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 "use strict";
+
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { URL } = require("./url");
 
 exports.MatchPattern = MatchPattern;

--- a/packages/api-utils/lib/memory.js
+++ b/packages/api-utils/lib/memory.js
@@ -4,6 +4,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "deprecated"
+};
+
 const {Cc,Ci,Cu,components} = require("chrome");
 var trackedObjects = {};
 

--- a/packages/api-utils/lib/namespace.js
+++ b/packages/api-utils/lib/namespace.js
@@ -4,6 +4,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const create = Object.create;
 const prototypeOf = Object.getPrototypeOf;
 

--- a/packages/api-utils/lib/observer-service.js
+++ b/packages/api-utils/lib/observer-service.js
@@ -4,6 +4,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "deprecated"
+};
+
 const { Cc, Ci } = require("chrome");
 const { when: unload } = require("./unload");
 const { ns } = require("./namespace");

--- a/packages/api-utils/lib/passwords/utils.js
+++ b/packages/api-utils/lib/passwords/utils.js
@@ -5,6 +5,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { Cc, Ci, CC } = require("chrome");
 const { uri: ADDON_URI } = require("self");
 const loginManager = Cc["@mozilla.org/login-manager;1"].

--- a/packages/api-utils/lib/plain-text-console.js
+++ b/packages/api-utils/lib/plain-text-console.js
@@ -4,6 +4,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const {Cc,Ci} = require("chrome");
 const self = require("self");
 

--- a/packages/api-utils/lib/preferences-service.js
+++ b/packages/api-utils/lib/preferences-service.js
@@ -4,6 +4,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 // The minimum and maximum integers that can be set as preferences.
 // The range of valid values is narrower than the range of valid JS values
 // because the native preferences code treats integers as NSPR PRInt32s,

--- a/packages/api-utils/lib/prefs/target.js
+++ b/packages/api-utils/lib/prefs/target.js
@@ -4,6 +4,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { Cc, Ci } = require("chrome");
 const { Class } = require('api-utils/heritage');
 const { EventTarget } = require('api-utils/event/target');

--- a/packages/api-utils/lib/private-browsing/utils.js
+++ b/packages/api-utils/lib/private-browsing/utils.js
@@ -4,6 +4,10 @@
 
 'use strict';
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { Cc, Ci } = require('chrome');
 const { defer } = require('api-utils/functional');
 const observers = require('api-utils/observer-service');

--- a/packages/api-utils/lib/promise.js
+++ b/packages/api-utils/lib/promise.js
@@ -24,6 +24,10 @@
 
 'use strict';
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 function resolution(value) {
   /**
   Returns non-standard compliant (`then` does not returns a promise) promise

--- a/packages/api-utils/lib/querystring.js
+++ b/packages/api-utils/lib/querystring.js
@@ -4,6 +4,10 @@
 
 'use strict';
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 let unescape = decodeURIComponent;
 exports.unescape = unescape;
 

--- a/packages/api-utils/lib/runtime.js
+++ b/packages/api-utils/lib/runtime.js
@@ -5,6 +5,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { Cc, Ci } = require("chrome");
 const runtime = Cc["@mozilla.org/xre/app-info;1"].getService(Ci.nsIXULRuntime);
 

--- a/packages/api-utils/lib/sandbox.js
+++ b/packages/api-utils/lib/sandbox.js
@@ -5,6 +5,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
+module.metadata = {
+  "stability": "experimental"
+};
+
 const { Cc, Ci, CC, Cu } = require('chrome');
 const systemPrincipal = CC('@mozilla.org/systemprincipal;1', 'nsIPrincipal')();
 const scriptLoader = Cc['@mozilla.org/moz/jssubscript-loader;1'].

--- a/packages/api-utils/lib/system.js
+++ b/packages/api-utils/lib/system.js
@@ -5,6 +5,10 @@
 
 'use strict';
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { Cc, Ci, CC } = require('chrome');
 const options = require('@loader/options');
 const file = require('./file');

--- a/packages/api-utils/lib/system/events.js
+++ b/packages/api-utils/lib/system/events.js
@@ -4,6 +4,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { Cc, Ci } = require('chrome');
 const { Unknown } = require('../xpcom');
 const { Class } = require('../heritage');

--- a/packages/api-utils/lib/tab-browser.js
+++ b/packages/api-utils/lib/tab-browser.js
@@ -3,6 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 "use strict";
+
+module.metadata = {
+  "stability": "deprecated"
+};
+
 const {Cc,Ci,Cu} = require("chrome");
 var NetUtil = {};
 Cu.import("resource://gre/modules/NetUtil.jsm", NetUtil);

--- a/packages/api-utils/lib/tabs/events.js
+++ b/packages/api-utils/lib/tabs/events.js
@@ -3,6 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const ON_PREFIX = "on";
 const TAB_PREFIX = "Tab";
 

--- a/packages/api-utils/lib/tabs/observer.js
+++ b/packages/api-utils/lib/tabs/observer.js
@@ -5,6 +5,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { EventEmitterTrait: EventEmitter } = require("../events");
 const { DOMEventAssembler } = require("../events/assembler");
 const { Trait } = require("../light-traits");

--- a/packages/api-utils/lib/tabs/tab.js
+++ b/packages/api-utils/lib/tabs/tab.js
@@ -3,6 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { Ci } = require('chrome');
 const { Trait } = require("../traits");
 const { EventEmitter } = require("../events");

--- a/packages/api-utils/lib/tabs/utils.js
+++ b/packages/api-utils/lib/tabs/utils.js
@@ -5,6 +5,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { Ci } = require("chrome");
 
 function getTabBrowser(window) {

--- a/packages/api-utils/lib/test.js
+++ b/packages/api-utils/lib/test.js
@@ -5,6 +5,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const BaseAssert = require("./test/assert").Assert;
 const { isFunction, isObject } = require("./type");
 

--- a/packages/api-utils/lib/test/assert.js
+++ b/packages/api-utils/lib/test/assert.js
@@ -4,6 +4,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { isFunction, isNull, isObject, isString, isRegExp, isArray, isDate,
         isPrimitive, isUndefined, instanceOf, source } = require("../type");
 

--- a/packages/api-utils/lib/text-streams.js
+++ b/packages/api-utils/lib/text-streams.js
@@ -6,6 +6,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "experimental"
+};
+
 const {Cc,Ci,Cu,components} = require("chrome");
 var NetUtil = {};
 Cu.import("resource://gre/modules/NetUtil.jsm", NetUtil);

--- a/packages/api-utils/lib/timer.js
+++ b/packages/api-utils/lib/timer.js
@@ -4,6 +4,10 @@
 
 'use strict';
 
+module.metadata = {
+  "stability": "deprecated"
+};
+
 const { CC, Ci } = require('chrome');
 const { when: unload } = require('./unload');
 

--- a/packages/api-utils/lib/traceback.js
+++ b/packages/api-utils/lib/traceback.js
@@ -4,6 +4,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "experimental"
+};
+
 const {Cc,Ci,components} = require("chrome");
 
 // Undo the auto-parentification of URLs done in bug 418356.

--- a/packages/api-utils/lib/traits.js
+++ b/packages/api-utils/lib/traits.js
@@ -4,6 +4,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "deprecated"
+};
+
 const {
   compose: _compose,
   override: _override,

--- a/packages/api-utils/lib/traits/core.js
+++ b/packages/api-utils/lib/traits/core.js
@@ -3,6 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 "use strict";
+
+module.metadata = {
+  "stability": "deprecated"
+};
+
 // Design inspired by: http://www.traitsjs.org/
 
 // shortcuts

--- a/packages/api-utils/lib/type.js
+++ b/packages/api-utils/lib/type.js
@@ -5,6 +5,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 /**
  * Returns `true` if `value` is `undefined`.
  * @examples

--- a/packages/api-utils/lib/unit-test-finder.js
+++ b/packages/api-utils/lib/unit-test-finder.js
@@ -4,6 +4,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "deprecated"
+};
+
 const file = require("./file");
 const memory = require('api-utils/memory');
 const suites = require('@test/options').allTestModules;

--- a/packages/api-utils/lib/unit-test.js
+++ b/packages/api-utils/lib/unit-test.js
@@ -5,6 +5,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "deprecated"
+};
+
 const memory = require('api-utils/memory');
 var timer = require("./timer");
 

--- a/packages/api-utils/lib/unload.js
+++ b/packages/api-utils/lib/unload.js
@@ -6,6 +6,9 @@
 //
 // http://narwhaljs.org
 
+module.metadata = {
+  "stability": "experimental"
+};
 
 const { on, off } = require('./system/events');
 const unloadSubject = require('@loader/unload');

--- a/packages/api-utils/lib/url.js
+++ b/packages/api-utils/lib/url.js
@@ -4,6 +4,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "experimental"
+};
+
 const { Cc, Ci, Cr } = require("chrome");
 
 const { Class } = require("./heritage");

--- a/packages/api-utils/lib/utils/data.js
+++ b/packages/api-utils/lib/utils/data.js
@@ -4,6 +4,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { Cc, Ci, Cu } = require("chrome");
 const base64 = require("../base64");
 

--- a/packages/api-utils/lib/utils/object.js
+++ b/packages/api-utils/lib/utils/object.js
@@ -4,6 +4,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 /**
  * Merges all the properties of all arguments into first argument. If two or
  * more argument objects have own properties with the same name, the property

--- a/packages/api-utils/lib/utils/registry.js
+++ b/packages/api-utils/lib/utils/registry.js
@@ -5,6 +5,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { EventEmitter } = require('../events');
 const unload = require('../unload');
 

--- a/packages/api-utils/lib/utils/thumbnail.js
+++ b/packages/api-utils/lib/utils/thumbnail.js
@@ -4,6 +4,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { Cc, Ci, Cu } = require("chrome");
 const AppShellService = Cc["@mozilla.org/appshell/appShellService;1"].
   getService(Ci.nsIAppShellService);

--- a/packages/api-utils/lib/uuid.js
+++ b/packages/api-utils/lib/uuid.js
@@ -4,6 +4,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { Cc, Ci, components: { ID: parseUUID } } = require('chrome');
 const { generateUUID } = Cc['@mozilla.org/uuid-generator;1'].
                           getService(Ci.nsIUUIDGenerator);

--- a/packages/api-utils/lib/window-utils.js
+++ b/packages/api-utils/lib/window-utils.js
@@ -4,6 +4,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "deprecated"
+};
+
 const { Cc, Ci } = require("chrome");
 const { EventEmitter } = require('./events');
 const { Trait } = require('./traits');

--- a/packages/api-utils/lib/window/utils.js
+++ b/packages/api-utils/lib/window/utils.js
@@ -4,6 +4,10 @@
 
 'use strict';
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { Cc, Ci } = require('chrome');
 
 const windowWatcher = Cc['@mozilla.org/embedcomp/window-watcher;1'].

--- a/packages/api-utils/lib/windows/dom.js
+++ b/packages/api-utils/lib/windows/dom.js
@@ -4,6 +4,10 @@
 
 'use strict';
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { Trait } = require('../traits'),
       { getMode } = require('api-utils/private-browsing/utils');
 

--- a/packages/api-utils/lib/windows/loader.js
+++ b/packages/api-utils/lib/windows/loader.js
@@ -3,6 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { Cc, Ci } = require('chrome'),
       { setTimeout } = require("../timer"),
       { Trait } = require('../traits'),

--- a/packages/api-utils/lib/windows/observer.js
+++ b/packages/api-utils/lib/windows/observer.js
@@ -5,6 +5,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { EventEmitterTrait: EventEmitter } = require("../events");
 const { WindowTracker, windowIterator } = require("../window-utils");
 const { DOMEventAssembler } = require("../events/assembler");

--- a/packages/api-utils/lib/windows/tabs.js
+++ b/packages/api-utils/lib/windows/tabs.js
@@ -3,6 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { Trait } = require("../traits");
 const { List } = require("../list");
 const { Tab, Options } = require("../tabs/tab");

--- a/packages/api-utils/lib/xhr.js
+++ b/packages/api-utils/lib/xhr.js
@@ -4,6 +4,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const {Cc,Ci} = require("chrome");
 const memory = require('api-utils/memory');
 

--- a/packages/api-utils/lib/xpcom.js
+++ b/packages/api-utils/lib/xpcom.js
@@ -4,6 +4,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "unstable"
+};
+
 const { Cc, Ci, Cr, Cm, components: { classesByID } } = require('chrome');
 const { registerFactory, unregisterFactory, isCIDRegistered } =
       Cm.QueryInterface(Ci.nsIComponentRegistrar);

--- a/packages/api-utils/lib/xul-app.js
+++ b/packages/api-utils/lib/xul-app.js
@@ -4,6 +4,10 @@
 
 "use strict";
 
+module.metadata = {
+  "stability": "experimental"
+};
+
 const {Cc, Ci} = require("chrome");
 
 var appInfo = Cc["@mozilla.org/xre/app-info;1"]


### PR DESCRIPTION
Modules' metadata proposal:

https://github.com/mozilla/addon-sdk/wiki/JEP-Metadata

Modules' stability status list:

https://docs.google.com/spreadsheet/ccc?key=0ArhtdvniRVpcdEl1SDdpQmJ1XzFuOHluaUt4YXhGQkE#gid=0
