### PR TITLE
Bug 805223 - Add to .gitignore the generated documents' files and folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,10 @@ jetpack-sdk-docs.tgz
 .test_tmp/
 doc/dev-guide/
 doc/index.html
-doc/packages/
+doc/modules/
 doc/status.md5
+python-lib/cuddlefish/tests/static-files/sdk-docs/
+addon-sdk-docs.tgz
 packages/*
 
 # Python


### PR DESCRIPTION
Added to .gitignore:
- `python-lib/cuddlefish/tests/static-files/sdk-docs/`
- `addon-sdk-docs.tgz`

And replaced `doc/packages/` with `doc/modules/`
