### PR TITLE
Hotfix for PrefTarget

### DIFF
--- a/lib/sdk/preferences/event-target.js
+++ b/lib/sdk/preferences/event-target.js
@@ -45,9 +45,10 @@ exports.PrefsTarget = PrefsTarget;
 /* HELPERS */
 
 function onChange(subject, topic, name) {
-  if (topic === 'nsPref:changed')
+  if (topic === 'nsPref:changed') {
     emit(this, name, name);
     emit(this, '', name);
+  }
 }
 
 function destroy() {


### PR DESCRIPTION
If a nsIPrefBranch observer emit something other than nsPref:changed then the PrefTarget listener would have improperly emit a prefchange event

I can't think of a way to test this atm, since `nsPref:changed` is the only topic that is emitted atm afaict.

@Mossop maybe you have some idea how to write a test for this?

Is it worth it for now? perhaps I can make a bug about it and punt it for later?
