### PR TITLE
Make tests expect tracebacks in the right order.

### DIFF
--- a/lib/sdk/console/traceback.js
+++ b/lib/sdk/console/traceback.js
@@ -61,7 +61,7 @@ var get = exports.get = function get() {
 var format = exports.format = function format(tbOrException) {
   if (tbOrException === undefined) {
     tbOrException = get();
-    tbOrException.splice(0, 1);
+    tbOrException.pop();
   }
 
   var tb;

--- a/test/test-plain-text-console.js
+++ b/test/test-plain-text-console.js
@@ -66,5 +66,5 @@ exports.testPlainTextConsole = function(test) {
   con.trace();
   tbLines = prints[0].split("\n");
   test.assertEqual(tbLines[0], "info: " + require("sdk/self").name + ": Traceback (most recent call last):");
-  test.assertEqual(tbLines[4].trim(), "con.trace();");
+  test.assertEqual(tbLines[tbLines.length - 2].trim(), "con.trace();");
 };

--- a/test/test-traceback.js
+++ b/test/test-traceback.js
@@ -78,7 +78,7 @@ exports.testFromExceptionWithNsIException = function(test) {
     test.fail("an exception should've been thrown");
   } catch (e if e.result == Cr.NS_ERROR_MALFORMED_URI) {
     var tb = traceback.fromException(e);
-    test.assertEqual(tb[0].name, "throwNsIException");
+    test.assertEqual(tb[tb.length - 1].name, "throwNsIException");
   }
 };
 
@@ -91,11 +91,11 @@ exports.testFormat = function(test) {
   test.assertEqual(typeof(formatted), "string");
   var lines = formatted.split("\n");
 
-  test.assertEqual(lines[1].indexOf("getTraceback") > 0,
+  test.assertEqual(lines[lines.length - 2].indexOf("getTraceback") > 0,
                    true,
                    "formatted traceback should include function name");
 
-  test.assertEqual(lines[2].trim(),
+  test.assertEqual(lines[lines.length - 1].trim(),
                    "return traceback.format();",
                    "formatted traceback should include source code");
 };


### PR DESCRIPTION
@Gozala as far as I can tell tracebacks generated from Components.stack have been displayed in the wrong order for a while. 25885083e51e64565a91eaf5c5a974471f51f5b5 fixed that but some tests we're relying on the incorrect ordering. This fixes them. As far as I can tell this is all the test failures left aside from the hidden-window brokenness but it's a little tricky to tell until that is fixed.
