### PR TITLE
Reuse self instance instead of loading it twice.

### DIFF
--- a/lib/sdk/console/plain-text.js
+++ b/lib/sdk/console/plain-text.js
@@ -11,8 +11,6 @@ module.metadata = {
 const { Cc, Ci } = require("chrome");
 const self = require("../self");
 const { sourceURI } = require("./traceback")
-
-const { id } = require("self");
 const prefs = require("../preferences/service");
 
 const LEVELS = {
@@ -24,7 +22,7 @@ const LEVELS = {
   "off": Number.MAX_VALUE,
 };
 const DEFAULT_LOG_LEVEL = "error";
-const ADDON_LOG_LEVEL_PREF = "extensions." + id + ".sdk.console.logLevel";
+const ADDON_LOG_LEVEL_PREF = "extensions." + self.id + ".sdk.console.logLevel";
 const SDK_LOG_LEVEL_PREF = "extensions.sdk.console.logLevel";
 
 let logLevel;


### PR DESCRIPTION
Small cosmetic hotfix for #689 that broke scratch-kit.
