### PR TITLE
Prevent "TypeError: tab.linkedBrowser is undefined" when trying to use PageMod in Fennec

### DIFF
--- a/lib/sdk/tabs/utils.js
+++ b/lib/sdk/tabs/utils.js
@@ -112,6 +112,8 @@ function closeTab(tab) {
 exports.closeTab = closeTab;
 
 function getURI(tab) {
+  if (tab.browser) // fennec
+    return tab.browser.currentURI.spec;
   return tab.linkedBrowser.currentURI.spec;
 }
 exports.getURI = getURI;


### PR DESCRIPTION
The patch should be fairly self-evident.  Hopefully.  :)

Thanks,
Blake.
