### PR TITLE
Bug 816611: Remove the explicit timeout from the widget tests.

### DIFF
--- a/test/test-widget.js
+++ b/test/test-widget.js
@@ -12,7 +12,7 @@ const self = require("self");
 const windowUtils = require("sdk/deprecated/window-utils");
 
 exports.testConstructor = function(test) {
-  test.waitUntilDone(30000);
+  test.waitUntilDone();
 
   let browserWindow = windowUtils.activeBrowserWindow;
   let doc = browserWindow.document;


### PR DESCRIPTION
This timeout is pointless, we have other timeouts to cover the test never ending. All it does is mean when the test does run long (which is common on win debug) it fails and makes later tests appear to fail too.
