### PR TITLE
Bug 817670: Catch exceptions from NetUtil.asyncFetch.

### DIFF
--- a/lib/sdk/net/url.js
+++ b/lib/sdk/net/url.js
@@ -40,16 +40,21 @@ function readAsync(uri, charset) {
 
   let { promise, resolve, reject } = defer();
 
-  NetUtil.asyncFetch(channel, function (stream, result) {
-    if (components.isSuccessCode(result)) {
-      let count = stream.available();
-      let data = NetUtil.readInputStreamToString(stream, count, { charset : charset });
+  try {
+    NetUtil.asyncFetch(channel, function (stream, result) {
+      if (components.isSuccessCode(result)) {
+        let count = stream.available();
+        let data = NetUtil.readInputStreamToString(stream, count, { charset : charset });
 
-      resolve(data);
-    } else {
-      reject("Failed to read: '" + uri + "' (Error Code: " + result + ")");
-    }
-  });
+        resolve(data);
+      } else {
+        reject("Failed to read: '" + uri + "' (Error Code: " + result + ")");
+      }
+    });
+  }
+  catch (e) {
+    reject("Failed to read: '" + uri + "' (Error: " + e.message + ")");
+  }
 
   return promise;
 }


### PR DESCRIPTION
I suspect this will fix the perma-orange on OSX, but I do not have an OSX machine to test with. @erikvold, @zer0 can one of you test and review this?
