### PR TITLE
Bug 821536 - Fix tab title

### DIFF
--- a/lib/sdk/tabs/utils.js
+++ b/lib/sdk/tabs/utils.js
@@ -160,7 +160,7 @@ exports.getTabId = getTabId;
 
 
 function getTabTitle(tab) {
-  return getBrowserForTab(tab).contentDocument.title || tab.label || "";
+  return tab.label || getBrowserForTab(tab).contentDocument.title || "";
 }
 exports.getTabTitle = getTabTitle;
 


### PR DESCRIPTION
Prefer tab.label instead of document title used by fennec.
