### PR TITLE
Bug 831933: Introduce a short timeout after the window gets focus before continuing

### DIFF
--- a/test/windows/test-firefox-windows.js
+++ b/test/windows/test-firefox-windows.js
@@ -278,11 +278,11 @@ exports.testActiveWindow = function(test) {
 
     var focused = (focusedChildWindow == childTargetWindow);
     if (focused) {
-      nextStep();
+      setTimeout(nextStep, 0);
     } else {
       childTargetWindow.addEventListener("focus", function focusListener() {
         childTargetWindow.removeEventListener("focus", focusListener, true);
-        nextStep();
+        setTimeout(nextStep, 0);
       }, true);
     }
 


### PR DESCRIPTION
This test clones SimpleTest.waitForFocus however it doesn't have the additional timeout after focus is complete that waitForFocus does. Let's see if that fixes the intermittent problem.
