### PR TITLE
Bug 832401: Put the new context-menu separator before the old one.

### DIFF
--- a/lib/sdk/context-menu.js
+++ b/lib/sdk/context-menu.js
@@ -809,7 +809,13 @@ let MenuWrapper = Class({
     if (!this.separator) {
       let separator = this.window.document.createElement("menuseparator");
       separator.setAttribute("class", SEPARATOR_CLASS);
-      this.contextMenu.appendChild(separator);
+
+      // Insert before the separator created by the old context-menu if it
+      // exists to avoid bug 832401
+      let oldSeparator = this.window.document.getElementById("jetpack-context-menu-separator");
+      if (oldSeparator && oldSeparator.parentNode != this.contextMenu)
+        oldSeparator = null;
+      this.contextMenu.insertBefore(separator, oldSeparator);
     }
 
     let type = "menuitem";

--- a/test/test-context-menu.js
+++ b/test/test-context-menu.js
@@ -19,6 +19,28 @@ const OVERFLOW_POPUP_CLASS = "addon-content-menu-overflow-popup";
 
 const TEST_DOC_URL = module.uri.replace(/\.js$/, ".html");
 
+// Tests that when present the separator is placed before the separator from
+// the old context-menu module
+exports.testSeparatorPosition = function (test) {
+  test = new TestHelper(test);
+  let loader = test.newLoader();
+
+  // Create the old separator
+  let oldSeparator = test.contextMenuPopup.ownerDocument.createElement("menuseparator");
+  oldSeparator.id = "jetpack-context-menu-separator";
+  test.contextMenuPopup.appendChild(oldSeparator);
+
+  // Create an item.
+  let item = new loader.cm.Item({ label: "item" });
+
+  test.showMenu(null, function (popup) {
+    test.assertEqual(test.contextMenuSeparator.nextSibling.nextSibling, oldSeparator,
+                     "New separator should appear before the old one");
+    test.contextMenuPopup.removeChild(oldSeparator);
+    test.done();
+  });
+};
+
 // Destroying items that were previously created should cause them to be absent
 // from the menu.
 exports.testConstructDestroy = function (test) {


### PR DESCRIPTION
This always positions the new context-menu separator before the old one when possible to workaround bug 832401
