### PR TITLE
Bug 807277 - Update the list of modules currently supported by Fennec

### DIFF
--- a/doc/dev-guide-source/tutorials/mobile.md
+++ b/doc/dev-guide-source/tutorials/mobile.md
@@ -28,15 +28,22 @@ and `cfx xpi` when targeting Firefox Mobile.
 
 Right now only the following modules are fully functional:
 
+**High Level APIs**
+
+* [base64](modules/sdk/base64.html)
+* [hotkeys](modules/sdk/hotkeys.html)
+* [l10n](modules/sdk/l10n.html)
+* [notifications ](modules/sdk/notifications.html)
 * [page-mod](modules/sdk/page-mod.html)
-* [page-worker](modules/sdk/page-worker.html)
 * [passwords](modules/sdk/passwords.html)
-* [private-browsing](modules/sdk/private-browsing.html)
+* [querystring](modules/sdk/querystring.html)
 * [request](modules/sdk/request.html)
 * [self](modules/sdk/self.html)
 * [simple-prefs](modules/sdk/simple-prefs.html)
 * [simple-storage](modules/sdk/simple-storage.html)
+* [tabs](modules/sdk/tabs.html)
 * [timers](modules/sdk/timers.html)
+* [url](modules/sdk/url.html)
 
 We're working on adding support for the other modules.
 


### PR DESCRIPTION
Updated the list with of current High Level modules supported by Fennec.
I was thinking to add the low level APIs as well, but the two list combine will result in a really long page, moving the content down. So not sure if we should just focus on High Level APIs, or instead a vertical list like that:

**High Level APIs**
- [base64](#)
- [hotkeys](#)
- [l10n](#)
  _…_

**Low Level APIs**
- [console/plain-text](#)
- [console/traceback](#)
- [content/content](#)

Have something horizontal:

**High Level APIs**

[base64](#), [hotkeys](#), [l10n](#l), …

**Low Level APIs**

[console/plain-text](#), [console/traceback](#), [content/content](#), …
