### PR TITLE
Bug 783743 - addon-page should work with "index.html?…" & "index.html#…"

### DIFF
--- a/lib/sdk/addon-page.js
+++ b/lib/sdk/addon-page.js
@@ -12,14 +12,34 @@ const { isXULBrowser } = require('./window/utils');
 const { add, remove } = require('./util/array');
 const { getTabs, closeTab, getURI } = require('./tabs/utils');
 const { data } = require('./self');
+const { ns } = require("./core/namespace");
 
 const addonURL = data.url('index.html');
 
+const windows = ns();
+
 WindowTracker({
   onTrack: function onTrack(window) {
-    if (isXULBrowser(window))
-      add(window.XULBrowserWindow.inContentWhitelist, addonURL);
+    if (!isXULBrowser(window) || windows(window).hideChromeForLocation)
+      return;
+
+    let { XULBrowserWindow } = window;
+    let { hideChromeForLocation } = XULBrowserWindow;
+
+    windows(window).hideChromeForLocation = hideChromeForLocation;
+
+    // Augmenting the behavior of `hideChromeForLocation` method, as
+    // suggested by https://developer.mozilla.org/en-US/docs/Hiding_browser_chrome
+    XULBrowserWindow.hideChromeForLocation = function(url) {
+      if (url.indexOf(addonURL) === 0) {
+        let rest = url.substr(addonURL.length);
+        return rest.length === 0 || ['#','?'].indexOf(rest.charAt(0)) > -1
+      }
+
+      return hideChromeForLocation.call(this, url);
+    }
   },
+
   onUntrack: function onUntrack(window) {
     if (isXULBrowser(window))
       getTabs(window).filter(tabFilter).forEach(untrackTab.bind(null, window));
@@ -33,6 +53,12 @@ function tabFilter(tab) {
 function untrackTab(window, tab) {
   // Note: `onUntrack` will be called for all windows on add-on unloads,
   // so we want to clean them up from these URLs.
-  remove(window.XULBrowserWindow.inContentWhitelist, addonURL);
+  let { hideChromeForLocation } = windows(window);
+
+  if (hideChromeForLocation) {
+    window.XULBrowserWindow.hideChromeForLocation = hideChromeForLocation;
+    windows(window).hideChromeForLocation = null;
+  }
+
   closeTab(tab);
 }

--- a/test/test-addon-page.js
+++ b/test/test-addon-page.js
@@ -42,6 +42,95 @@ exports['test that add-on page has no chrome'] = function(assert, done) {
   });
 };
 
+exports['test that add-on page with hash has no chrome'] = function(assert, done) {
+  let loader = Loader(module);
+  loader.require('addon-kit/addon-page');
+
+  let window = windows.activeBrowserWindow;
+  let tab = openTab(window, uri + "#foo");
+
+  assert.ok(isChromeVisible(window), 'chrome is visible for non addon page');
+
+  // need to do this in another turn to make sure event listener
+  // that sets property has time to do that.
+  setTimeout(function() {
+    activateTab(tab);
+
+    assert.equal(isChromeVisible(window), is('Fennec'), 'chrome is not visible for addon page');
+
+    closeTab(tab);
+    assert.ok(isChromeVisible(window), 'chrome is visible again');
+    loader.unload();
+    done();
+  });
+};
+
+exports['test that add-on page with querystring has no chrome'] = function(assert, done) {
+  let loader = Loader(module);
+  loader.require('addon-kit/addon-page');
+
+  let window = windows.activeBrowserWindow;
+  let tab = openTab(window, uri + '?foo=bar');
+
+  assert.ok(isChromeVisible(window), 'chrome is visible for non addon page');
+
+  // need to do this in another turn to make sure event listener
+  // that sets property has time to do that.
+  setTimeout(function() {
+    activateTab(tab);
+
+    assert.equal(isChromeVisible(window), is('Fennec'), 'chrome is not visible for addon page');
+
+    closeTab(tab);
+    assert.ok(isChromeVisible(window), 'chrome is visible again');
+    loader.unload();
+    done();
+  });
+};
+
+exports['test that add-on page with hash and querystring has no chrome'] = function(assert, done) {
+  let loader = Loader(module);
+  loader.require('addon-kit/addon-page');
+
+  let window = windows.activeBrowserWindow;
+  let tab = openTab(window, uri + '#foo?foo=bar');
+
+  assert.ok(isChromeVisible(window), 'chrome is visible for non addon page');
+
+  // need to do this in another turn to make sure event listener
+  // that sets property has time to do that.
+  setTimeout(function() {
+    activateTab(tab);
+
+    assert.equal(isChromeVisible(window), is('Fennec'), 'chrome is not visible for addon page');
+
+    closeTab(tab);
+    assert.ok(isChromeVisible(window), 'chrome is visible again');
+    loader.unload();
+    done();
+  });
+};
+
+exports['test that malformed uri is not an addon-page'] = function(assert, done) {
+  let loader = Loader(module);
+  loader.require('addon-kit/addon-page');
+
+  let window = windows.activeBrowserWindow;
+  let tab = openTab(window, uri + 'anguage');
+
+  // need to do this in another turn to make sure event listener
+  // that sets property has time to do that.
+  setTimeout(function() {
+    activateTab(tab);
+
+    assert.ok(isChromeVisible(window), 'chrome is visible for malformed uri');
+
+    closeTab(tab);
+    loader.unload();
+    done();
+  });
+};
+
 exports['test that add-on pages are closed on unload'] = function(assert, done) {
   let loader = Loader(module);
   loader.require('sdk/addon-page');


### PR DESCRIPTION
Replaced usage of `inContentWhitelist` with `hideChromeForLocation` to have more flexibility about URLs to hide.
