### PR TITLE
Bug 820095 - Selection listeners are not applied on document reload

### DIFF
--- a/lib/sdk/selection.js
+++ b/lib/sdk/selection.js
@@ -22,7 +22,7 @@ const { Ci, Cc } = require("chrome"),
     { EventTarget } = require("./event/target"),
     { ns } = require("./core/namespace"),
     { when: unload } = require("./system/unload"),
-    { getTabs, getTabContentWindow,
+    { getTabs, getTabContentWindow, getTabForContentWindow,
       getAllTabContentWindows } = require('./tabs/utils'),
     { getInnerId, getMostRecentBrowserWindow,
       windows, getFocusedWindow, getFocusedElement } = require("./window/utils"),
@@ -301,11 +301,12 @@ function getElementWithSelection() {
  * Adds the Selection Listener to the content's window given
  */
 function addSelectionListener(window) {
-  // Don't add the selection's listener more than once to the same window.
-  if ("selection" in selections(window))
-    return;
-
   let selection = window.getSelection();
+
+  // Don't add the selection's listener more than once to the same window,
+  // if the selection object is the same
+  if ("selection" in selections(window) && selections(window).selection === selection)
+    return;
 
   // We ensure that the current selection is an instance of
   // `nsISelectionPrivate` before working on it, in case is `null`.
@@ -346,10 +347,12 @@ function removeSelectionListener(window) {
     return;
 
   let selection = window.getSelection();
+  let isSameSelection = selection === selections(window).selection;
 
-  // We ensure that the current selection is an instance of
-  // `nsISelectionPrivate` before working on it, in case is `null`.
-  if (selection instanceof Ci.nsISelectionPrivate)
+  // Before remove the listener, we ensure that the current selection is an
+  // instance of `nsISelectionPrivate` (it could be `null`), and that is still
+  // the selection we managed for this window (it could be detached).
+  if (selection instanceof Ci.nsISelectionPrivate && isSameSelection)
     selection.removeSelectionListener(selectionListener);
 
   window.removeEventListener("select", selectionListener.onSelect, true);
@@ -360,9 +363,9 @@ function removeSelectionListener(window) {
 function onContent(event) {
   let window = event.subject.defaultView;
 
-  // We are not interested in documents without valid defaultView.
-  // For example XML documents don't have windows and we don't yet support them.
-  if (window)
+  // We are not interested in documents without valid defaultView (e.g. XML), or
+  // not in a tab (e.g. Panel).
+   if (window && getTabForContentWindow(window))
     addSelectionListener(window);
 }
 


### PR DESCRIPTION
- Added the selection listener only to documents loaded in Tab (is consistent with other modules like PageMod)
- Avoid to handle detached selections
