### PR TITLE
Bug 820095 - Selection listeners are not applied on document reload

### DIFF
--- a/test/test-selection.js
+++ b/test/test-selection.js
@@ -60,6 +60,20 @@ function close() {
   closeTab(getActiveTab(getMostRecentBrowserWindow()));
 }
 
+/**
+ * Reload the window given and return a promise, that will be resolved with the
+ * content window after a small delay.
+ */
+function reload(window) {
+  let { promise, resolve } = defer();
+
+  window.location.reload(true);
+
+  setTimeout(resolve, 250, window);
+
+  return promise;
+}
+
 // Selection's unit test utility function
 
 /**
@@ -674,6 +688,40 @@ exports["test Textarea OnSelect Listener on existing document"] = function(asser
     then(dispatchOnSelectEvent).
     then(close).
     then(loader.unload)
+};
+
+exports["test Selection Listener on document reload"] = function(assert, done) {
+  let loader = Loader(module);
+  let selection = loader.require("sdk/selection");
+
+  selection.once("select", function() {
+    assert.equal(selection.text, "fo");
+    done();
+  });
+
+  open(URL).
+    then(reload).
+    then(selectContentFirstDiv).
+    then(dispatchSelectionEvent).
+    then(close).
+    then(loader.unload);
+};
+
+exports["test Textarea OnSelect Listener on document reload"] = function(assert, done) {
+  let loader = Loader(module);
+  let selection = loader.require("sdk/selection");
+
+  selection.once("select", function() {
+    assert.equal(selection.text, "noodles");
+    done();
+  });
+
+  open(URL).
+    then(reload).
+    then(selectTextarea).
+    then(dispatchOnSelectEvent).
+    then(close).
+    then(loader.unload);
 };
 
 // TODO: test Selection Listener on long-held connection (Bug 661884)


### PR DESCRIPTION
Added test cases
