### PR TITLE
bug 836955 - move Google JS loading to the bottom of the page to improve...

### DIFF
--- a/doc/static-files/base.html
+++ b/doc/static-files/base.html
@@ -45,7 +45,6 @@
           <input type="text" name="q" size="31" id="search-box" />
         </div>
       </form>
-      <script type="text/javascript" src="https://www.google.com/cse/brand?form=cse-search-box&lang=en"></script>
     <!-- Google CSE Search Box Ends -->
     </div>
   </div>
@@ -163,6 +162,8 @@
 
 <script type="text/javascript" src="static-files/js/jquery.js"></script>
 <script type="text/javascript" src="static-files/js/main.js"></script>
+<!-- load the google JS last, in case we're offline ( bug 836955 ) -->
+<script type="text/javascript" src="https://www.google.com/cse/brand?form=cse-search-box&lang=en"></script>
 
 </body>
 


### PR DESCRIPTION
bug 836955 - move Google JS loading to the bottom of the page to improve the offline case, see https://bugzilla.mozilla.org/show_bug.cgi?id=836955 ( "Loading docs offline takes forever" )
