### PR TITLE
Bug 613587 - Make cfx init automatically generate the jID

### DIFF
--- a/python-lib/cuddlefish/__init__.py
+++ b/python-lib/cuddlefish/__init__.py
@@ -484,12 +484,13 @@ def get_config_args(name, env_root):
 
 def initializer(env_root, args, out=sys.stdout, err=sys.stderr):
     from templates import PACKAGE_JSON, TEST_MAIN_JS
+    from preflight import create_jid
     path = os.getcwd()
     addon = os.path.basename(path)
     # if more than two arguments
     if len(args) > 2:
         print >>err, 'Too many arguments.'
-        return 1
+        return {"result":1}
     if len(args) == 2:
         path = os.path.join(path,args[1])
         try:
@@ -501,14 +502,17 @@ def initializer(env_root, args, out=sys.stdout, err=sys.stderr):
     existing = [fn for fn in os.listdir(path) if not fn.startswith(".")]
     if existing:
         print >>err, 'This command must be run in an empty directory.'
-        return 1
+        return {"result":1}
     for d in ['lib','data','test','doc']:
         os.mkdir(os.path.join(path,d))
         print >>out, '*', d, 'directory created'
     open(os.path.join(path,'README.md'),'w').write('')
     print >>out, '* README.md written'
+    jid = create_jid()
+    print >>out, '* generated jID automatically:', jid
     open(os.path.join(path,'package.json'),'w').write(PACKAGE_JSON % {'name':addon.lower(),
-                                                   'fullName':addon })
+                                                   'fullName':addon,
+                                                   'id':jid })
     print >>out, '* package.json written'
     open(os.path.join(path,'test','test-main.js'),'w').write(TEST_MAIN_JS)
     print >>out, '* test/test-main.js written'
@@ -522,7 +526,7 @@ def initializer(env_root, args, out=sys.stdout, err=sys.stderr):
     else:
         print >>out, '\nYour sample add-on is now ready in the \'' + args[1] +  '\' directory.'
         print >>out, 'Change to that directory, then do "cfx test" to test it, \nand "cfx run" to try it.  Have fun!' 
-    return 0
+    return {"result":0, "jid":jid}
 
 def buildJID(target_cfg):
     if "id" in target_cfg:

--- a/python-lib/cuddlefish/templates.py
+++ b/python-lib/cuddlefish/templates.py
@@ -23,6 +23,7 @@ PACKAGE_JSON = '''\
 {
   "name": "%(name)s",
   "fullName": "%(fullName)s",
+  "id": "%(id)s",
   "description": "a basic add-on",
   "author": "",
   "license": "MPL 2.0",

--- a/python-lib/cuddlefish/tests/test_init.py
+++ b/python-lib/cuddlefish/tests/test_init.py
@@ -25,7 +25,7 @@ class TestInit(unittest.TestCase):
             os.chdir(top)
 
     def do_test_init(self,basedir):
-        # Let's init the addon, no error admited
+        # Let's init the addon, no error admitted
         f = open(".ignoreme","w")
         f.write("stuff")
         f.close()
@@ -33,7 +33,7 @@ class TestInit(unittest.TestCase):
         out, err = StringIO(), StringIO()
         init_run = initializer(None, ["init"], out, err)
         out, err = out.getvalue(), err.getvalue()
-        self.assertEqual(init_run, 0)
+        self.assertEqual(init_run["result"], 0)
         self.assertTrue("* lib directory created" in out)
         self.assertTrue("* data directory created" in out)
         self.assertTrue("Have fun!" in out)
@@ -46,16 +46,17 @@ class TestInit(unittest.TestCase):
         self.assertTrue(os.path.exists(package_json))
         self.assertTrue(os.path.exists(test_main_js))
         self.assertEqual(open(main_js,"r").read(),"")
-        self.assertEqual(open(package_json,"r").read(),
+        self.assertEqual(open(package_json,"r").read() % {"id":"tmp_addon_id" },
                          PACKAGE_JSON % {"name":"tmp_addon_sample",
-                                         "fullName": "tmp_addon_SAMPLE" })
+                                         "fullName": "tmp_addon_SAMPLE",
+                                         "id":init_run["jid"] })
         self.assertEqual(open(test_main_js,"r").read(),TEST_MAIN_JS)
 
         # Let's check that the addon is initialized
         out, err = StringIO(), StringIO()
         init_run = initializer(None, ["init"], out, err)
         out, err = out.getvalue(), err.getvalue()
-        self.failIfEqual(init_run,0)
+        self.failIfEqual(init_run["result"],0)
         self.assertTrue("This command must be run in an empty directory." in err)
 
     def test_initializer(self):
@@ -66,7 +67,7 @@ class TestInit(unittest.TestCase):
         out,err = StringIO(), StringIO()
         init_run = initializer(None, ["init", "specified-dirname", "extra-arg"], out, err)
         out, err = out.getvalue(), err.getvalue()
-        self.failIfEqual(init_run, 0)
+        self.failIfEqual(init_run["result"], 0)
         self.assertTrue("Too many arguments" in err)
 
     def test_args(self):
@@ -79,7 +80,7 @@ class TestInit(unittest.TestCase):
         out,err = StringIO(), StringIO()
         rc = initializer(None, ["init"], out, err)
         out, err = out.getvalue(), err.getvalue()
-        self.assertEqual(rc, 1)
+        self.assertEqual(rc["result"], 1)
         self.failUnless("This command must be run in an empty directory" in err,
                         err)
         self.failIf(os.path.exists("lib"))
@@ -102,7 +103,7 @@ class TestInit(unittest.TestCase):
         out, err = StringIO(), StringIO()
         rc = initializer(None, ["init", basedir], out, err)
         out, err = out.getvalue(), err.getvalue()
-        self.assertEqual(rc, 1)
+        self.assertEqual(rc["result"], 1)
         self.assertTrue("testing if directory is empty" in out, out)
         self.assertTrue("This command must be run in an empty directory." in err,
                         err)
@@ -112,7 +113,7 @@ class TestInit(unittest.TestCase):
         out, err = StringIO(), StringIO()
         rc = initializer(None, ["init", basedir], out, err)
         out, err = out.getvalue(), err.getvalue()
-        self.assertEqual(rc, 0)
+        self.assertEqual(rc["result"], 0)
         self.assertTrue("* data directory created" in out, out)
         self.assertTrue("Have fun!" in out)
         self.assertEqual(err,"")
@@ -127,7 +128,7 @@ class TestInit(unittest.TestCase):
         out, err = StringIO(), StringIO()
         rc = initializer(None, ["init", basedir], out, err)
         out, err = out.getvalue(), err.getvalue()
-        self.assertEqual(rc, 0)
+        self.assertEqual(rc["result"], 0)
         self.assertTrue("* data directory created" in out)
         self.assertTrue("Have fun!" in out)
         self.assertEqual(err,"")


### PR DESCRIPTION
This replaces pull request #564, because I have no idea how I screwed up the branch I was working on this in, nor how to unscrew it.

All tests pass with this applied, and both 'cfx init' and 'cfx init DIRNAME' have the jID in the generated package.json files.
