### PR TITLE
Bug 825803 - Avoid double-escaping Unicode escapes when building JSON locale

### DIFF
--- a/lib/sdk/l10n/loader.js
+++ b/lib/sdk/l10n/loader.js
@@ -13,15 +13,9 @@ const { getPreferedLocales, findClosestLocale } = require("./locale");
 const { readURI } = require("../net/url");
 const { resolve } = require("../core/promise");
 
-function parseJSONResolvingUnicodeEscapes (str) {
-    return JSON.parse(str.replace(/\\\\u([\da-fA-F]{4})/g, function (n0, hex) {
-        return String.fromCharCode(parseInt(hex, 16));
-    }));
-}
-
 function parseJsonURI(uri) {
   return readURI(uri).
-    then(parseJSONResolvingUnicodeEscapes).
+    then(JSON.parse).
     then(null, function (error) {
       throw Error("Failed to parse locale file:\n" + uri + "\n" + error);
     });


### PR DESCRIPTION
Attempt to resolve https://bugzilla.mozilla.org/show_bug.cgi?id=825803 regarding ensuring parsed locale JSON avoids double-escaping Unicode escapes (and we instead resolve them)
