### PR TITLE
Bug 833870 - Avoid hacking document style when translating html files.

### DIFF
--- a/lib/sdk/l10n/html.js
+++ b/lib/sdk/l10n/html.js
@@ -8,11 +8,15 @@ module.metadata = {
   "stability": "unstable"
 };
 
-const { Ci } = require("chrome");
+const { Ci, Cu } = require("chrome");
 const events = require("../system/events");
 const core = require("./core");
 
 const assetsURI = require('../self').data.url();
+const { Services } = Cu.import("resource://gre/modules/Services.jsm");
+
+const hideContentStyle = "data:text/css,:root {visibility: hidden !important;}";
+const hideSheetUri = Services.io.newURI(hideContentStyle, null, null);
 
 // Taken from Gaia:
 // https://github.com/andreasgal/gaia/blob/04fde2640a7f40314643016a5a6c98bf3755f5fd/webapi.js#L1470
@@ -41,8 +45,15 @@ function onDocumentReady2Translate(event) {
 
   translateElement(document);
 
-  // Finally display document when we finished replacing all text content
-  document.documentElement.style.visibility = "visible";
+  try {
+    // Finally display document when we finished replacing all text content
+    let winUtils = document.defaultView.QueryInterface(Ci.nsIInterfaceRequestor)
+                                       .getInterface(Ci.nsIDOMWindowUtils);
+    winUtils.removeSheet(hideSheetUri, winUtils.USER_SHEET);
+  }
+  catch(e) {
+    console.exception(e);
+  }
 }
 
 function onContentWindow(event) {
@@ -61,12 +72,16 @@ function onContentWindow(event) {
   if (document.location.href.indexOf(assetsURI) !== 0)
     return;
 
-  // First hide content of the document in order to have content blinking
-  // between untranslated and translated states
-  // TODO: use result of bug 737003 discussion in order to avoid any conflict
-  // with document CSS
-  document.documentElement.style.visibility = "hidden";
-
+  try {
+    // First hide content of the document in order to have content blinking
+    // between untranslated and translated states
+    let winUtils = document.defaultView.QueryInterface(Ci.nsIInterfaceRequestor)
+                                       .getInterface(Ci.nsIDOMWindowUtils);
+    winUtils.loadSheet(hideSheetUri, winUtils.USER_SHEET);
+  }
+  catch(e) {
+    console.exception(e);
+  }
   // Wait for DOM tree to be built before applying localization
   document.addEventListener("DOMContentLoaded", onDocumentReady2Translate,
                             false);


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=833870
