### PR TITLE
Bug 828113 Support accesskey (also on overflow menu), correct outdated comment, fix...

### DIFF
--- a/lib/sdk/context-menu.js
+++ b/lib/sdk/context-menu.js
@@ -309,8 +309,8 @@ let ContextWorker = Worker.compose({
   // that is either a string or a value that evaluates to true. If all of the
   // listeners returned false then returns false. If there are no listeners
   // then returns null.
-  getMatchedContext: function getCurrentContexts(popupNode) {
-    let results = this._contentWorker.emitSync("context", popupNode);
+  getMatchedContext: function getCurrentContexts(popupNode, data) {
+    let results = this._contentWorker.emitSync("context", popupNode, data);
     return results.reduce(function(val, result) val || result, null);
   },
 
@@ -339,7 +339,7 @@ function getCurrentWorkerContext(item, popupNode) {
   let worker = getItemWorkerForWindow(item, popupNode.ownerDocument.defaultView);
   if (!worker)
     return null;
-  return worker.getMatchedContext(popupNode);
+  return worker.getMatchedContext(popupNode, item.data);
 }
 
 // Tests whether an item should be visible or not based on its contexts and
@@ -448,6 +448,12 @@ let BaseItem = Class({
     Object.defineProperty(this, "contentScriptFile", {
       enumerable: true,
       value: internal(this).options.contentScriptFile
+    });
+
+    Object.defineProperty(this, "data", {
+      writable: true,
+      enumerable: true,
+      value: internal(this).options.data
     });
   },
 


### PR DESCRIPTION
Code fix: Fix context menus to allow key activation to activate the "click" event (i.e., use "command" event). I preserved the naming of "click" for content scripts so they could continue to work with "click" events.
Comment fix: Correct outdated comment (Separator is also part of baseItemRules)
New Feature: Support accesskey on context-menus (also on overflow menu)

For changes I did NOT make:
1. I did not incorporate accesskey along with label in toString() descriptions though perhaps that would be good.
2. I did not change the context listener to allow users to dynamically provide an accesskey in their "context" event handler, though perhaps these user events could allow return of an array, with one as the label, another as the accesskey (instead of just a string label, as I understand it is now).
