### PR TITLE
Bug 789056: Document api-utils/system/events and use same names than nsIObserverService

### DIFF
--- a/packages/api-utils/docs/system/events.md
+++ b/packages/api-utils/docs/system/events.md
@@ -1,0 +1,71 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+Module provides core (low level) API for working with the application
+observer service, also known as
+[nsIObserverService](https://developer.mozilla.org/en-US/docs/XPCOM_Interface_Reference/nsIObserverService).
+You can find a list of events dispatched by firefox codebase
+[here](https://developer.mozilla.org/en-US/docs/Observer_Notifications).
+
+## Example
+
+    var events = require("api-utils/system/events");
+    var { Ci } = require("chrome");
+
+    events.on("http-on-modify-request", function (event) {
+      var channel = event.subject.QueryInterface(Ci.nsIHttpChannel);
+      channel.setRequestHeader("User-Agent", "MyBrowser/1.0", false);
+    });
+
+<api name="emit">
+@function
+  Send an event to observer service
+
+@param topic {string}
+  The topic name for this event.
+@param [event] {object}
+  An optional object object with `data` and `subject` attributes.
+  `data` refers to a string that you would like to pass through this event.
+  `subject` should refer to the actual actor of this event.
+</api>
+
+<api name="on">
+@function
+  Listen to events of a given topic
+
+@param topic {string}
+  The topic name to watch.
+@param listener {function}
+  Function that will be called when an event is fired, with a single `event`
+  object as argument. This object has three attributes:
+  
+    * topic: the event name
+    * subject: the event subject object
+    * data: the event data string
+
+@param strong {boolean}
+  Should we keep a strong of weak reference to the listener method.
+</api>
+
+<api name="on">
+@function
+  Listen only once to a particular event topic
+
+@param topic {string}
+  The topic name to watch.
+@param listener {function}
+  Function that will be called when an event is fired.
+@param strong {boolean}
+  Should we keep a strong of weak reference to the listener method.
+</api>
+
+<api name="off">
+@function
+  Stop listening for an event
+
+@param topic {string}
+  The topic name to unsubscribe to.
+@param listener {function}
+  The function we registered to listen for events.
+</api>

--- a/packages/api-utils/lib/system/events.js
+++ b/packages/api-utils/lib/system/events.js
@@ -28,10 +28,10 @@ const Subject = Class({
   getInterfaces: function() {}
 });
 
-function emit(type, event) {
+function emit(topic, event) {
   let subject = 'subject' in event ? Subject(event.subject) : null;
   let data = 'data' in event ? event.data : null;
-  notifyObservers(subject, type, data);
+  notifyObservers(subject, topic, data);
 }
 exports.emit = emit;
 
@@ -53,7 +53,7 @@ const Observer = Class({
 
     try {
       this.listener({
-        type: topic,
+        topic: topic,
         subject: subject,
         data: data
       });
@@ -66,44 +66,44 @@ const Observer = Class({
 
 const subscribers = ns();
 
-function on(type, listener, strong) {
+function on(topic, listener, strong) {
   // Unless last optional argument is `true` we use a weak reference to a
   // listener.
   let weak = !strong;
   // Take list of observers associated with given `listener` function.
   let observers = subscribers(listener);
-  // If `observer` for the given `type` is not registered yet, then
+  // If `observer` for the given `topic` is not registered yet, then
   // associate an `observer` and register it.
-  if (!(type in observers)) {
+  if (!(topic in observers)) {
     let observer = Observer(listener);
-    observers[type] = observer;
-    addObserver(observer, type, weak);
+    observers[topic] = observer;
+    addObserver(observer, topic, weak);
   }
 }
 exports.on = on;
 
-function once(type, listener) {
+function once(topic, listener) {
   // Note: this code assumes order in which listeners are called, which is fine
   // as long as dispatch happens in same order as listener registration which
   // is the case now. That being said we should be aware that this may break
   // in a future if order will change.
-  on(type, listener);
-  on(type, function cleanup() {
-    off(type, listener);
-    off(type, cleanup);
+  on(topic, listener);
+  on(topic, function cleanup() {
+    off(topic, listener);
+    off(topic, cleanup);
   }, true);
 }
 exports.once = once;
 
-function off(type, listener) {
+function off(topic, listener) {
   // Take list of observers as with the given `listener`.
   let observers = subscribers(listener);
-  // If `observer` for the given `type` is registered, then
+  // If `observer` for the given `topic` is registered, then
   // remove it & unregister.
-  if (type in observers) {
-    let observer = observers[type];
-    delete observers[type];
-    removeObserver(observer, type);
+  if (topic in observers) {
+    let observer = observers[topic];
+    delete observers[topic];
+    removeObserver(observer, topic);
   }
 }
 exports.off = off;


### PR DESCRIPTION
Some documentation for this module and I renamed `type` to `topic` as I don't see much value in having a difference between mozilla world and jetpack one. So that people won't be puzzled by a different naming between various existing docs and SDK one.

https://bugzilla.mozilla.org/show_bug.cgi?id=789056
