### PR TITLE
Updating scan_requirements_with_grep to get all require statements from the line

### DIFF
--- a/python-lib/cuddlefish/manifest.py
+++ b/python-lib/cuddlefish/manifest.py
@@ -641,12 +641,13 @@ def scan_requirements_with_grep(fn, lines):
                     iscomment = True
             if iscomment:
                 continue
-            mo = re.search(REQUIRE_RE, clause)
+            mo = re.finditer(REQUIRE_RE, clause)
             if mo:
-                modname = mo.group(1)
-                requires[modname] = {}
-                if modname not in first_location:
-                    first_location[modname] = lineno0+1
+                for mod in mo:
+                    modname = mod.group(1)
+                    requires[modname] = {}
+                    if modname not in first_location:
+                        first_location[modname] = lineno0 + 1
 
     # define() can happen across multiple lines, so join everyone up.
     wholeshebang = "\n".join(lines)


### PR DESCRIPTION
Use finditer and iterate over the MatchObject objects. This handles comma-separated require statements such as those resulting from code minified by GCC, e.g.

```
var a = require('module');
var b = require('another-module');
```

would become something like

```
var a=require,b=a('module'),c=a('another-module');
```

Previously, only the first require would be registered and code relying on the second would cause an error.
