### PR TITLE
Bug 831933: Use a window tracker to detect the newloy opened windows instead of getMostRecentWindow

### DIFF
--- a/test/windows/test-firefox-windows.js
+++ b/test/windows/test-firefox-windows.js
@@ -244,6 +244,7 @@ exports.testActiveWindow = function(test) {
         test.assert(newWindow, "A new window was opened");
         rawWindow2 = newWindow;
         newWindow = null;
+        test.assertEqual(rawWindow2.content.document.title, "window 2", "Got correct raw window 2");
         test.assertEqual(rawWindow2.document.title, window2.title, "Saw correct title on window 2");
 
         windows.open({
@@ -254,6 +255,7 @@ exports.testActiveWindow = function(test) {
               test.assert(newWindow, "A new window was opened");
               rawWindow3 = newWindow;
               tracker.unload();
+              test.assertEqual(rawWindow3.content.document.title, "window 3", "Got correct raw window 3");
               test.assertEqual(rawWindow3.document.title, window3.title, "Saw correct title on window 3");
               continueAfterFocus(rawWindow3);
               rawWindow3.focus();


### PR DESCRIPTION
So it looks like getMostRecentWindow is returning the wrong window, this screws up a lot of the test as we're waiting for the wrong windows to get focus. This change switches to use a window tracker to catch the new windows as they open. It passes consistently for me, though that doesn't say whether it really fixes it.

It does assume that the window tracker gets notified of the new window before the new tab load. I think that's a safe assumption.
