### PR TITLE
Bug 790687:  Intermittent test failure in test-widget.testNavigationBarWidgets

### DIFF
--- a/packages/api-utils/lib/window/utils.js
+++ b/packages/api-utils/lib/window/utils.js
@@ -118,7 +118,7 @@ function open(uri, options) {
                uri,
                options.name || null,
                serializeFeatures(options.features || {}),
-               null);
+               options.args || null);
 }
 exports.open = open;
 


### PR DESCRIPTION
Based on top of PR #563.

This test was weak for multiple reason:
1/ we weren't waiting nor for widget loading, so that we may assert while the widget is still in process of being added to chrome DOM
2/ Firefox modify the toolbar and dynamically inserts some toolbaritem during windows loading. So that we shouldn't assert for n-th position in toolbar but verify that widget are still next to the item we inserted to. (hopefully, firefox won't insert something between it and our widgets!!)

It depends on #563, as we rely on `attach` event, that has to be fired when the widget is already added to chrome DOM. (which isn't the case on master)
