### PR TITLE
Bug 805223 - Add to .gitignore the generated documents' files and folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,6 @@ doc/dev-guide/
 doc/index.html
 doc/modules/
 doc/status.md5
-python-lib/cuddlefish/tests/static-files/sdk-docs/
-addon-sdk-docs.tgz
 packages/*
 
 # Python

--- a/python-lib/cuddlefish/tests/test_generate.py
+++ b/python-lib/cuddlefish/tests/test_generate.py
@@ -92,6 +92,13 @@ class Link_Checker(HTMLParser.HTMLParser):
 class Generate_Docs_Tests(unittest.TestCase):
 
     def test_generate_static_docs(self):
+
+        def cleanup():
+            shutil.rmtree(get_base_url_path())
+            tgz.close()
+            os.remove(tar_filename)
+            generate.clean_generated_docs(os.path.join(env_root, "doc"))
+
         # make sure we start clean
         if os.path.exists(get_base_url_path()):
             shutil.rmtree(get_base_url_path())
@@ -118,12 +125,11 @@ class Generate_Docs_Tests(unittest.TestCase):
             print "The following links are broken:"
             for broken_link in sorted(broken_links):
                 print " "+ broken_link
+
+            cleanup()
             self.fail("%d links are broken" % len(broken_links))
-        # clean up
-        shutil.rmtree(get_base_url_path())
-        tgz.close()
-        os.remove(tar_filename)
-        generate.clean_generated_docs(os.path.join(env_root, "doc"))
+
+        cleanup()
 
     def test_generate_docs(self):
         test_root = get_test_root()


### PR DESCRIPTION
- Removed from .gitignore `python-lib/cuddlefish/tests/static-files/sdk-...docs/` and `addon-sdk-docs.tgz`, as discussed in Bug 805223.
- Added a `cleanup` function call before `self.fail` to get rid of the files above
