### PR TITLE
Bug 719206 - Put our python libraries first in the path to override any system installed mozrunner

### DIFF
--- a/bin/cfx
+++ b/bin/cfx
@@ -17,7 +17,7 @@ if 'CUDDLEFISH_ROOT' not in os.environ:
 # add our own python-lib path to the python module search path.
 python_lib_dir = os.path.join(cuddlefish_root, "python-lib")
 if python_lib_dir not in sys.path:
-    sys.path.append(python_lib_dir)
+    sys.path.insert(0, python_lib_dir)
 
 # now export to env so sub-processes get it too
 if 'PYTHONPATH' not in os.environ:


### PR DESCRIPTION
Maybe this is an easy solution, the problem is we stick our python libraries at the end of the search path so when we import mozrunner anything earlier on the system gets used instead. Putting our libraries at the start solves this for at least the once case I can reproduce
