### PR TITLE
Bug 804935 - TypeError: window.tabs is undefined

### DIFF
--- a/lib/sdk/tabs/helpers.js
+++ b/lib/sdk/tabs/helpers.js
@@ -5,6 +5,8 @@
 
 const { getTabForContentWindow } = require('./utils');
 const { Tab } = require('./tab');
+const { getOwnerWindow } = require('./utils');
+const { BrowserWindow } = require('../windows');
 
 function getTabForWindow(win) {
   let tab = getTabForContentWindow(win);
@@ -12,6 +14,17 @@ function getTabForWindow(win) {
   if (!tab)
     return null;
 
-  return Tab({ tab: tab });
+  let topWindow = getOwnerWindow(tab);
+
+  return Tab({
+    tab: tab,
+    // Bring back this line for consistency. However it's actually not needed,
+    // as soon as the `windows` module is included - even if it's not used -
+    // the Tab will have the proper browser window assigned. That will be
+    // eventually fixed when deprecated Trackers will be removed.
+    //
+    // See: https://bugzilla.mozilla.org/show_bug.cgi?id=804935
+    window: BrowserWindow({ window: topWindow })
+  });
 }
 exports.getTabForWindow = getTabForWindow;

--- a/lib/sdk/tabs/tab-firefox.js
+++ b/lib/sdk/tabs/tab-firefox.js
@@ -32,7 +32,7 @@ const TabTrait = Trait.compose(EventEmitter, {
   constructor: function Tab(options) {
     this._onReady = this._onReady.bind(this);
     this._tab = options.tab;
-    let window = this.window = options.window || getOwnerWindow(this._tab);
+    let window = this.window = options.window;
 
     // Setting event listener if was passed.
     for each (let type in EVENTS) {


### PR DESCRIPTION
It was a regression during fennec implementation of windows and tabs. A `ChromeWindow` was used instead of the expected `BrowserWindow`.
