### PR TITLE
Handle undefined __$coverObject (re #624)

### DIFF
--- a/lib/sdk/test/harness.js
+++ b/lib/sdk/test/harness.js
@@ -185,6 +185,7 @@ function showResults() {
 }
 
 function cleanup() {
+  let coverObject;
   try {
     for (let name in loader.modules)
       memory.track(loader.modules[name],
@@ -211,6 +212,11 @@ function cleanup() {
                    "be indicative of aberrant behavior.");
     }
 
+    // read the code coverage object, if it exists, from CoverJS-moz
+    if (typeof loader.globals.global == "object") {
+      coverObject = loader.globals.global['__$coverObject'] || {};
+    }
+
     consoleListener.errorsLogged = 0;
     loader = null;
 
@@ -222,6 +228,21 @@ function cleanup() {
   };
 
   setTimeout(showResults, 1);
+
+  // dump the coverobject
+  if (typeof coverObject == "object" && Object.keys(coverObject).length){
+    const self = require('self');
+    const {pathFor} = require("sdk/system");
+    let file = require('file');
+    const {env} = require('sdk/system/environment');
+    console.log("CWD:", env.PWD);
+    let out = file.join(env.PWD,'coverstats-'+self.id+'.json');
+    console.log('coverstats:', out);
+    let outfh = file.open(out,'w');
+    outfh.write(JSON.stringify(coverObject,null,2));
+    outfh.flush();
+    outfh.close();
+  }
 }
 
 function nextIteration(tests) {
@@ -416,7 +437,8 @@ var runTests = exports.runTests = function runTests(options) {
       testConsole = new TestRunnerConsole(new PlainTextConsole(print), options);
 
     loader = Loader(module, {
-      console: testConsole
+      console: testConsole,
+      global: {} // useful for storing things like coverage testing.
     });
 
     nextIteration();


### PR DESCRIPTION
If `CoverJS` is not installed, `globals.global.__$coverObject` will be
undefined.  Handle this case.
