### PR TITLE
Bug 832934 - Fennec: 'ready' events not fired for tabs exiting at startup.

### DIFF
--- a/lib/sdk/windows/tabs-fennec.js
+++ b/lib/sdk/windows/tabs-fennec.js
@@ -188,3 +188,9 @@ unload(function() {
     tabInternals.window = null;
   }
 });
+
+let tabs = mainWindow.BrowserApp.tabs;
+
+for (let i = 0; i < tabs.length; i++) {
+  onTabOpen({target : tabs[i].browser});
+}


### PR DESCRIPTION
[Bug 832934](https://bugzilla.mozilla.org/show_bug.cgi?id=832934)
### Description

`ready` events not fired for tabs exiting at startup on Firefox for Android, since `open` events, on which event listeners for `DOMContentLoaded` are installed, are not fired.
### Steps to Reproduce the Problem
1. Install the attached extension at Bugzilla to Firefox for Android.
   The extension simply logs the URLs of tabs on `ready` events.
   
   lib/main.js:
   
   ``` javascript
    let tabs = require('tabs');
   
    tabs.on('ready', function (tab) {
      console.log(tab.url);
    });
   
    console.log("initialized");
   ```
2. Open about:home.
3. Press the home button to back to the home screen.
4. Kill Firefox process.
5. Start monitoring logcat.
   `adb logcat | grep 'Gecko'`
6. Start Firefox.
### Expected

Getting log like the following lines:

```
I/GeckoApp( 1819): Got message: DOMContentLoaded
...
E/GeckoConsole( 1819): info: log-url: about:home
```
### Actual

Getting `DOMContentLoaded` but not `about:home`.
### Cause

The listeners for `DOMContentLoaded` events are installed in the `onTabOpen` function in `lib/sdk/windows/tabs-fennec.js`, whereas tabs are opened before initializing the extension. We see `I/GeckoTabs( 1819): Got message: Tab:Added` before the message `initialized`.
### Possible Fix

Call `onTabOpen` for all tabs at startup.

``` javascript
let tabs = mainWindow.BrowserApp.tabs;

for (let i = 0; i < tabs.length; i++) {
  onTabOpen({target : tabs[i].browser});
}
```

Note that `tabs-firefox.js` has similar code.
Note also that `onTabOpen` depends on `gTabs`, so that it cannot be called in the Tabs constructor.
### Issue

Is it possible that an extension is initialized before opening tabs at startup?
