### PR TITLE
Bug 803417 - Fix support for packages with defined dependencie

### DIFF
--- a/python-lib/cuddlefish/packaging.py
+++ b/python-lib/cuddlefish/packaging.py
@@ -215,6 +215,12 @@ def get_config_in_dir(path):
 
     base_json.root_dir = path
 
+    if "dependencies" in base_json:
+      deps = base_json["dependencies"]
+      deps.append("addon-sdk")
+      deps = [x for x in deps if x not in ["addon-kit", "api-utils"]]
+      base_json["dependencies"] = deps
+
     return base_json
 
 def _is_same_file(a, b):


### PR DESCRIPTION
@wbamberg pointed out that our documentation is no longer valid
https://addons.mozilla.org/en-US/developers/docs/sdk/latest/dev-guide/tutorials/adding-menus.html

It turns out cfx breaks on packages that declare dependencies on "addon-kit" or "api-utils" as such packages no longer exist and there for can't be found. This patch replaces these dependencies with
"addon-sdk" instead.

Either way I think we should change documentation to avoid people start depending on features that don't plan on supporting.
