### PR TITLE
Add forceAllowThirdPartyCookie flag for requests

### DIFF
--- a/lib/sdk/net/xhr.js
+++ b/lib/sdk/net/xhr.js
@@ -114,6 +114,10 @@ XMLHttpRequest.prototype = {
   set upload(newValue) {
     throw new Error("not implemented");
   },
+  forceAllowThirdPartyCookie: function forceAllowThirdPartyCookie() {
+    if (this._req.channel instanceof Ci.nsIHttpChannelInternal)
+      this._req.channel.forceAllowThirdPartyCookie = true;
+  },
   get onreadystatechange() {
     return this._orsc;
   },

--- a/lib/sdk/request.js
+++ b/lib/sdk/request.js
@@ -71,6 +71,8 @@ function runRequest(mode, target) {
   // open the request
   xhr.open(mode, url);
 
+  xhr.forceAllowThirdPartyCookie();
+
   // request header must be set after open, but before send
   xhr.setRequestHeader("Content-Type", contentType);
 


### PR DESCRIPTION
This is the same code as in the PR https://github.com/mozilla/addon-sdk/pull/239, but with all tests passing and in only one commit.
