### PR TITLE
Bug 824115 - error: addon-sdk: TEST FAILED: test-selection.test Selection Listener on document reload

### DIFF
--- a/test/test-selection.js
+++ b/test/test-selection.js
@@ -67,9 +67,15 @@ function close() {
 function reload(window) {
   let { promise, resolve } = defer();
 
-  window.location.reload(true);
+  // Here we assuming that the most recent browser window is the one we're
+  // doing the test, and the active tab is the one we just opened.
+  let tab = tabs.activeTab;
 
-  setTimeout(resolve, 250, window);
+  tab.once("ready", function () {
+    resolve(window);
+  });
+
+  window.location.reload(true);
 
   return promise;
 }


### PR DESCRIPTION
Removed the setTimeout in favour of a tab's ready event. If it is a timing issue, that should fix the problem.
