### PR TITLE
Bug 807271 - Removes `api-utils` from base64's example

### DIFF
--- a/doc/module-source/sdk/base64.md
+++ b/doc/module-source/sdk/base64.md
@@ -6,7 +6,7 @@ The module provides data encoding and decoding using Base64 algorithms.
 
 ##Example
 
-    var base64 = require("api-utils/base64");
+    var base64 = require("base64");
 
     var encodedData = base64.encode("Hello, World");
     var decodedData = base64.decode(encodedData);
@@ -16,7 +16,7 @@ The module provides data encoding and decoding using Base64 algorithms.
 In order to `encode` and `decode` properly Unicode strings, the `charset`
 parameter needs to be set to `"utf-8"`:
 
-    var base64 = require("api-utils/base64");
+    var base64 = require("base64");
 
     var encodedData = base64.encode(unicodeString, "utf-8");
     var decodedData = base64.decode(encodedData, "utf-8");

--- a/lib/sdk/base64.js
+++ b/lib/sdk/base64.js
@@ -10,9 +10,8 @@ module.metadata = {
 
 const { Cu } = require("chrome");
 
-// If an object is not given as second argument, the JavaScript Module scope is
-// returned, so we can obtain from it the `atob` and `btoa` functions
-const { atob, btoa } = Cu.import("resource://gre/modules/Services.jsm");
+// Passing an empty object as second argument to avoid scope's pollution
+const { atob, btoa } = Cu.import("resource://gre/modules/Services.jsm", {});
 
 function isUTF8(charset) {
   let type = typeof charset;


### PR DESCRIPTION
- Removed `api-utils` from base64's example
- Fix a nit on `base64` module to avoid module scope's pollution
