### PR TITLE
Bug 826080 - New context-menu module applies the PageContext in cases where it shouldn't

### DIFF
--- a/lib/sdk/context-menu.js
+++ b/lib/sdk/context-menu.js
@@ -291,6 +291,11 @@ let menuRules = mix(labelledItemRules, {
 });
 
 let ContextWorker = Worker.compose({
+  //Returns true if any context listeners are defined in the worker's port.
+  anyContextListeners: function anyContextListeners() {
+    return this._contentWorker.hasListenerFor("context");
+  },
+
   // Calls the context workers context listeners and returns the first result
   // that is either a string or a value that evaluates to true. If all of the
   // listeners returned false then returns false. If there are no listeners
@@ -311,16 +316,12 @@ let ContextWorker = Worker.compose({
 // Returns true if any contexts match. If there are no contexts then a
 // PageContext is tested instead
 function hasMatchingContext(contexts, popupNode) {
-  if (contexts.length) {
-    for (let context in contexts) {
-      if (!context.isCurrent(popupNode))
-        return false;
-    }
-
-    return true;
+  for (let context in contexts) {
+    if (!context.isCurrent(popupNode))
+      return false;
   }
 
-  return PageContext().isCurrent(popupNode);
+  return true;
 }
 
 // Gets the matched context from any worker for this item. If there is no worker
@@ -335,6 +336,12 @@ function getCurrentWorkerContext(item, popupNode) {
 // Tests whether an item should be visible or not based on its contexts and
 // content scripts
 function isItemVisible(item, popupNode) {
+  if (!item.context.length) {
+    let worker = getItemWorkerForWindow(item, popupNode.ownerDocument.defaultView);
+    if (!worker || !worker.anyContextListeners())
+      return PageContext().isCurrent(popupNode);
+  }
+
   if (!hasMatchingContext(item.context, popupNode))
     return false;
 

--- a/test/test-context-menu.js
+++ b/test/test-context-menu.js
@@ -421,7 +421,7 @@ exports.testURLContextRemove = function (test) {
   let item = loader.cm.Item({
     label: "item",
     context: context,
-    contentScript: 'self.postMessage("ok");',
+    contentScript: 'self.postMessage("ok"); self.on("context", function () true);',
     onMessage: function (msg) {
       test.assert(shouldBeEvaled,
                   "content script should be evaluated when expected");
@@ -529,6 +529,82 @@ exports.testContentContextNoMatch = function (test) {
   test.showMenu(null, function (popup) {
     test.checkMenu([item], [item], []);
     test.done();
+  });
+};
+
+
+// Content contexts that return true should cause their items to be present
+// in the menu when context clicking an active element.
+exports.testContentContextMatchActiveElement = function (test) {
+  test = new TestHelper(test);
+  let loader = test.newLoader();
+
+  let items = [
+    new loader.cm.Item({
+      label: "item 1",
+      contentScript: 'self.on("context", function () true);'
+    }),
+    new loader.cm.Item({
+      label: "item 2",
+      context: undefined,
+      contentScript: 'self.on("context", function () true);'
+    }),
+    // These items will always be hidden by the declarative usage of PageContext
+    new loader.cm.Item({
+      label: "item 3",
+      context: loader.cm.PageContext(),
+      contentScript: 'self.on("context", function () true);'
+    }),
+    new loader.cm.Item({
+      label: "item 4",
+      context: [loader.cm.PageContext()],
+      contentScript: 'self.on("context", function () true);'
+    })
+  ];
+
+  test.withTestDoc(function (window, doc) {
+    test.showMenu(doc.getElementById("image"), function (popup) {
+      test.checkMenu(items, [items[2], items[3]], []);
+      test.done();
+    });
+  });
+};
+
+
+// Content contexts that return false should cause their items to be absent
+// from the menu when context clicking an active element.
+exports.testContentContextNoMatchActiveElement = function (test) {
+  test = new TestHelper(test);
+  let loader = test.newLoader();
+
+  let items = [
+    new loader.cm.Item({
+      label: "item 1",
+      contentScript: 'self.on("context", function () false);'
+    }),
+    new loader.cm.Item({
+      label: "item 2",
+      context: undefined,
+      contentScript: 'self.on("context", function () false);'
+    }),
+    // These items will always be hidden by the declarative usage of PageContext
+    new loader.cm.Item({
+      label: "item 3",
+      context: loader.cm.PageContext(),
+      contentScript: 'self.on("context", function () false);'
+    }),
+    new loader.cm.Item({
+      label: "item 4",
+      context: [loader.cm.PageContext()],
+      contentScript: 'self.on("context", function () false);'
+    })
+  ];
+
+  test.withTestDoc(function (window, doc) {
+    test.showMenu(doc.getElementById("image"), function (popup) {
+      test.checkMenu(items, items, []);
+      test.done();
+    });
   });
 };
 


### PR DESCRIPTION
I misunderstood the behaviour when there were no declarative contexts but were context listeners in the content script which leaves us behaving differently in at least one real world example I've seen. This should fix it and add tests around it. Can you review @gozala?
