### PR TITLE
Bug 834944 - require("api-utils/utils/data").getChromeURIContent("...") throw 'deprecatedUsage is not a function'

### DIFF
--- a/lib/sdk/io/data.js
+++ b/lib/sdk/io/data.js
@@ -17,7 +17,7 @@ const IOService = Cc["@mozilla.org/network/io-service;1"].
 const { NetUtil } = Cu.import("resource://gre/modules/NetUtil.jsm");
 const FaviconService = Cc["@mozilla.org/browser/favicon-service;1"].
                           getService(Ci.nsIFaviconService);
-const { deprecateFunction, deprecatedUsage } = require("../util/deprecate");
+const { deprecateFunction } = require("../util/deprecate");
 
 const PNG_B64 = "data:image/png;base64,";
 const DEF_FAVICON_URI = "chrome://mozapps/skin/places/defaultFavicon.png";
@@ -61,12 +61,10 @@ function getChromeURIContent(chromeURI) {
   input.close();
   return content;
 }
-exports.getChromeURIContent = function deprecated_getChromeURIContent() {
-  deprecatedUsage(
-    'getChromeURIContent is deprecated, ' +
-    'please use require("sdk/net/url").readURI instead.'
-  );
-};
+exports.getChromeURIContent = deprecateFunction(getChromeURIContent,
+  'getChromeURIContent is deprecated, ' +
+  'please use require("sdk/net/url").readURI instead.'
+);
 
 /**
  * Creates a base-64 encoded ASCII string from a string of binary data.


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=834944
