### PR TITLE
Bug 808074 updated credits page

### DIFF
--- a/doc/dev-guide-source/credits.md
+++ b/doc/dev-guide-source/credits.md
@@ -11,58 +11,144 @@ We'd like to thank our many Jetpack project contributors!  They include:
 * arky
 * [Heather Arthur](https://github.com/harthur)
 * Dietrich Ayala
+
+<!--end-->
+
 * [Romain B](https://github.com/Niamor)
+* [Louis-Rémi Babé](https://github.com/louisremi)
 * Will Bamberg
+* Thomas Bassetto
+* Tomaz Bevec
 * Zbigniew Braniecki
 * Daniel Buchner
 * James Burke
+
+<!--end-->
+
 * [Shane Caraveo](https://github.com/mixedpuppy)
 * [Matěj Cepl](https://github.com/mcepl)
+* Marc Chevrier
 * Hernán Rodriguez Colmeiro
 * [David Creswick](https://github.com/dcrewi)
+
+<!--end-->
+
 * dexter
+* Christopher Dorn
+* Connor Dunn
+* dynamis
+
+<!--end-->
+
 * [Matteo Ferretti (ZER0)](https://github.com/ZER0)
 * fuzzykiller
+
+<!--end-->
+
 * [Marcio Galli](https://github.com/taboca)
 * [Ben Gillbanks](http://www.iconfinder.com/browse/iconset/circular_icons/)
 * Felipe Gomes
 * Irakli Gozalishvili
 * Luca Greco
+* Jeff Griffiths
+* [David Guo](https://github.com/dglol)
+
+<!--end-->
+
 * Mark Hammond
+* Mark A. Hershberger
 * Lloyd Hilaiel
 * Bobby Holley
+
+<!--end-->
+
+* Shun Ikejima
+
+<!--end-->
+
 * Eric H. Jung
+
+<!--end-->
+
 * Hrishikesh Kale
 * Wes Kocher
+* Lajos Koszti
+
+<!--end-->
+
 * Edward Lee
+* Gregg Lind
+
+<!--end-->
+
+* [Nils Maier](https://github.com/nmaier)
+* Gervase Markham
+* Dave Mason
 * Myk Melez
 * Zandr Milewski
 * Noelle Murata
+
+<!--end-->
+
+* Siavash Askari Nasr
 * Joe R. Nassimian ([placidrage](https://github.com/placidrage))
+* Dương H. Nguyễn <cmpitg@gmail.com>
 * Nick Nguyen
+
+<!--end-->
+
 * [ongaeshi](https://github.com/ongaeshi)
 * Paul O’Shannessy
-* l.m.orchard
+* Les Orchard
+
+<!--end-->
+
+* Robert Pankowecki
 * Alexandre Poirot
 * Nickolay Ponomarev
+
+<!--end-->
+
 * Aza Raskin
+
+<!--end-->
+
 * Till Schneidereit
 * Justin Scott
 * Ayan Shah
 * [skratchdot](https://github.com/skratchdot)
+* Henrik Skupin
+* slash
+* Markus Stange
+* Dan Stevens
 * [Mihai Sucan](https://github.com/mihaisucan)
+
+<!--end-->
+
+* taku0
 * Clint Talbert
-* Thomas
+* Tim Taubert
+* Shane Tomlinson
 * Dave Townsend
+* [Matthias Tylkowski](https://github.com/tylkomat)
+
+<!--end-->
+
 * Peter Van der Beken
+* Sander van Veen
 * Atul Varma
 * [Erik Vold](https://github.com/erikvold)
 * Vladimir Vukicevic
+
+<!--end-->
+
 * Brian Warner
 * [Henri Wiechers](https://github.com/hwiechers)
 * Drew Willcoxon
+* Blake Winton
+* Michal Wojciechowski
+
+<!--end-->
+
 * Piotr Zalewa
-* [David Guo](https://github.com/dglol)
-* [Nils Maier](https://github.com/nmaier)
-* [Louis-Rémi Babé](https://github.com/louisremi)
-* [Matthias Tylkowski](https://github.com/tylkomat)
+* Brett Zamir


### PR DESCRIPTION
This pull request updates the credits page at https://addons.mozilla.org/en-US/developers/docs/sdk/1.13/dev-guide/credits.html.

I'm not ready for it to be merged just yet, because we might still need to add people.
