### PR TITLE
Bug 746124 - cfx-js integration work

### DIFF
--- a/lib/sdk/core/heritage.js
+++ b/lib/sdk/core/heritage.js
@@ -160,8 +160,12 @@ var Class = new function() {
                          getDataProperties(prototype));
 
     constructor.attributes = attributes;
-    constructor.prototype = prototype;
-    return freeze(constructor);
+    Object.defineProperty(constructor, 'prototype', {
+      configurable: false,
+      writable: false,
+      value: prototype
+    });
+    return constructor;
   };
 }
 Class.prototype = extend(null, obscure({

--- a/lib/sdk/fs/path.js
+++ b/lib/sdk/fs/path.js
@@ -1,0 +1,446 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Adapted version of:
+// https://github.com/joyent/node/blob/v0.9.1/lib/path.js
+
+
+var system = require('../system');
+var isWindows = system.platform.indexOf('win') === 0;
+
+
+// resolves . and .. elements in a path array with directory names there
+// must be no slashes, empty elements, or device names (c:\) in the array
+// (so also no leading and trailing slashes - it does not distinguish
+// relative and absolute paths)
+function normalizeArray(parts, allowAboveRoot) {
+  // if the path tries to go above the root, `up` ends up > 0
+  var up = 0;
+  for (var i = parts.length - 1; i >= 0; i--) {
+    var last = parts[i];
+    if (last === '.') {
+      parts.splice(i, 1);
+    } else if (last === '..') {
+      parts.splice(i, 1);
+      up++;
+    } else if (up) {
+      parts.splice(i, 1);
+      up--;
+    }
+  }
+
+  // if the path is allowed to go above the root, restore leading ..s
+  if (allowAboveRoot) {
+    for (; up--; up) {
+      parts.unshift('..');
+    }
+  }
+
+  return parts;
+}
+
+
+if (isWindows) {
+  // Regex to split a windows path into three parts: [*, device, slash,
+  // tail] windows-only
+  var splitDeviceRe =
+      /^([a-zA-Z]:|[\\\/]{2}[^\\\/]+[\\\/][^\\\/]+)?([\\\/])?([\s\S]*?)$/;
+
+  // Regex to split the tail part of the above into [*, dir, basename, ext]
+  var splitTailRe =
+      /^([\s\S]+[\\\/](?!$)|[\\\/])?((?:\.{1,2}$|[\s\S]+?)?(\.[^.\/\\]*)?)$/;
+
+  // Function to split a filename into [root, dir, basename, ext]
+  // windows version
+  var splitPath = function(filename) {
+    // Separate device+slash from tail
+    var result = splitDeviceRe.exec(filename),
+        device = (result[1] || '') + (result[2] || ''),
+        tail = result[3] || '';
+    // Split the tail into dir, basename and extension
+    var result2 = splitTailRe.exec(tail),
+        dir = result2[1] || '',
+        basename = result2[2] || '',
+        ext = result2[3] || '';
+    return [device, dir, basename, ext];
+  };
+
+  // path.resolve([from ...], to)
+  // windows version
+  exports.resolve = function() {
+    var resolvedDevice = '',
+        resolvedTail = '',
+        resolvedAbsolute = false;
+
+    for (var i = arguments.length - 1; i >= -1; i--) {
+      var path;
+      if (i >= 0) {
+        path = arguments[i];
+      } else if (!resolvedDevice) {
+        path = system.pathFor('CurProcD');
+      } else {
+        // Windows has the concept of drive-specific current working
+        // directories. If we've resolved a drive letter but not yet an
+        // absolute path, get cwd for that drive. We're sure the device is not
+        // an unc path at this points, because unc paths are always absolute.
+        path = system.env['=' + resolvedDevice];
+        // Verify that a drive-local cwd was found and that it actually points
+        // to our drive. If not, default to the drive's root.
+        if (!path || path.substr(0, 3).toLowerCase() !==
+            resolvedDevice.toLowerCase() + '\\') {
+          path = resolvedDevice + '\\';
+        }
+      }
+
+      // Skip empty and invalid entries
+      if (typeof path !== 'string' || !path) {
+        continue;
+      }
+
+      var result = splitDeviceRe.exec(path),
+          device = result[1] || '',
+          isUnc = device && device.charAt(1) !== ':',
+          isAbsolute = !!result[2] || isUnc, // UNC paths are always absolute
+          tail = result[3];
+
+      if (device &&
+          resolvedDevice &&
+          device.toLowerCase() !== resolvedDevice.toLowerCase()) {
+        // This path points to another device so it is not applicable
+        continue;
+      }
+
+      if (!resolvedDevice) {
+        resolvedDevice = device;
+      }
+      if (!resolvedAbsolute) {
+        resolvedTail = tail + '\\' + resolvedTail;
+        resolvedAbsolute = isAbsolute;
+      }
+
+      if (resolvedDevice && resolvedAbsolute) {
+        break;
+      }
+    }
+
+    // Replace slashes (in UNC share name) by backslashes
+    resolvedDevice = resolvedDevice.replace(/\//g, '\\');
+
+    // At this point the path should be resolved to a full absolute path,
+    // but handle relative paths to be safe (might happen when process.cwd()
+    // fails)
+
+    // Normalize the tail path
+
+    function f(p) {
+      return !!p;
+    }
+
+    resolvedTail = normalizeArray(resolvedTail.split(/[\\\/]+/).filter(f),
+                                  !resolvedAbsolute).join('\\');
+
+    return (resolvedDevice + (resolvedAbsolute ? '\\' : '') + resolvedTail) ||
+           '.';
+  };
+
+  // windows version
+  exports.normalize = function(path) {
+    var result = splitDeviceRe.exec(path),
+        device = result[1] || '',
+        isUnc = device && device.charAt(1) !== ':',
+        isAbsolute = !!result[2] || isUnc, // UNC paths are always absolute
+        tail = result[3],
+        trailingSlash = /[\\\/]$/.test(tail);
+
+    // Normalize the tail path
+    tail = normalizeArray(tail.split(/[\\\/]+/).filter(function(p) {
+      return !!p;
+    }), !isAbsolute).join('\\');
+
+    if (!tail && !isAbsolute) {
+      tail = '.';
+    }
+    if (tail && trailingSlash) {
+      tail += '\\';
+    }
+
+    // Convert slashes to backslashes when `device` points to an UNC root.
+    device = device.replace(/\//g, '\\');
+
+    return device + (isAbsolute ? '\\' : '') + tail;
+  };
+
+  // windows version
+  exports.join = function() {
+    function f(p) {
+      return p && typeof p === 'string';
+    }
+
+    var paths = Array.prototype.filter.call(arguments, f);
+    var joined = paths.join('\\');
+
+    // Make sure that the joined path doesn't start with two slashes
+    // - it will be mistaken for an unc path by normalize() -
+    // unless the paths[0] also starts with two slashes
+    if (/^[\\\/]{2}/.test(joined) && !/^[\\\/]{2}/.test(paths[0])) {
+      joined = joined.substr(1);
+    }
+
+    return exports.normalize(joined);
+  };
+
+  // path.relative(from, to)
+  // it will solve the relative path from 'from' to 'to', for instance:
+  // from = 'C:\\orandea\\test\\aaa'
+  // to = 'C:\\orandea\\impl\\bbb'
+  // The output of the function should be: '..\\..\\impl\\bbb'
+  // windows version
+  exports.relative = function(from, to) {
+    from = exports.resolve(from);
+    to = exports.resolve(to);
+
+    // windows is not case sensitive
+    var lowerFrom = from.toLowerCase();
+    var lowerTo = to.toLowerCase();
+
+    function trim(arr) {
+      var start = 0;
+      for (; start < arr.length; start++) {
+        if (arr[start] !== '') break;
+      }
+
+      var end = arr.length - 1;
+      for (; end >= 0; end--) {
+        if (arr[end] !== '') break;
+      }
+
+      if (start > end) return [];
+      return arr.slice(start, end - start + 1);
+    }
+
+    var toParts = trim(to.split('\\'));
+
+    var lowerFromParts = trim(lowerFrom.split('\\'));
+    var lowerToParts = trim(lowerTo.split('\\'));
+
+    var length = Math.min(lowerFromParts.length, lowerToParts.length);
+    var samePartsLength = length;
+    for (var i = 0; i < length; i++) {
+      if (lowerFromParts[i] !== lowerToParts[i]) {
+        samePartsLength = i;
+        break;
+      }
+    }
+
+    if (samePartsLength == 0) {
+      return to;
+    }
+
+    var outputParts = [];
+    for (var i = samePartsLength; i < lowerFromParts.length; i++) {
+      outputParts.push('..');
+    }
+
+    outputParts = outputParts.concat(toParts.slice(samePartsLength));
+
+    return outputParts.join('\\');
+  };
+
+  exports.sep = '\\';
+
+} else /* posix */ {
+
+  // Split a filename into [root, dir, basename, ext], unix version
+  // 'root' is just a slash, or nothing.
+  var splitPathRe =
+      /^(\/?)([\s\S]+\/(?!$)|\/)?((?:\.{1,2}$|[\s\S]+?)?(\.[^.\/]*)?)$/;
+  var splitPath = function(filename) {
+    var result = splitPathRe.exec(filename);
+    return [result[1] || '', result[2] || '', result[3] || '', result[4] || ''];
+  };
+
+  // path.resolve([from ...], to)
+  // posix version
+  exports.resolve = function() {
+    var resolvedPath = '',
+        resolvedAbsolute = false;
+
+    for (var i = arguments.length - 1; i >= -1 && !resolvedAbsolute; i--) {
+      var path = (i >= 0) ? arguments[i] : system.pathFor('CurProcD');
+
+      // Skip empty and invalid entries
+      if (typeof path !== 'string' || !path) {
+        continue;
+      }
+
+      resolvedPath = path + '/' + resolvedPath;
+      resolvedAbsolute = path.charAt(0) === '/';
+    }
+
+    // At this point the path should be resolved to a full absolute path, but
+    // handle relative paths to be safe (might happen when process.cwd() fails)
+
+    // Normalize the path
+    resolvedPath = normalizeArray(resolvedPath.split('/').filter(function(p) {
+      return !!p;
+    }), !resolvedAbsolute).join('/');
+
+    return ((resolvedAbsolute ? '/' : '') + resolvedPath) || '.';
+  };
+
+  // path.normalize(path)
+  // posix version
+  exports.normalize = function(path) {
+    var isAbsolute = path.charAt(0) === '/',
+        trailingSlash = path.substr(-1) === '/';
+
+    // Normalize the path
+    path = normalizeArray(path.split('/').filter(function(p) {
+      return !!p;
+    }), !isAbsolute).join('/');
+
+    if (!path && !isAbsolute) {
+      path = '.';
+    }
+    if (path && trailingSlash) {
+      path += '/';
+    }
+
+    return (isAbsolute ? '/' : '') + path;
+  };
+
+
+  // posix version
+  exports.join = function() {
+    var paths = Array.prototype.slice.call(arguments, 0);
+    return exports.normalize(paths.filter(function(p, index) {
+      return p && typeof p === 'string';
+    }).join('/'));
+  };
+
+
+  // path.relative(from, to)
+  // posix version
+  exports.relative = function(from, to) {
+    from = exports.resolve(from).substr(1);
+    to = exports.resolve(to).substr(1);
+
+    function trim(arr) {
+      var start = 0;
+      for (; start < arr.length; start++) {
+        if (arr[start] !== '') break;
+      }
+
+      var end = arr.length - 1;
+      for (; end >= 0; end--) {
+        if (arr[end] !== '') break;
+      }
+
+      if (start > end) return [];
+      return arr.slice(start, end - start + 1);
+    }
+
+    var fromParts = trim(from.split('/'));
+    var toParts = trim(to.split('/'));
+
+    var length = Math.min(fromParts.length, toParts.length);
+    var samePartsLength = length;
+    for (var i = 0; i < length; i++) {
+      if (fromParts[i] !== toParts[i]) {
+        samePartsLength = i;
+        break;
+      }
+    }
+
+    var outputParts = [];
+    for (var i = samePartsLength; i < fromParts.length; i++) {
+      outputParts.push('..');
+    }
+
+    outputParts = outputParts.concat(toParts.slice(samePartsLength));
+
+    return outputParts.join('/');
+  };
+
+  exports.sep = '/';
+}
+
+
+exports.dirname = function(path) {
+  var result = splitPath(path),
+      root = result[0],
+      dir = result[1];
+
+  if (!root && !dir) {
+    // No dirname whatsoever
+    return '.';
+  }
+
+  if (dir) {
+    // It has a dirname, strip trailing slash
+    dir = dir.substr(0, dir.length - 1);
+  }
+
+  return root + dir;
+};
+
+
+exports.basename = function(path, ext) {
+  var f = splitPath(path)[2];
+  // TODO: make this comparison case-insensitive on windows?
+  if (ext && f.substr(-1 * ext.length) === ext) {
+    f = f.substr(0, f.length - ext.length);
+  }
+  return f;
+};
+
+
+exports.extname = function(path) {
+  return splitPath(path)[3];
+};
+
+
+if (isWindows) {
+  exports._makeLong = function(path) {
+    path = '' + path;
+    if (!path) {
+      return '';
+    }
+
+    var resolvedPath = exports.resolve(path);
+
+    if (/^[a-zA-Z]\:\\/.test(resolvedPath)) {
+      // path is local filesystem path, which needs to be converted
+      // to long UNC path.
+      return '\\\\?\\' + resolvedPath;
+    } else if (/^\\\\[^?.]/.test(resolvedPath)) {
+      // path is network UNC path, which needs to be converted
+      // to long UNC path.
+      return '\\\\?\\UNC\\' + resolvedPath.substring(2);
+    }
+
+    return path;
+  };
+} else {
+  exports._makeLong = function(path) {
+    return path;
+  };
+}

--- a/lib/sdk/io/buffer.js
+++ b/lib/sdk/io/buffer.js
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+"use strict";
+
+module.metadata = {
+  "stability": "experimental"
+};
+
+
+const { Cc, Ci, CC } = require("chrome");
+const { Class } = require("../core/heritage");
+
+const Transcoder = CC("@mozilla.org/intl/scriptableunicodeconverter",
+                      "nsIScriptableUnicodeConverter");
+
+var Buffer = Class({
+  initialize: function initialize(subject, encoding) {
+    subject = subject ? subject.valueOf() : 0;
+    let length = typeof subject === "number" ? subject : 0;
+    this.encoding = encoding || "utf-8";
+    this.valueOf(Array.isArray(subject) ? subject : new Array(length));
+
+    if (typeof subject === "string") this.write(subject);
+  },
+  get length() {
+    return this.valueOf().length;
+  },
+  get: function get(index) {
+    return this.valueOf()[index];
+  },
+  set: function set(index, value) {
+    return this.valueOf()[index] = value;
+  },
+  valueOf: function valueOf(value) {
+    Object.defineProperty(this, "valueOf", {
+      value: Array.prototype.valueOf.bind(value),
+      configurable: false,
+      writable: false,
+      enumerable: false
+    });
+  },
+  toString: function toString(encoding, start, end) {
+    let bytes = this.valueOf().slice(start || 0, end || this.length);
+    let transcoder = Transcoder();
+    transcoder.charset = String(encoding || this.encoding).toUpperCase();
+    return transcoder.convertFromByteArray(bytes, this.length);
+  },
+  toJSON: function toJSON() {
+    return this.toString()
+  },
+  write: function write(string, offset, encoding) {
+    offset = Math.max(offset || 0, 0);
+    let value = this.valueOf();
+    let transcoder = Transcoder();
+    transcoder.charset = String(encoding || this.encoding).toUpperCase();
+    let bytes = transcoder.convertToByteArray(string, {});
+    value.splice.apply(value, [
+      offset,
+      Math.min(value.length - offset, bytes.length, bytes)
+    ].concat(bytes));
+    return bytes;
+  },
+  slice: function slice(start, end) {
+    return new Buffer(this.valueOf().slice(start, end));
+  },
+  copy: function copy(target, offset, start, end) {
+    offset = Math.max(offset || 0, 0);
+    target = target.valueOf();
+    let bytes = this.valueOf();
+    bytes.slice(Math.max(start || 0, 0), end);
+    target.splice.apply(target, [
+      offset,
+      Math.min(target.length - offset, bytes.length),
+    ].concat(bytes));
+  }
+});
+Buffer.isBuffer = function isBuffer(buffer) {
+  return buffer instanceof Buffer
+};
+exports.Buffer = Buffer;

--- a/lib/sdk/io/fs.js
+++ b/lib/sdk/io/fs.js
@@ -1,0 +1,892 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+"use strict";
+
+module.metadata = {
+  "stability": "experimental"
+};
+
+const { Cc, Ci, CC } = require("chrome");
+
+const { setTimeout } = require("../timers");
+const { Stream, InputStream, OutputStream } = require("./stream");
+const { Buffer } = require("./buffer");
+const { ns } = require("../core/namespace");
+const { Class } = require("../core/heritage");
+
+const nsILocalFile = CC("@mozilla.org/file/local;1", "nsILocalFile",
+                        "initWithPath");
+const FileOutputStream = CC("@mozilla.org/network/file-output-stream;1",
+                            "nsIFileOutputStream", "init");
+const FileInputStream = CC("@mozilla.org/network/file-input-stream;1",
+                           "nsIFileInputStream", "init");
+const BinaryInputStream = CC("@mozilla.org/binaryinputstream;1",
+                             "nsIBinaryInputStream", "setInputStream");
+const BinaryOutputStream = CC("@mozilla.org/binaryoutputstream;1",
+                              "nsIBinaryOutputStream", "setOutputStream");
+const StreamPump = CC("@mozilla.org/network/input-stream-pump;1",
+                      "nsIInputStreamPump", "init");
+
+const { createOutputTransport, createInputTransport } =
+  Cc["@mozilla.org/network/stream-transport-service;1"].
+  getService(Ci.nsIStreamTransportService);
+
+
+const { REOPEN_ON_REWIND, DEFER_OPEN } = Ci.nsIFileInputStream;
+const { DIRECTORY_TYPE, NORMAL_FILE_TYPE } = Ci.nsIFile;
+const { NS_SEEK_SET, NS_SEEK_CUR, NS_SEEK_END } = Ci.nsISeekableStream;
+
+const FILE_PERMISSION = parseInt("0666", 8);
+const PR_UINT32_MAX = 0xfffffff;
+// Values taken from:
+// http://mxr.mozilla.org/mozilla-central/source/nsprpub/pr/include/prio.h#615
+const PR_RDONLY =       0x01;
+const PR_WRONLY =       0x02;
+const PR_RDWR =         0x04;
+const PR_CREATE_FILE =  0x08;
+const PR_APPEND =       0x10;
+const PR_TRUNCATE =     0x20;
+const PR_SYNC =         0x40;
+const PR_EXCL =         0x80;
+
+const FLAGS = {
+  "r":                  PR_RDONLY,
+  "r+":                 PR_RDWR,
+  "w":                  PR_CREATE_FILE | PR_TRUNCATE | PR_WRONLY,
+  "w+":                 PR_CREATE_FILE | PR_TRUNCATE | PR_RDWR,
+  "a":                  PR_APPEND | PR_CREATE_FILE | PR_WRONLY,
+  "a+":                 PR_APPEND | PR_CREATE_FILE | PR_RDWR
+};
+
+function accessor() {
+  let map = new WeakMap();
+  return function(fd, value) {
+    if (value === null) map.delete(fd);
+    if (value !== undefined) map.set(fd, value);
+    return map.get(fd);
+  }
+}
+
+let nsIFile = accessor();
+let nsIFileInputStream = accessor();
+let nsIFileOutputStream = accessor();
+let nsIBinaryInputStream = accessor();
+let nsIBinaryOutputStream = accessor();
+
+// Just a contstant object used to signal that all of the file
+// needs to be read.
+const ALL = new String("Read all of the file");
+
+function isWritable(mode) !!(mode & PR_WRONLY || mode & PR_RDWR)
+function isReadable(mode) !!(mode & PR_RDONLY || mode & PR_RDWR)
+
+function isString(value) typeof(value) === "string"
+function isFunction(value) typeof(value) === "function"
+
+function toArray(enumerator) {
+  let value = [];
+  while(enumerator.hasMoreElements())
+    value.push(enumerator.getNext())
+  return value
+}
+
+function getFileName(file) file.QueryInterface(Ci.nsIFile).leafName
+
+
+function remove(path, recursive) {
+  let fd = new nsILocalFile(path)
+  if (fd.exists()) {
+    fd.remove(recursive || false);
+  }
+  else {
+    throw FSError("remove", "ENOENT", 34, path);
+  }
+}
+
+function Mode(mode, fallback) {
+  return isString(mode) ? parseInt(mode) : mode || fallback;
+}
+function Flags(flag) {
+  return !isString(flag) ? flag :
+         FLAGS[flag] || Error("Unknown file open flag: " + flag);
+}
+
+
+function FSError(op, code, errno, path, file, line) {
+  let error = Error(code + ", " + op + " " + path, file, line);
+  error.code = code;
+  error.path = path;
+  error.errno = errno;
+  return error;
+}
+
+const ReadStream = Class({
+  extends: InputStream,
+  initialize: function initialize(path, options) {
+    this.position = -1;
+    this.length = -1;
+    this.flags = "r";
+    this.mode = FILE_PERMISSION;
+    this.bufferSize = 64 * 1024;
+
+    options = options || {};
+
+    if ("flags" in options && options.flags)
+      this.flags = options.flags;
+    if ("bufferSize" in options && options.bufferSize)
+      this.bufferSize = options.bufferSize;
+    if ("length" in options && options.length)
+      this.length = options.length;
+    if ("position" in options && options.position !== undefined)
+      this.position = options.position;
+
+    let { flags, mode, position, length } = this;
+    let fd = isString(path) ? openSync(path, flags, mode) : path;
+    let input = nsIFileInputStream(fd);
+    // Setting a stream position, unless it"s `-1` which means current position.
+    if (position >= 0)
+      input.QueryInterface(Ci.nsISeekableStream).seek(NS_SEEK_SET, position);
+    // We use `nsIStreamTransportService` service to transform blocking
+    // file input stream into a fully asynchronous stream that can be written
+    // without blocking the main thread.
+    let transport = createInputTransport(input, position, length, false);
+    // Open an input stream on a transport. We don"t pass flags to guarantee
+    // non-blocking stream semantics. Also we use defaults for segment size &
+    // count.
+    let asyncInputStream = transport.openInputStream(null, 0, 0);
+    let binaryInputStream = BinaryInputStream(asyncInputStream);
+    nsIBinaryInputStream(fd, binaryInputStream);
+    let pump = StreamPump(asyncInputStream, position, length, 0, 0, false);
+
+    InputStream.prototype.initialize.call(this, {
+      input: binaryInputStream, pump: pump
+    });
+    this.read();
+  }
+});
+exports.ReadStream = ReadStream;
+exports.createReadStream = function createReadStream(path, options) {
+  return new ReadStream(path, options);
+};
+
+const WriteStream = Class({
+  extends: OutputStream,
+  initialize: function initialize(path, options) {
+    this.drainable = true;
+    this.flags = "w";
+    this.position = -1;
+    this.mode = FILE_PERMISSION;
+
+    options = options || {};
+
+    if ("flags" in options && options.flags)
+      this.flags = options.flags;
+    if ("mode" in options && options.mode)
+      this.mode = options.mode;
+    if ("position" in options && options.position !== undefined)
+      this.position = options.position;
+
+    let { position, flags, mode } = this;
+    // If pass was passed we create a file descriptor out of it. Otherwise
+    // we just use given file descriptor.
+    let fd = isString(path) ? openSync(path, flags, mode) : path;
+    let output = nsIFileOutputStream(fd);
+    // Setting a stream position, unless it"s `-1` which means current position.
+    if (position >= 0)
+      output.QueryInterface(Ci.nsISeekableStream).seek(NS_SEEK_SET, position);
+    // We use `nsIStreamTransportService` service to transform blocking
+    // file output stream into a fully asynchronous stream that can be written
+    // without blocking the main thread.
+    let transport = createOutputTransport(output, position, -1, false);
+    // Open an output stream on a transport. We don"t pass flags to guarantee
+    // non-blocking stream semantics. Also we use defaults for segment size &
+    // count.
+    let asyncOutputStream = transport.openOutputStream(null, 0, 0);
+    // Finally we create a non-blocking binary output stream. This will allows
+    // us to write buffers as byte arrays without any further transcoding.
+    let binaryOutputStream = BinaryOutputStream(asyncOutputStream);
+    nsIBinaryOutputStream(fd, binaryOutputStream);
+
+    // Storing output stream so that it can beaccessed later.
+    OutputStream.prototype.initialize.call(this, {
+      output: binaryOutputStream,
+      asyncOutputStream: asyncOutputStream
+    });
+  }
+});
+exports.WriteStream = WriteStream;
+exports.createWriteStream = function createWriteStream(path, options) {
+  return new WriteStream(path, options);
+};
+
+const Stats = Class({
+  initialize: function initialize(path) {
+    let file = new nsILocalFile(path);
+    if (!file.exists()) throw FSError("stat", "ENOENT", 34, path);
+    nsIFile(this, file);
+  },
+  isDirectory: function() nsIFile(this).isDirectory(),
+  isFile: function() nsIFile(this).isFile(),
+  isSymbolicLink: function() nsIFile(this).isSymlink(),
+  get mode() nsIFile(this).permissions,
+  get size() nsIFile(this).fileSize,
+  get mtime() nsIFile(this).lastModifiedTime,
+  isBlockDevice: function() nsIFile(this).isSpecial(),
+  isCharacterDevice: function() nsIFile(this).isSpecial(),
+  isFIFO: function() nsIFile(this).isSpecial(),
+  isSocket: function() nsIFile(this).isSpecial(),
+  // non standard
+  get exists() nsIFile(this).exists(),
+  get hidden() nsIFile(this).isHidden(),
+  get writable() nsIFile(this).isWritable(),
+  get readable() nsIFile(this).isReadable()
+});
+exports.Stats = Stats;
+
+const LStats = Class({
+  extends: Stats,
+  get size() this.isSymbolicLink() ? nsIFile(this).fileSizeOfLink :
+                                     nsIFile(this).fileSize,
+  get mtime() this.isSymbolicLink() ? nsIFile(this).lastModifiedTimeOfLink :
+                                      nsIFile(this).lastModifiedTime,
+  // non standard
+  get permissions() this.isSymbolicLink() ? nsIFile(this).permissionsOfLink :
+                                            nsIFile(this).permissions
+});
+
+const FStat = Class({
+  extends: Stats,
+  initialize: function initialize(fd) {
+    nsIFile(this, nsIFile(fd));
+  }
+});
+
+function noop() {}
+function Async(wrapped) {
+  return function (path, callback) {
+    let args = Array.slice(arguments);
+    callback = args.pop();
+    // If node is not given a callback argument
+    // it just does not calls it.
+    if (typeof(callback) !== "function") {
+      args.push(callback);
+      callback = noop;
+    }
+    setTimeout(function() {
+      try {
+        var result = wrapped.apply(this, args);
+        if (result === undefined) callback(null);
+        else callback(null, result);
+      } catch (error) {
+        callback(error);
+      }
+    }, 0);
+  }
+}
+
+
+/**
+ * Synchronous rename(2)
+ */
+function renameSync(oldPath, newPath) {
+  let source = new nsILocalFile(oldPath);
+  let target = new nsILocalFile(newPath);
+  if (!source.exists()) throw FSError("rename", "ENOENT", 34, oldPath);
+  return source.moveTo(target.parent, target.leafName);
+};
+exports.renameSync = renameSync;
+
+/**
+ * Asynchronous rename(2). No arguments other than a possible exception are
+ * given to the completion callback.
+ */
+let rename = Async(renameSync);
+exports.rename = rename;
+
+/**
+ * Test whether or not the given path exists by checking with the file system.
+ */
+function existsSync(path) {
+  return new nsILocalFile(path).exists();
+}
+exports.existsSync = existsSync;
+
+let exists = Async(existsSync);
+exports.exists = exists;
+
+/**
+ * Synchronous ftruncate(2).
+ */
+function truncateSync(path, length) {
+  let fd = openSync(path, "w");
+  ftruncateSync(fd, length);
+  closeSync(fd);
+}
+exports.truncateSync = truncateSync;
+
+/**
+ * Asynchronous ftruncate(2). No arguments other than a possible exception are
+ * given to the completion callback.
+ */
+function truncate(path, length, callback) {
+  open(path, "w", function(error, fd) {
+    if (error) return callback(error);
+    ftruncate(fd, length, function(error) {
+      if (error) {
+        closeSync(fd);
+        callback(error);
+      }
+      else {
+        close(fd, callback);
+      }
+    });
+  });
+}
+exports.truncate = truncate;
+
+function ftruncate(fd, length, callback) {
+  write(fd, new Buffer(length), 0, length, 0, function(error) {
+    callback(error);
+  });
+}
+exports.ftruncate = ftruncate;
+
+function ftruncateSync(fd, length) {
+  writeSync(fd, new Buffer(length), 0, length, 0);
+}
+exports.ftruncateSync = ftruncateSync;
+
+function chownSync(path, uid, gid) {
+  throw Error("Not implemented yet!!");
+}
+exports.chownSync = chownSync;
+
+let chown = Async(chownSync);
+exports.chown = chown;
+
+function lchownSync(path, uid, gid) {
+  throw Error("Not implemented yet!!");
+}
+exports.lchownSync = chownSync;
+
+let lchown = Async(lchown);
+exports.lchown = lchown;
+
+/**
+ * Synchronous chmod(2).
+ */
+function chmodSync (path, mode) {
+  throw Error("Not implemented yet!!");
+};
+exports.chmodSync = chmodSync;
+/**
+ * Asynchronous chmod(2). No arguments other than a possible exception are
+ * given to the completion callback.
+ */
+let chmod = Async(chmodSync);
+exports.chmod = chmod;
+
+/**
+ * Synchronous chmod(2).
+ */
+function fchmodSync(fd, mode) {
+  throw Error("Not implemented yet!!");
+};
+exports.fchmodSync = fchmodSync;
+/**
+ * Asynchronous chmod(2). No arguments other than a possible exception are
+ * given to the completion callback.
+ */
+let fchmod = Async(fchmodSync);
+exports.chmod = fchmod;
+
+
+/**
+ * Synchronous stat(2). Returns an instance of `fs.Stats`
+ */
+function statSync(path) {
+  return new Stats(path);
+};
+exports.statSync = statSync;
+
+/**
+ * Asynchronous stat(2). The callback gets two arguments (err, stats) where
+ * stats is a `fs.Stats` object. It looks like this:
+ */
+let stat = Async(statSync);
+exports.stat = stat;
+
+/**
+ * Synchronous lstat(2). Returns an instance of `fs.Stats`.
+ */
+function lstatSync(path) {
+  return new LStats(path);
+};
+exports.lstatSync = lstatSync;
+
+/**
+ * Asynchronous lstat(2). The callback gets two arguments (err, stats) where
+ * stats is a fs.Stats object. lstat() is identical to stat(), except that if
+ * path is a symbolic link, then the link itself is stat-ed, not the file that
+ * it refers to.
+ */
+let lstat = Async(lstatSync);
+exports.lstat = lstat;
+
+/**
+ * Synchronous fstat(2). Returns an instance of `fs.Stats`.
+ */
+function fstatSync(fd) {
+  return new FStat(fd);
+};
+exports.fstatSync = fstatSync;
+
+/**
+ * Asynchronous fstat(2). The callback gets two arguments (err, stats) where
+ * stats is a fs.Stats object.
+ */
+let fstat = Async(fstatSync);
+exports.fstat = fstat;
+
+/**
+ * Synchronous link(2).
+ */
+function linkSync(source, target) {
+  throw Error("Not implemented yet!!");
+};
+exports.linkSync = linkSync;
+
+/**
+ * Asynchronous link(2). No arguments other than a possible exception are given
+ * to the completion callback.
+ */
+let link = Async(linkSync);
+exports.link = link;
+
+/**
+ * Synchronous symlink(2).
+ */
+function symlinkSync(source, target) {
+  throw Error("Not implemented yet!!");
+};
+exports.symlinkSync = symlinkSync;
+
+/**
+ * Asynchronous symlink(2). No arguments other than a possible exception are
+ * given to the completion callback.
+ */
+let symlink = Async(symlinkSync);
+exports.symlink = symlink;
+
+/**
+ * Synchronous readlink(2). Returns the resolved path.
+ */
+function readlinkSync(path) {
+  return new nsILocalFile(path).target;
+};
+exports.readlinkSync = readlinkSync;
+
+/**
+ * Asynchronous readlink(2). The callback gets two arguments
+ * `(error, resolvedPath)`.
+ */
+let readlink = Async(readlinkSync);
+exports.readlink = readlink;
+
+/**
+ * Synchronous realpath(2). Returns the resolved path.
+ */
+function realpathSync(path) {
+  return new nsILocalFile(path).path;
+};
+exports.realpathSync = realpathSync;
+
+/**
+ * Asynchronous realpath(2). The callback gets two arguments
+ * `(err, resolvedPath)`.
+ */
+let realpath = Async(realpathSync);
+exports.realpath = realpath;
+
+/**
+ * Synchronous unlink(2).
+ */
+let unlinkSync = remove;
+exports.unlinkSync = unlinkSync;
+
+/**
+ * Asynchronous unlink(2). No arguments other than a possible exception are
+ * given to the completion callback.
+ */
+let unlink = Async(remove);
+exports.unlink = unlink;
+
+/**
+ * Synchronous rmdir(2).
+ */
+let rmdirSync = remove;
+exports.rmdirSync = rmdirSync;
+
+/**
+ * Asynchronous rmdir(2). No arguments other than a possible exception are
+ * given to the completion callback.
+ */
+let rmdir = Async(rmdirSync);
+exports.rmdir = rmdir;
+
+/**
+ * Synchronous mkdir(2).
+ */
+function mkdirSync(path, mode) {
+  try {
+    return nsILocalFile(path).create(DIRECTORY_TYPE, Mode(mode));
+  } catch (error) {
+    // Adjust exception thorw to match ones thrown by node.
+    if (error.name === "NS_ERROR_FILE_ALREADY_EXISTS") {
+      let { fileName, lineNumber } = error;
+      error = FSError("mkdir", "EEXIST", 47, path, fileName, lineNumber);
+    }
+    throw error;
+  }
+};
+exports.mkdirSync = mkdirSync;
+
+/**
+ * Asynchronous mkdir(2). No arguments other than a possible exception are
+ * given to the completion callback.
+ */
+let mkdir = Async(mkdirSync);
+exports.mkdir = mkdir;
+
+/**
+ * Synchronous readdir(3). Returns an array of filenames excluding `"."` and
+ * `".."`.
+ */
+function readdirSync(path) {
+  try {
+    return toArray(new nsILocalFile(path).directoryEntries).map(getFileName);
+  }
+  catch (error) {
+    // Adjust exception thorw to match ones thrown by node.
+    if (error.name === "NS_ERROR_FILE_TARGET_DOES_NOT_EXIST") {
+      let { fileName, lineNumber } = error;
+      error = FSError("readdir", "ENOENT", 34, path, fileName, lineNumber);
+    }
+    throw error;
+  }
+};
+exports.readdirSync = readdirSync;
+
+/**
+ * Asynchronous readdir(3). Reads the contents of a directory. The callback
+ * gets two arguments `(error, files)` where `files` is an array of the names
+ * of the files in the directory excluding `"."` and `".."`.
+ */
+let readdir = Async(readdirSync);
+exports.readdir = readdir;
+
+/**
+ * Synchronous close(2).
+ */
+ function closeSync(fd) {
+   let input = nsIFileInputStream(fd);
+   let output = nsIFileOutputStream(fd);
+
+   // Closing input stream and removing reference.
+   if (input) input.close();
+   // Closing output stream and removing reference.
+   if (output) output.close();
+
+   nsIFile(fd, null);
+   nsIFileInputStream(fd, null);
+   nsIFileOutputStream(fd, null);
+   nsIBinaryInputStream(fd, null);
+   nsIBinaryOutputStream(fd, null);
+};
+exports.closeSync = closeSync;
+/**
+ * Asynchronous close(2). No arguments other than a possible exception are
+ * given to the completion callback.
+ */
+let close = Async(closeSync);
+exports.close = close;
+
+/**
+ * Synchronous open(2).
+ */
+function openSync(path, flags, mode) {
+  let [ fd, flags, mode, file ] =
+      [ { path: path }, Flags(flags), Mode(mode), nsILocalFile(path) ];
+
+  // If trying to open file for just read that does not exists
+  // need to throw exception as node does.
+  if (!file.exists() && !isWritable(flags))
+    throw FSError("open", "ENOENT", 34, path);
+
+  // If we want to open file in read mode we initialize input stream.
+  if (isReadable(flags)) {
+    let input = FileInputStream(file, flags, mode, DEFER_OPEN);
+    nsIFileInputStream(fd, input);
+  }
+
+  // If we want to open file in write mode we initialize output stream for it.
+  if (isWritable(flags)) {
+    let output = FileOutputStream(file, flags, mode, DEFER_OPEN);
+    nsIFileOutputStream(fd, output);
+  }
+
+  return fd;
+}
+exports.openSync = openSync;
+/**
+ * Asynchronous file open. See open(2). Flags can be
+ * `"r", "r+", "w", "w+", "a"`, or `"a+"`. mode defaults to `0666`.
+ * The callback gets two arguments `(error, fd).
+ */
+let open = Async(openSync);
+exports.open = open;
+
+/**
+ * Synchronous version of buffer-based fs.write(). Returns the number of bytes
+ * written.
+ */
+function writeSync(fd, buffer, offset, length, position) {
+  if (length + offset > buffer.length) {
+    throw Error("Length is extends beyond buffer");
+  }
+  else if (length + offset !== buffer.length) {
+    buffer = buffer.slice(offset, offset + length);
+  }
+  let writeStream = new WriteStream(fd, { position: position,
+                                          length: length });
+  let output = nsIBinaryOutputStream(fd);
+  // We write content as a byte array as this will avoid any transcoding
+  // if content was a buffer.
+  output.writeByteArray(buffer.valueOf(), buffer.length);
+  output.flush();
+};
+exports.writeSync = writeSync;
+
+/**
+ * Write buffer to the file specified by fd.
+ *
+ * `offset` and `length` determine the part of the buffer to be written.
+ *
+ * `position` refers to the offset from the beginning of the file where this
+ * data should be written. If `position` is `null`, the data will be written
+ * at the current position. See pwrite(2).
+ *
+ * The callback will be given three arguments `(error, written, buffer)` where
+ * written specifies how many bytes were written into buffer.
+ *
+ * Note that it is unsafe to use `fs.write` multiple times on the same file
+ * without waiting for the callback.
+ */
+function write(fd, buffer, offset, length, position, callback) {
+  if (!Buffer.isBuffer(buffer)) {
+    // (fd, data, position, encoding, callback)
+    let encoding = null;
+    [ position, encoding, callback ] = Array.slice(arguments, 1);
+    buffer = new Buffer(String(buffer), encoding);
+    offset = 0;
+  } else if (length + offset > buffer.length) {
+    throw Error("Length is extends beyond buffer");
+  } else if (length + offset !== buffer.length) {
+    buffer = buffer.slice(offset, offset + length);
+  }
+
+  let writeStream = new WriteStream(fd, { position: position,
+                                          length: length });
+  writeStream.on("error", callback);
+  writeStream.write(buffer, function onEnd() {
+    writeStream.destroy();
+    if (callback)
+      callback(null, buffer.length, buffer);
+  });
+};
+exports.write = write;
+
+/**
+ * Synchronous version of string-based fs.read. Returns the number of
+ * bytes read.
+ */
+function readSync(fd, buffer, offset, length, position) {
+  let input = nsIFileInputStream(fd);
+  // Setting a stream position, unless it"s `-1` which means current position.
+  if (position >= 0)
+    input.QueryInterface(Ci.nsISeekableStream).seek(NS_SEEK_SET, position);
+  // We use `nsIStreamTransportService` service to transform blocking
+  // file input stream into a fully asynchronous stream that can be written
+  // without blocking the main thread.
+  let binaryInputStream = BinaryInputStream(input);
+  let count = length === ALL ? binaryInputStream.available() : length;
+  var bytes = binaryInputStream.readByteArray(count);
+  buffer.copy.call(bytes, buffer, offset);
+
+  return bytes;
+};
+exports.readSync = readSync;
+
+/**
+ * Read data from the file specified by `fd`.
+ *
+ * `buffer` is the buffer that the data will be written to.
+ * `offset` is offset within the buffer where writing will start.
+ *
+ * `length` is an integer specifying the number of bytes to read.
+ *
+ * `position` is an integer specifying where to begin reading from in the file.
+ * If `position` is `null`, data will be read from the current file position.
+ *
+ * The callback is given the three arguments, `(error, bytesRead, buffer)`.
+ */
+function read(fd, buffer, offset, length, position, callback) {
+  let bytesRead = 0;
+  let readStream = new ReadStream(fd, { position: position, length: length });
+  readStream.on("data", function onData(chunck) {
+      chunck.copy(buffer, offset + bytesRead);
+      bytesRead += chunck.length;
+  });
+  readStream.on("end", function onEnd() {
+    callback(null, bytesRead, buffer);
+    readStream.destroy();
+  });
+};
+exports.read = read;
+
+/**
+ * Asynchronously reads the entire contents of a file.
+ * The callback is passed two arguments `(error, data)`, where data is the
+ * contents of the file.
+ */
+function readFile(path, encoding, callback) {
+  if (isFunction(encoding)) {
+    callback = encoding
+    encoding = null
+  }
+
+  let buffer = new Buffer();
+  try {
+    let readStream = new ReadStream(path);
+    readStream.on("data", function(chunck) {
+      chunck.copy(buffer, buffer.length);
+    });
+    readStream.on("error", function onError(error) {
+      callback(error);
+      readStream.destroy();
+    });
+    readStream.on("end", function onEnd() {
+      callback(null, buffer);
+      readStream.destroy();
+    });
+  } catch (error) {
+    setTimeout(callback, 0, error);
+  }
+};
+exports.readFile = readFile;
+
+/**
+ * Synchronous version of `fs.readFile`. Returns the contents of the path.
+ * If encoding is specified then this function returns a string.
+ * Otherwise it returns a buffer.
+ */
+function readFileSync(path, encoding) {
+  let buffer = new Buffer();
+  let fd = openSync(path, "r");
+  try {
+    readSync(fd, buffer, 0, ALL, 0);
+  }
+  finally {
+    closeSync(fd);
+  }
+  return buffer;
+};
+exports.readFileSync = readFileSync;
+
+/**
+ * Asynchronously writes data to a file, replacing the file if it already
+ * exists. data can be a string or a buffer.
+ */
+function writeFile(path, content, encoding, callback) {
+  try {
+    if (isFunction(encoding)) {
+      callback = encoding
+      encoding = null
+    }
+    if (isString(content))
+      content = new Buffer(content, encoding);
+
+    let writeStream = new WriteStream(path);
+    writeStream.on("error", function onError(error) {
+      callback(error);
+      writeStream.destroy();
+    });
+    writeStream.write(content, function onDrain() {
+      callback(null);
+      writeStream.destroy();
+    });
+  } catch (error) {
+    callback(error);
+  }
+};
+exports.writeFile = writeFile;
+
+/**
+ * The synchronous version of `fs.writeFile`.
+ */
+function writeFileSync(filename, data, encoding) {
+  throw Error("Not implemented");
+};
+exports.writeFileSync = writeFileSync;
+
+
+function utimesSync(path, atime, mtime) {
+  throw Error("Not implemented");
+}
+exports.utimesSync = utimesSync;
+
+let utimes = Async(utimesSync);
+exports.utimes = utimes;
+
+function futimesSync(fd, atime, mtime, callback) {
+  throw Error("Not implemented");
+}
+exports.futimesSync = futimesSync;
+
+let futimes = Async(futimesSync);
+exports.futimes = futimes;
+
+function fsyncSync(fd, atime, mtime, callback) {
+  throw Error("Not implemented");
+}
+exports.fsyncSync = fsyncSync;
+
+let fsync = Async(fsyncSync);
+exports.fsync = fsync;
+
+
+/**
+ * Watch for changes on filename. The callback listener will be called each
+ * time the file is accessed.
+ *
+ * The second argument is optional. The options if provided should be an object
+ * containing two members a boolean, persistent, and interval, a polling value
+ * in milliseconds. The default is { persistent: true, interval: 0 }.
+ */
+function watchFile(path, options, listener) {
+  throw Error("Not implemented");
+};
+exports.watchFile = watchFile;
+
+
+function unwatchFile(path, listener) {
+  throw Error("Not implemented");
+}
+exports.unwatchFile = unwatchFile;
+
+function watch(path, options, listener) {
+  throw Error("Not implemented");
+}
+exports.watch = watch;

--- a/lib/sdk/io/stream.js
+++ b/lib/sdk/io/stream.js
@@ -1,0 +1,324 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+"use strict";
+
+module.metadata = {
+  "stability": "experimental"
+};
+
+const { EventTarget } = require("../event/target");
+const { emit } = require("../event/core");
+const { Buffer } = require("./buffer");
+const { Class } = require("../core/heritage");
+const { setTimeout } = require("../timers");
+const { ns } = require("../core/namespace");
+
+function isFunction(value) typeof value === "function"
+
+function accessor() {
+  let map = new WeakMap();
+  return function(fd, value) {
+    if (value === null) map.delete(fd);
+    if (value !== undefined) map.set(fd, value);
+    return map.get(fd);
+  }
+}
+
+let nsIInputStreamPump = accessor();
+let nsIAsyncOutputStream = accessor();
+let nsIInputStream = accessor();
+let nsIOutputStream = accessor();
+
+
+/**
+ * Utility function / hack that we use to figure if output stream is closed.
+ */
+function isClosed(stream) {
+  // We assume that stream is not closed.
+  let isClosed = false;
+  stream.asyncWait({
+    // If `onClose` callback is called before outer function returns
+    // (synchronously) `isClosed` will be set to `true` identifying
+    // that stream is closed.
+    onOutputStreamReady: function onClose() isClosed = true
+
+  // `WAIT_CLOSURE_ONLY` flag overrides the default behavior, causing the
+  // `onOutputStreamReady` notification to be suppressed until the stream
+  // becomes closed.
+  }, stream.WAIT_CLOSURE_ONLY, 0, null);
+  return isClosed;
+}
+/**
+ * Utility function takes output `stream`, `onDrain`, `onClose` callbacks and
+ * calls one of this callbacks depending on stream state. It is guaranteed
+ * that only one called will be called and it will be called asynchronously.
+ * @param {nsIAsyncOutputStream} stream
+ * @param {Function} onDrain
+ *    callback that is called when stream becomes writable.
+ * @param {Function} onClose
+ *    callback that is called when stream becomes closed.
+ */
+function onStateChange(stream, target) {
+  let isAsync = false;
+  stream.asyncWait({
+    onOutputStreamReady: function onOutputStreamReady() {
+      // If `isAsync` was not yet set to `true` by the last line we know that
+      // `onOutputStreamReady` was called synchronously. In such case we just
+      // defer execution until next turn of event loop.
+      if (!isAsync)
+        return setTimeout(onOutputStreamReady, 0);
+
+      // As it"s not clear what is a state of the stream (TODO: Is there really
+      // no better way ?) we employ hack (see details in `isClosed`) to verify
+      // if stream is closed.
+      emit(target, isClosed(stream) ? "close" : "drain");
+    }
+  }, 0, 0, null);
+  isAsync = true;
+}
+
+function pump(stream) {
+  let input = nsIInputStream(stream);
+  nsIInputStreamPump(stream).asyncRead({
+    onStartRequest: function onStartRequest() {
+      emit(stream, "start");
+    },
+    onDataAvailable: function onDataAvailable(req, c, is, offset, count) {
+      try {
+        let bytes = input.readByteArray(count);
+        emit(stream, "data", new Buffer(bytes, stream.encoding));
+      } catch (error) {
+        emit(stream, "error", error);
+        stream.readable = false;
+      }
+    },
+    onStopRequest: function onStopRequest() {
+      stream.readable = false;
+      emit(stream, "end");
+    }
+  }, null);
+}
+
+const Stream = Class({
+  extends: EventTarget,
+  initialize: function() {
+    this.readable = false;
+    this.writable = false;
+    this.encoding = null;
+  },
+  setEncoding: function setEncoding(encoding) {
+    this.encoding = String(encoding).toUpperCase();
+  },
+  pipe: function pipe(target, options) {
+    let source = this;
+    function onData(chunk) {
+      if (target.writable) {
+        if (false === target.write(chunk))
+          source.pause();
+      }
+    }
+    function onDrain() {
+      if (source.readable) source.resume();
+    }
+    function onEnd() {
+      target.end();
+    }
+    function onPause() {
+      source.pause();
+    }
+    function onResume() {
+      if (source.readable)
+        source.resume();
+    }
+
+    function cleanup() {
+      source.removeListener("data", onData);
+      target.removeListener("drain", onDrain);
+      source.removeListener("end", onEnd);
+
+      target.removeListener("pause", onPause);
+      target.removeListener("resume", onResume);
+
+      source.removeListener("end", cleanup);
+      source.removeListener("close", cleanup);
+
+      target.removeListener("end", cleanup);
+      target.removeListener("close", cleanup);
+    }
+
+    if (!options || options.end !== false)
+      target.on("end", onEnd);
+
+    source.on("data", onData);
+    target.on("drain", onDrain);
+    target.on("resume", onResume);
+    target.on("pause", onPause);
+
+    source.on("end", cleanup);
+    source.on("close", cleanup);
+
+    target.on("end", cleanup);
+    target.on("close", cleanup);
+
+    emit(target, "pipe", source);
+  },
+  pause: function pause() {
+    emit(this, "pause");
+  },
+  resume: function resume() {
+    emit(this, "resume");
+  },
+  destroySoon: function destroySoon() {
+    this.destroy();
+  }
+});
+exports.Stream = Stream;
+
+const InputStream = Class({
+  extends: Stream,
+  initialize: function initialize(options) {
+    let { input, pump } = options;
+
+    this.readable = true;
+    this.paused = false;
+    nsIInputStream(this, input);
+    nsIInputStreamPump(this, pump);
+  },
+  get status() nsIInputStreamPump(this).status,
+  read: function() pump(this),
+  pause: function pause() {
+    this.paused = true;
+    nsIInputStreamPump(this).suspend();
+    emit(this, "paused");
+  },
+  resume: function resume() {
+    this.paused = false;
+    nsIInputStreamPump(this).resume();
+    emit(this, "resume");
+  },
+  destroy: function destroy() {
+    this.readable = false;
+    try {
+      emit(this, "close", null);
+      nsIInputStreamPump(this).cancel(null);
+      nsIInputStreamPump(this, null);
+
+      nsIInputStream(this).close();
+      nsIInputStream(this, null);
+    } catch (error) {
+      emit(this, "error", error);
+    }
+  }
+});
+exports.InputStream = InputStream;
+
+const OutputStream = Class({
+  extends: Stream,
+  initialize: function initialize(options) {
+    let { output, asyncOutputStream } = options;
+
+    this.writable = true;
+    nsIOutputStream(this, output);
+    nsIAsyncOutputStream(this, asyncOutputStream);
+  },
+  write: function write(content, encoding, callback) {
+    let output = nsIOutputStream(this);
+    let asyncOutputStream = nsIAsyncOutputStream(this);
+
+    if (isFunction(encoding)) {
+      callback = encoding;
+      encoding = callback;
+    }
+
+    // Flag indicating whether or not content has been flushed to the kernel
+    // buffer.
+    let isWritten = false;
+    // If stream is not writable we throw an error.
+    if (!this.writable)
+      throw Error("stream not writable");
+
+    try {
+      // If content is not a buffer then we create one out of it.
+      if (!Buffer.isBuffer(content))
+        content = new Buffer(content, encoding);
+
+      // We write content as a byte array as this will avoid any transcoding
+      // if content was a buffer.
+      output.writeByteArray(content.valueOf(), content.length);
+      output.flush();
+
+      if (callback) this.once("drain", callback);
+      onStateChange(asyncOutputStream, this);
+      return true;
+    } catch (error) {
+      // If errors occur we emit appropriate event.
+      emit(this, "error", error);
+    }
+  },
+  flush: function flush() {
+    nsIOutputStream(this).flush();
+  },
+  end: function end(content, encoding, callback) {
+    if (isFunction(content)) {
+      callback = content
+      content = callback
+    }
+    if (isFunction(encoding)) {
+      callback = encoding
+      encoding = callback
+    }
+
+    // Setting a listener to "close" event if passed.
+    if (isFunction(callback))
+      this.once("close", callback);
+
+    // If content is passed then we defer closing until we finish with writing.
+    if (content)
+      this.write(content, encoding, end.bind(this));
+    // If we don"t write anything, then we close an outputStream.
+    else
+      nsIOutputStream(this).close();
+  },
+  destroy: function destroy(callback) {
+    try {
+      this.end(callback);
+      nsIOutputStream(this, null);
+      nsIAsyncOutputStream(this, null);
+    } catch (error) {
+      emit(this, "error", error);
+    }
+  }
+});
+exports.OutputStream = OutputStream;
+
+const DuplexStream = Class({
+  extends: Stream,
+  initialize: function initialize(options) {
+    let { input, output, pump } = options;
+
+    this.writable = true;
+    this.readable = true;
+    this.encoding = null;
+
+    nsIInputStream(this, input);
+    nsIOutputStream(this, output);
+    nsIInputStreamPump(this, pump);
+  },
+  read: InputStream.prototype.read,
+  pause: InputStream.prototype.pause,
+  resume: InputStream.prototype.resume,
+
+  write: OutputStream.prototype.write,
+  flush: OutputStream.prototype.flush,
+  end: OutputStream.prototype.end,
+
+  destroy: function destroy(error) {
+    if (error)
+      emit(this, "error", error);
+    InputStream.prototype.destroy.call(this);
+    OutputStream.prototype.destroy.call(this);
+  }
+});
+exports.DuplexStream = DuplexStream;

--- a/lib/sdk/system.js
+++ b/lib/sdk/system.js
@@ -85,7 +85,7 @@ exports.stdout = new function() {
 /**
  * Returns a path of the system's or application's special directory / file
  * associated with a given `id`. For list of possible `id`s please see:
- * https://developer.mozilla.org/en/Code_snippets/File_I%2F%2FO#Getting_special_files
+ * https://developer.mozilla.org/en-US/docs/Code_snippets/File_I_O#Getting_files_in_special_directories
  * http://mxr.mozilla.org/mozilla-central/source/xpcom/io/nsAppDirectoryServiceDefs.h
  * @example
  *

--- a/lib/sdk/test.js
+++ b/lib/sdk/test.js
@@ -12,6 +12,8 @@ module.metadata = {
 const BaseAssert = require("sdk/test/assert").Assert;
 const { isFunction, isObject } = require("sdk/lang/type");
 
+exports.Assert = BaseAssert;
+
 function extend(target) {
   let descriptor = {}
   Array.slice(arguments, 1).forEach(function(source) {

--- a/test/test-fs.js
+++ b/test/test-fs.js
@@ -1,0 +1,462 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const { pathFor } = require("sdk/system");
+const fs = require("sdk/io/fs");
+const url = require("sdk/url");
+const path = require("sdk/fs/path");
+const { Buffer } = require("sdk/io/buffer");
+
+// Use profile directory to list / read / write files.
+const profilePath = pathFor("ProfD");
+const fileNameInProfile = "compatibility.ini";
+const dirNameInProfile = "extensions";
+const filePathInProfile = path.join(profilePath, fileNameInProfile);
+const dirPathInProfile = path.join(profilePath, dirNameInProfile);
+const mkdirPath = path.join(profilePath, "sdk-fixture-mkdir");
+const writePath = path.join(profilePath, "sdk-fixture-writeFile");
+const unlinkPath = path.join(profilePath, "sdk-fixture-unlink");
+const truncatePath = path.join(profilePath, "sdk-fixture-truncate");
+const renameFromPath = path.join(profilePath, "sdk-fixture-rename-from");
+const renameToPath = path.join(profilePath, "sdk-fixture-rename-to");
+
+const profileEntries = [
+  "compatibility.ini",
+  "extensions",
+  "extensions.ini",
+  "prefs.js"
+  // There are likely to be a lot more files but we can't really
+  // on consistent list so we limit to this.
+];
+
+exports["test readir"] = function(assert, end) {
+  var async = false;
+  fs.readdir(profilePath, function(error, entries) {
+    assert.ok(async, "readdir is async");
+    assert.ok(!error, "there is no error when reading directory");
+    assert.ok(profileEntries.length <= entries.length,
+              "got et least number of entries we expect");
+    assert.ok(profileEntries.every(function(entry) {
+                return entries.indexOf(entry) >= 0;
+              }), "all profiles are present");
+    end();
+  });
+
+  async = true;
+};
+
+exports["test readir error"] = function(assert, end) {
+  var async = false;
+  var path = profilePath + "-does-not-exists";
+  fs.readdir(path, function(error, entries) {
+    assert.ok(async, "readdir is async");
+    assert.equal(error.message, "ENOENT, readdir " + path);
+    assert.equal(error.code, "ENOENT", "error has a code");
+    assert.equal(error.path, path, "error has a path");
+    assert.equal(error.errno, 34, "error has a errno");
+    end();
+  });
+
+  async = true;
+};
+
+exports["test readdirSync"] = function(assert) {
+  var async = false;
+  var entries = fs.readdirSync(profilePath);
+  assert.ok(profileEntries.length <= entries.length,
+            "got et least number of entries we expect");
+  assert.ok(profileEntries.every(function(entry) {
+    return entries.indexOf(entry) >= 0;
+  }), "all profiles are present");
+};
+
+exports["test readirSync error"] = function(assert) {
+  var async = false;
+  var path = profilePath + "-does-not-exists";
+  try {
+    fs.readdirSync(path);
+    assert.fail(Error("No error was thrown"));
+  } catch (error) {
+    assert.equal(error.message, "ENOENT, readdir " + path);
+    assert.equal(error.code, "ENOENT", "error has a code");
+    assert.equal(error.path, path, "error has a path");
+    assert.equal(error.errno, 34, "error has a errno");
+  }
+};
+
+exports["test readFile"] = function(assert, end) {
+  let async = false;
+  fs.readFile(filePathInProfile, function(error, content) {
+    assert.ok(async, "readFile is async");
+    assert.ok(!error, "error is falsy");
+    assert.ok(Buffer.isBuffer(content), "readFile returns buffer");
+    assert.ok(typeof(content.length) === "number", "buffer has length");
+    assert.ok(content.toString().indexOf("[Compatibility]") >= 0,
+              "content contains expected data");
+    end();
+  });
+  async = true;
+};
+
+exports["test readFile error"] = function(assert, end) {
+  let async = false;
+  let path = filePathInProfile + "-does-not-exists";
+  fs.readFile(path, function(error, content) {
+    assert.ok(async, "readFile is async");
+    assert.equal(error.message, "ENOENT, open " + path);
+    assert.equal(error.code, "ENOENT", "error has a code");
+    assert.equal(error.path, path, "error has a path");
+    assert.equal(error.errno, 34, "error has a errno");
+
+    end();
+  });
+  async = true;
+};
+
+exports["test readFileSync not implemented"] = function(assert) {
+  let buffer = fs.readFileSync(filePathInProfile);
+  assert.ok(buffer.toString().indexOf("[Compatibility]") >= 0,
+            "read content");
+};
+
+exports["test fs.stat file"] = function(assert, end) {
+  let async = false;
+  let path = filePathInProfile;
+  fs.stat(path, function(error, stat) {
+    assert.ok(async, "fs.stat is async");
+    assert.ok(!error, "error is falsy");
+    assert.ok(!stat.isDirectory(), "not a dir");
+    assert.ok(stat.isFile(), "is a file");
+    assert.ok(!stat.isSymbolicLink(), "isn't a symlink");
+    assert.ok(typeof(stat.size) === "number", "size is a number");
+    assert.ok(stat.exists === true, "file exists");
+    assert.ok(typeof(stat.isBlockDevice()) === "boolean");
+    assert.ok(typeof(stat.isCharacterDevice()) === "boolean");
+    assert.ok(typeof(stat.isFIFO()) === "boolean");
+    assert.ok(typeof(stat.isSocket()) === "boolean");
+    assert.ok(typeof(stat.hidden) === "boolean");
+    assert.ok(typeof(stat.writable) === "boolean")
+    assert.ok(stat.readable === true);
+
+    end();
+  });
+  async = true;
+};
+
+exports["test fs.stat dir"] = function(assert, end) {
+  let async = false;
+  let path = dirPathInProfile;
+  fs.stat(path, function(error, stat) {
+    assert.ok(async, "fs.stat is async");
+    assert.ok(!error, "error is falsy");
+    assert.ok(stat.isDirectory(), "is a dir");
+    assert.ok(!stat.isFile(), "not a file");
+    assert.ok(!stat.isSymbolicLink(), "isn't a symlink");
+    assert.ok(typeof(stat.size) === "number", "size is a number");
+    assert.ok(stat.exists === true, "file exists");
+    assert.ok(typeof(stat.isBlockDevice()) === "boolean");
+    assert.ok(typeof(stat.isCharacterDevice()) === "boolean");
+    assert.ok(typeof(stat.isFIFO()) === "boolean");
+    assert.ok(typeof(stat.isSocket()) === "boolean");
+    assert.ok(typeof(stat.hidden) === "boolean");
+    assert.ok(typeof(stat.writable) === "boolean")
+    assert.ok(typeof(stat.readable) === "boolean");
+
+    end();
+  });
+  async = true;
+};
+
+exports["test fs.stat error"] = function(assert, end) {
+  let async = false;
+  let path = filePathInProfile + "-does-not-exists";
+  fs.stat(path, function(error, stat) {
+    assert.ok(async, "fs.stat is async");
+    assert.equal(error.message, "ENOENT, stat " + path);
+    assert.equal(error.code, "ENOENT", "error has a code");
+    assert.equal(error.path, path, "error has a path");
+    assert.equal(error.errno, 34, "error has a errno");
+
+    end();
+  });
+  async = true;
+};
+
+exports["test fs.exists NO"] = function(assert, end) {
+  let async = false
+  let path = filePathInProfile + "-does-not-exists";
+  fs.exists(path, function(error, value) {
+    assert.ok(async, "fs.exists is async");
+    assert.ok(!error, "error is falsy");
+    assert.ok(!value, "file does not exists");
+    end();
+  });
+  async = true;
+};
+
+exports["test fs.exists YES"] = function(assert, end) {
+  let async = false
+  let path = filePathInProfile
+  fs.exists(path, function(error, value) {
+    assert.ok(async, "fs.exists is async");
+    assert.ok(!error, "error is falsy");
+    assert.ok(value, "file exists");
+    end();
+  });
+  async = true;
+};
+
+exports["test fs.exists NO"] = function(assert, end) {
+  let async = false
+  let path = filePathInProfile + "-does-not-exists";
+  fs.exists(path, function(error, value) {
+    assert.ok(async, "fs.exists is async");
+    assert.ok(!error, "error is falsy");
+    assert.ok(!value, "file does not exists");
+    end();
+  });
+  async = true;
+};
+
+exports["test fs.existsSync"] = function(assert) {
+  let path = filePathInProfile
+  assert.equal(fs.existsSync(path), true, "exists");
+  assert.equal(fs.existsSync(path + "-does-not-exists"), false, "exists");
+};
+
+exports["test fs.mkdirSync fs.rmdirSync"] = function(assert) {
+  let path = mkdirPath;
+
+  assert.equal(fs.existsSync(path), false, "does not exists");
+  fs.mkdirSync(path);
+  assert.equal(fs.existsSync(path), true, "dir was created");
+  try {
+    fs.mkdirSync(path);
+    assert.fail(Error("mkdir on existing should throw"));
+  } catch (error) {
+    assert.equal(error.message, "EEXIST, mkdir " + path);
+    assert.equal(error.code, "EEXIST", "error has a code");
+    assert.equal(error.path, path, "error has a path");
+    assert.equal(error.errno, 47, "error has a errno");
+  }
+  fs.rmdirSync(path);
+  assert.equal(fs.existsSync(path), false, "dir was removed");
+};
+
+exports["test fs.mkdir"] = function(assert, end) {
+  let path = mkdirPath;
+
+  if (!fs.existsSync(path)) {
+    let async = false;
+    fs.mkdir(path, function(error) {
+      assert.ok(async, "mkdir is async");
+      assert.ok(!error, "no error");
+      assert.equal(fs.existsSync(path), true, "dir was created");
+      fs.rmdirSync(path);
+      assert.equal(fs.existsSync(path), false, "dir was removed");
+      end();
+    });
+    async = true;
+  }
+};
+
+exports["test fs.mkdir error"] = function(assert, end) {
+  let path = mkdirPath;
+
+  if (!fs.existsSync(path)) {
+    fs.mkdirSync(path);
+    let async = false;
+    fs.mkdir(path, function(error) {
+      assert.ok(async, "mkdir is async");
+      assert.equal(error.message, "EEXIST, mkdir " + path);
+      assert.equal(error.code, "EEXIST", "error has a code");
+      assert.equal(error.path, path, "error has a path");
+      assert.equal(error.errno, 47, "error has a errno");
+      fs.rmdirSync(path);
+      assert.equal(fs.existsSync(path), false, "dir was removed");
+      end();
+    });
+    async = true;
+  }
+};
+
+exports["test fs.rmdir"] = function(assert, end) {
+  let path = mkdirPath;
+
+  if (!fs.existsSync(path)) {
+    fs.mkdirSync(path);
+    assert.equal(fs.existsSync(path), true, "dir exists");
+    let async = false;
+    fs.rmdir(path, function(error) {
+      assert.ok(async, "mkdir is async");
+      assert.ok(!error, "no error");
+      assert.equal(fs.existsSync(path), false, "dir was removed");
+      end();
+    });
+    async = true;
+  }
+};
+
+
+exports["test fs.rmdir error"] = function(assert, end) {
+  let path = mkdirPath;
+
+  if (!fs.existsSync(path)) {
+    assert.equal(fs.existsSync(path), false, "dir doesn't exists");
+    let async = false;
+    fs.rmdir(path, function(error) {
+      assert.ok(async, "mkdir is async");
+      assert.equal(error.message, "ENOENT, remove " + path);
+      assert.equal(error.code, "ENOENT", "error has a code");
+      assert.equal(error.path, path, "error has a path");
+      assert.equal(error.errno, 34, "error has a errno");
+      assert.equal(fs.existsSync(path), false, "dir is removed");
+      end();
+    });
+    async = true;
+  }
+};
+
+exports["test fs.truncateSync fs.unlinkSync"] = function(assert) {
+  let path = truncatePath;
+
+  assert.equal(fs.existsSync(path), false, "does not exists");
+  fs.truncateSync(path);
+  assert.equal(fs.existsSync(path), true, "file was created");
+  fs.truncateSync(path);
+  fs.unlinkSync(path);
+  assert.equal(fs.existsSync(path), false, "file was removed");
+};
+
+
+exports["test fs.truncate"] = function(assert, end) {
+  let path = truncatePath;
+  if (!fs.existsSync(path)) {
+    let async = false;
+    fs.truncate(path, 0, function(error) {
+      assert.ok(async, "truncate is async");
+      console.log(error);
+      assert.ok(!error, "no error");
+      assert.equal(fs.existsSync(path), true, "file was created");
+      fs.unlinkSync(path);
+      assert.equal(fs.existsSync(path), false, "file was removed");
+      end();
+    })
+    async = true;
+  }
+};
+
+exports["test fs.unlink"] = function(assert, end) {
+  let path = unlinkPath;
+  let async = false;
+  assert.ok(!fs.existsSync(path), "file doesn't exists yet");
+  fs.truncateSync(path, 0);
+  assert.ok(fs.existsSync(path), "file was created");
+  fs.unlink(path, function(error) {
+    assert.ok(async, "fs.unlink is async");
+    assert.ok(!error, "error is falsy");
+    assert.ok(!fs.existsSync(path), "file was removed");
+    end();
+  });
+  async = true;
+};
+
+exports["test fs.unlink error"] = function(assert, end) {
+  let path = unlinkPath;
+  let async = false;
+  assert.ok(!fs.existsSync(path), "file doesn't exists yet");
+  fs.unlink(path, function(error) {
+    assert.ok(async, "fs.unlink is async");
+    assert.equal(error.message, "ENOENT, remove " + path);
+    assert.equal(error.code, "ENOENT", "error has a code");
+    assert.equal(error.path, path, "error has a path");
+    assert.equal(error.errno, 34, "error has a errno");
+    end();
+  });
+  async = true;
+};
+
+exports["test fs.rename"] = function(assert, end) {
+  let fromPath = renameFromPath;
+  let toPath = renameToPath;
+
+  fs.truncateSync(fromPath);
+  assert.ok(fs.existsSync(fromPath), "source file exists");
+  assert.ok(!fs.existsSync(toPath), "destination doesn't exists");
+  var async = false;
+  fs.rename(fromPath, toPath, function(error) {
+    assert.ok(async, "fs.rename is async");
+    assert.ok(!error, "error is falsy");
+    assert.ok(!fs.existsSync(fromPath), "source path no longer exists");
+    assert.ok(fs.existsSync(toPath), "destination file exists");
+    fs.unlinkSync(toPath);
+    assert.ok(!fs.existsSync(toPath), "cleaned up properly");
+    end();
+  });
+  async = true;
+};
+
+exports["test fs.rename (missing source file)"] = function(assert, end) {
+  let fromPath = renameFromPath;
+  let toPath = renameToPath;
+
+  assert.ok(!fs.existsSync(fromPath), "source file doesn't exists");
+  assert.ok(!fs.existsSync(toPath), "destination doesn't exists");
+  var async = false;
+  fs.rename(fromPath, toPath, function(error) {
+    assert.ok(async, "fs.rename is async");
+    assert.equal(error.message, "ENOENT, rename " + fromPath);
+    assert.equal(error.code, "ENOENT", "error has a code");
+    assert.equal(error.path, fromPath, "error has a path");
+    assert.equal(error.errno, 34, "error has a errno");
+    end();
+  });
+  async = true;
+};
+
+exports["test fs.rename (existing target file)"] = function(assert, end) {
+  let fromPath = renameFromPath;
+  let toPath = renameToPath;
+
+  fs.truncateSync(fromPath);
+  fs.truncateSync(toPath);
+  assert.ok(fs.existsSync(fromPath), "source file exists");
+  assert.ok(fs.existsSync(toPath), "destination file exists");
+  var async = false;
+  fs.rename(fromPath, toPath, function(error) {
+    assert.ok(async, "fs.rename is async");
+    assert.ok(!error, "error is falsy");
+    assert.ok(!fs.existsSync(fromPath), "source path no longer exists");
+    assert.ok(fs.existsSync(toPath), "destination file exists");
+    fs.unlinkSync(toPath);
+    assert.ok(!fs.existsSync(toPath), "cleaned up properly");
+    end();
+  });
+  async = true;
+};
+
+exports["test fs.writeFile"] = function(assert, end) {
+  let path = writePath;
+  let content = ["hello world",
+                 "this is some text"].join("\n");
+
+  var async = false;
+  fs.writeFile(path, content, function(error) {
+    assert.ok(async, "fs write is sync");
+    assert.ok(!error, "error is falsy");
+    assert.ok(fs.existsSync(path), "file was created");
+    assert.equal(fs.readFileSync(path).toString(),
+                 content,
+                 "contet was written");
+    fs.unlinkSync(path);
+    assert.ok(!fs.exists(path), "file was removed");
+
+    end();
+  });
+  async = true;
+};
+
+require("test").run(exports);

--- a/test/test-path.js
+++ b/test/test-path.js
@@ -1,0 +1,285 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+// Adapted version of:
+// https://github.com/joyent/node/blob/v0.9.1/test/simple/test-path.js
+
+exports['test path'] = function(assert) {
+
+var system = require('sdk/system');
+var path = require('sdk/fs/path');
+var isWindows = require('sdk/system').platform.indexOf('win') === 0;
+
+
+// POSIX filenames may include control characters
+// c.f. http://www.dwheeler.com/essays/fixing-unix-linux-filenames.html
+if (!isWindows) {
+  var controlCharFilename = 'Icon' + String.fromCharCode(13);
+  assert.equal(path.basename('/a/b/' + controlCharFilename),
+               controlCharFilename);
+}
+
+
+assert.equal(path.dirname('/a/b/'), '/a');
+assert.equal(path.dirname('/a/b'), '/a');
+assert.equal(path.dirname('/a'), '/');
+assert.equal(path.dirname('/'), '/');
+
+if (isWindows) {
+  assert.equal(path.dirname('c:\\'), 'c:\\');
+  assert.equal(path.dirname('c:\\foo'), 'c:\\');
+  assert.equal(path.dirname('c:\\foo\\'), 'c:\\');
+  assert.equal(path.dirname('c:\\foo\\bar'), 'c:\\foo');
+  assert.equal(path.dirname('c:\\foo\\bar\\'), 'c:\\foo');
+  assert.equal(path.dirname('c:\\foo\\bar\\baz'), 'c:\\foo\\bar');
+  assert.equal(path.dirname('\\'), '\\');
+  assert.equal(path.dirname('\\foo'), '\\');
+  assert.equal(path.dirname('\\foo\\'), '\\');
+  assert.equal(path.dirname('\\foo\\bar'), '\\foo');
+  assert.equal(path.dirname('\\foo\\bar\\'), '\\foo');
+  assert.equal(path.dirname('\\foo\\bar\\baz'), '\\foo\\bar');
+  assert.equal(path.dirname('c:'), 'c:');
+  assert.equal(path.dirname('c:foo'), 'c:');
+  assert.equal(path.dirname('c:foo\\'), 'c:');
+  assert.equal(path.dirname('c:foo\\bar'), 'c:foo');
+  assert.equal(path.dirname('c:foo\\bar\\'), 'c:foo');
+  assert.equal(path.dirname('c:foo\\bar\\baz'), 'c:foo\\bar');
+  assert.equal(path.dirname('\\\\unc\\share'), '\\\\unc\\share');
+  assert.equal(path.dirname('\\\\unc\\share\\foo'), '\\\\unc\\share\\');
+  assert.equal(path.dirname('\\\\unc\\share\\foo\\'), '\\\\unc\\share\\');
+  assert.equal(path.dirname('\\\\unc\\share\\foo\\bar'),
+               '\\\\unc\\share\\foo');
+  assert.equal(path.dirname('\\\\unc\\share\\foo\\bar\\'),
+               '\\\\unc\\share\\foo');
+  assert.equal(path.dirname('\\\\unc\\share\\foo\\bar\\baz'),
+               '\\\\unc\\share\\foo\\bar');
+}
+
+
+assert.equal(path.extname(''), '');
+assert.equal(path.extname('/path/to/file'), '');
+assert.equal(path.extname('/path/to/file.ext'), '.ext');
+assert.equal(path.extname('/path.to/file.ext'), '.ext');
+assert.equal(path.extname('/path.to/file'), '');
+assert.equal(path.extname('/path.to/.file'), '');
+assert.equal(path.extname('/path.to/.file.ext'), '.ext');
+assert.equal(path.extname('/path/to/f.ext'), '.ext');
+assert.equal(path.extname('/path/to/..ext'), '.ext');
+assert.equal(path.extname('file'), '');
+assert.equal(path.extname('file.ext'), '.ext');
+assert.equal(path.extname('.file'), '');
+assert.equal(path.extname('.file.ext'), '.ext');
+assert.equal(path.extname('/file'), '');
+assert.equal(path.extname('/file.ext'), '.ext');
+assert.equal(path.extname('/.file'), '');
+assert.equal(path.extname('/.file.ext'), '.ext');
+assert.equal(path.extname('.path/file.ext'), '.ext');
+assert.equal(path.extname('file.ext.ext'), '.ext');
+assert.equal(path.extname('file.'), '.');
+assert.equal(path.extname('.'), '');
+assert.equal(path.extname('./'), '');
+assert.equal(path.extname('.file.ext'), '.ext');
+assert.equal(path.extname('.file'), '');
+assert.equal(path.extname('.file.'), '.');
+assert.equal(path.extname('.file..'), '.');
+assert.equal(path.extname('..'), '');
+assert.equal(path.extname('../'), '');
+assert.equal(path.extname('..file.ext'), '.ext');
+assert.equal(path.extname('..file'), '.file');
+assert.equal(path.extname('..file.'), '.');
+assert.equal(path.extname('..file..'), '.');
+assert.equal(path.extname('...'), '.');
+assert.equal(path.extname('...ext'), '.ext');
+assert.equal(path.extname('....'), '.');
+assert.equal(path.extname('file.ext/'), '');
+
+if (isWindows) {
+  // On windows, backspace is a path separator.
+  assert.equal(path.extname('.\\'), '');
+  assert.equal(path.extname('..\\'), '');
+  assert.equal(path.extname('file.ext\\'), '');
+} else {
+  // On unix, backspace is a valid name component like any other character.
+  assert.equal(path.extname('.\\'), '');
+  assert.equal(path.extname('..\\'), '.\\');
+  assert.equal(path.extname('file.ext\\'), '.ext\\');
+}
+
+// path.join tests
+var failures = [];
+var joinTests =
+    // arguments                     result
+    [[['.', 'x/b', '..', '/b/c.js'], 'x/b/c.js'],
+     [['/.', 'x/b', '..', '/b/c.js'], '/x/b/c.js'],
+     [['/foo', '../../../bar'], '/bar'],
+     [['foo', '../../../bar'], '../../bar'],
+     [['foo/', '../../../bar'], '../../bar'],
+     [['foo/x', '../../../bar'], '../bar'],
+     [['foo/x', './bar'], 'foo/x/bar'],
+     [['foo/x/', './bar'], 'foo/x/bar'],
+     [['foo/x/', '.', 'bar'], 'foo/x/bar'],
+     [['./'], './'],
+     [['.', './'], './'],
+     [['.', '.', '.'], '.'],
+     [['.', './', '.'], '.'],
+     [['.', '/./', '.'], '.'],
+     [['.', '/////./', '.'], '.'],
+     [['.'], '.'],
+     [['', '.'], '.'],
+     [['', 'foo'], 'foo'],
+     [['foo', '/bar'], 'foo/bar'],
+     [['', '/foo'], '/foo'],
+     [['', '', '/foo'], '/foo'],
+     [['', '', 'foo'], 'foo'],
+     [['foo', ''], 'foo'],
+     [['foo/', ''], 'foo/'],
+     [['foo', '', '/bar'], 'foo/bar'],
+     [['./', '..', '/foo'], '../foo'],
+     [['./', '..', '..', '/foo'], '../../foo'],
+     [['.', '..', '..', '/foo'], '../../foo'],
+     [['', '..', '..', '/foo'], '../../foo'],
+     [['/'], '/'],
+     [['/', '.'], '/'],
+     [['/', '..'], '/'],
+     [['/', '..', '..'], '/'],
+     [[''], '.'],
+     [['', ''], '.'],
+     [[' /foo'], ' /foo'],
+     [[' ', 'foo'], ' /foo'],
+     [[' ', '.'], ' '],
+     [[' ', '/'], ' /'],
+     [[' ', ''], ' '],
+     // filtration of non-strings.
+     [['x', true, 7, 'y', null, {}], 'x/y']
+    ];
+joinTests.forEach(function(test) {
+  var actual = path.join.apply(path, test[0]);
+  var expected = isWindows ? test[1].replace(/\//g, '\\') : test[1];
+  var message = 'path.join(' + test[0].map(JSON.stringify).join(',') + ')' +
+                '\n  expect=' + JSON.stringify(expected) +
+                '\n  actual=' + JSON.stringify(actual);
+  if (actual !== expected) failures.push('\n' + message);
+  // assert.equal(actual, expected, message);
+});
+assert.equal(failures.length, 0, failures.join(''));
+
+// path normalize tests
+if (isWindows) {
+  assert.equal(path.normalize('./fixtures///b/../b/c.js'),
+               'fixtures\\b\\c.js');
+  assert.equal(path.normalize('/foo/../../../bar'), '\\bar');
+  assert.equal(path.normalize('a//b//../b'), 'a\\b');
+  assert.equal(path.normalize('a//b//./c'), 'a\\b\\c');
+  assert.equal(path.normalize('a//b//.'), 'a\\b');
+  assert.equal(path.normalize('//server/share/dir/file.ext'),
+               '\\\\server\\share\\dir\\file.ext');
+} else {
+  assert.equal(path.normalize('./fixtures///b/../b/c.js'),
+               'fixtures/b/c.js');
+  assert.equal(path.normalize('/foo/../../../bar'), '/bar');
+  assert.equal(path.normalize('a//b//../b'), 'a/b');
+  assert.equal(path.normalize('a//b//./c'), 'a/b/c');
+  assert.equal(path.normalize('a//b//.'), 'a/b');
+}
+
+// path.resolve tests
+if (isWindows) {
+  // windows
+  var resolveTests =
+      // arguments                                    result
+      [[['c:/blah\\blah', 'd:/games', 'c:../a'], 'c:\\blah\\a'],
+       [['c:/ignore', 'd:\\a/b\\c/d', '\\e.exe'], 'd:\\e.exe'],
+       [['c:/ignore', 'c:/some/file'], 'c:\\some\\file'],
+       [['d:/ignore', 'd:some/dir//'], 'd:\\ignore\\some\\dir'],
+       [['.'], system.pathFor('CurProcD')],
+       [['//server/share', '..', 'relative\\'], '\\\\server\\share\\relative']];
+} else {
+  // Posix
+  var resolveTests =
+      // arguments                                    result
+      [[['/var/lib', '../', 'file/'], '/var/file'],
+       [['/var/lib', '/../', 'file/'], '/file'],
+       [['a/b/c/', '../../..'], system.pathFor('CurProcD')],
+       [['.'], system.pathFor('CurProcD')],
+       [['/some/dir', '.', '/absolute/'], '/absolute']];
+}
+var failures = [];
+resolveTests.forEach(function(test) {
+  var actual = path.resolve.apply(path, test[0]);
+  var expected = test[1];
+  var message = 'path.resolve(' + test[0].map(JSON.stringify).join(',') + ')' +
+                '\n  expect=' + JSON.stringify(expected) +
+                '\n  actual=' + JSON.stringify(actual);
+  if (actual !== expected) failures.push('\n' + message);
+  // assert.equal(actual, expected, message);
+});
+assert.equal(failures.length, 0, failures.join(''));
+
+// path.relative tests
+if (isWindows) {
+  // windows
+  var relativeTests =
+      // arguments                     result
+      [['c:/blah\\blah', 'd:/games', 'd:\\games'],
+       ['c:/aaaa/bbbb', 'c:/aaaa', '..'],
+       ['c:/aaaa/bbbb', 'c:/cccc', '..\\..\\cccc'],
+       ['c:/aaaa/bbbb', 'c:/aaaa/bbbb', ''],
+       ['c:/aaaa/bbbb', 'c:/aaaa/cccc', '..\\cccc'],
+       ['c:/aaaa/', 'c:/aaaa/cccc', 'cccc'],
+       ['c:/', 'c:\\aaaa\\bbbb', 'aaaa\\bbbb'],
+       ['c:/aaaa/bbbb', 'd:\\', 'd:\\']];
+} else {
+  // posix
+  var relativeTests =
+      // arguments                    result
+      [['/var/lib', '/var', '..'],
+       ['/var/lib', '/bin', '../../bin'],
+       ['/var/lib', '/var/lib', ''],
+       ['/var/lib', '/var/apache', '../apache'],
+       ['/var/', '/var/lib', 'lib'],
+       ['/', '/var/lib', 'var/lib']];
+}
+var failures = [];
+relativeTests.forEach(function(test) {
+  var actual = path.relative(test[0], test[1]);
+  var expected = test[2];
+  var message = 'path.relative(' +
+                test.slice(0, 2).map(JSON.stringify).join(',') +
+                ')' +
+                '\n  expect=' + JSON.stringify(expected) +
+                '\n  actual=' + JSON.stringify(actual);
+  if (actual !== expected) failures.push('\n' + message);
+});
+assert.equal(failures.length, 0, failures.join(''));
+
+// path.sep tests
+if (isWindows) {
+    // windows
+    assert.equal(path.sep, '\\');
+} else {
+    // posix
+    assert.equal(path.sep, '/');
+}
+
+};
+
+require('test').run(exports);


### PR DESCRIPTION
This is work is pool of changes required for integrating [cfx-js linker](https://github.com/Gozala/cfx-js)

With this changes inn and clone of [cfx-js](https://github.com/Gozala/cfx-js)  under `addon-sdk/cfx` all the tests pass both on cfx-py and node. In other words this how you test it:

``` sh
cd addon-sdk
git clone git://github.com/Gozala/cfx-js.git cfx
cd cfx

cfx test
Using binary at '/Applications/Firefox.app/Contents/MacOS/firefox-bin'.
Using profile at '/var/folders/0z/nztt5n4d4kg7b43dg9nv_3fc0000gp/T/tmpitLfnV.mozrunner'.
Running tests on Firefox 15.0/Gecko 15.0 ({ec8030f7-c20a-464f-9b0e-13a3a9e97384}) under darwin/x86.
..............................................................
62 of 62 tests passed.
Total time: 3.451745 seconds
Program terminated successfully.


npm test
Running all tests:
..............................................................
Passed:62 Failed:0 Errors:0
```
