### PR TITLE
Bug 834960: Ignore private document unless addon explicitely support private browsing

### DIFF
--- a/lib/sdk/page-mod.js
+++ b/lib/sdk/page-mod.js
@@ -25,6 +25,7 @@ const { isBrowser, getFrames } = require('./window/utils');
 const { getTabs, getTabContentWindow, getTabForContentWindow,
         getURI: getTabURI } = require('./tabs/utils');
 const { has, hasAny } = require('./util/array');
+const { ignoreWindow } = require('sdk/private-browsing/utils');
 
 const styleSheetService = Cc["@mozilla.org/content/style-sheet-service;1"].
                             getService(Ci.nsIStyleSheetService);
@@ -352,6 +353,12 @@ const PageModManager = Registry.resolve({
     // We apply only on documents in tabs of Firefox
     if (!getTabForContentWindow(window))
       return;
+
+    // When the tab is private, only addons with 'private-browsing' flag in
+    // their package.json can apply content script to private documents
+    if (ignoreWindow(window)) {
+      return;
+    }
 
     for (let rule in RULES)
       if (RULES[rule].test(document.URL))

--- a/lib/sdk/private-browsing.js
+++ b/lib/sdk/private-browsing.js
@@ -23,7 +23,7 @@ onStateChange('stop', function onStop() {
 });
 
 Object.defineProperty(exports, "isActive", {
-	get: deprecateFunction(getMode, 'require("private-browsing").isActive is deprecated.')
+  get: deprecateFunction(getMode, 'require("private-browsing").isActive is deprecated.')
 });
 
 exports.activate = function activate() setMode(true);

--- a/test/addons/private-browsing-supported/main.js
+++ b/test/addons/private-browsing-supported/main.js
@@ -166,5 +166,6 @@ if (!is('Fennec')) {
 
 merge(module.exports, require('./windows'));
 merge(module.exports, require('./tabs'));
+merge(module.exports, require('./page-mod'));
 
 require('sdk/test/runner').runTestsFromModule(module);

--- a/test/addons/private-browsing-supported/page-mod.js
+++ b/test/addons/private-browsing-supported/page-mod.js
@@ -1,0 +1,90 @@
+const { getMostRecentBrowserWindow } = require('sdk/window/utils');
+const { PageMod } = require("sdk/page-mod");
+const { openDialog } = require('sdk/window/utils');
+const { getActiveTab, setTabURL, openTab, closeTab } = require('sdk/tabs/utils');
+const xulApp = require('sdk/system/xul-app');
+const windowHelpers = require('sdk/window/helpers');
+const promise = require("sdk/core/promise");
+const { isPrivate } = require('sdk/private-browsing');
+const { isTabPBSupported, isWindowPBSupported } = require('sdk/private-browsing/utils');
+
+function openWebpage(url, enablePrivate) {
+  if (xulApp.is("Fennec")) {
+    let chromeWindow = getMostRecentBrowserWindow();
+    let rawTab = openTab(chromeWindow, url, {
+      isPrivate: enablePrivate
+    });
+    return {
+      close: function () {
+        closeTab(rawTab)
+        // Returns a resolved promise as there is no need to wait
+        return promise.resolve();
+      }
+    };
+  }
+  else {
+    let win = openDialog({
+      private: enablePrivate
+    });
+    win.addEventListener("load", function onLoad() {
+      win.removeEventListener("load", onLoad, false);
+      setTabURL(getActiveTab(win), url);
+    });
+    return {
+      close: function () {
+        return windowHelpers.close(win);
+      }
+    };
+  }
+}
+
+exports["test page-mod on private tab"] = function (assert, done) {
+  // Only set private mode when explicitely supported.
+  // (fennec 19 has some intermediate PB support where isTabPBSupported
+  // will be false, but isPrivate(worker.tab) will be true if we open a private
+  // tab)
+  let setPrivate = isTabPBSupported || isWindowPBSupported;
+
+  let count = 0;
+  let pageMod = new PageMod({
+    include: "data:*",
+    onAttach: function(worker) {
+      assert.ok(worker.tab.url == uri || worker.tab.url == frameUri,
+                "Got a worker attached to the private window tab");
+
+      if (setPrivate) {
+        assert.ok(isPrivate(worker.tab), "The document is really private");
+      }
+      else {
+        assert.ok(!isPrivate(worker.tab),
+                  "private browsing isn't supported, " +
+                  "so that the document isn't private");
+      }
+
+      if (++count == 2) {
+        pageMod.destroy();
+        page.close().then(done);
+      }
+    }
+  });
+
+  let frameUri = "data:text/html;charset=utf-8,frame";
+  let uri = "data:text/html;charset=utf-8," +
+            encodeURIComponent("document<iframe src=\"" + frameUri + "\" />");
+  let page = openWebpage(uri, setPrivate);
+}
+
+exports["test page-mod on non-private tab"] = function (assert, done) {
+  let pageMod = new PageMod({
+    include: "about:buildconfig",
+    onAttach: function(worker) {
+      assert.equal(worker.tab.url, "about:buildconfig",
+                   "Got a worker attached to the private window tab");
+      assert.ok(!isPrivate(worker.tab), "The document is really non-private");
+      pageMod.destroy();
+      page.close().then(done);
+    }
+  });
+
+  let page = openWebpage("about:buildconfig", false);
+}

--- a/test/private-browsing/tabs.js
+++ b/test/private-browsing/tabs.js
@@ -12,7 +12,7 @@ exports.testIsPrivateOnTab = function(test) {
   test.assert(!pb.isPrivate(chromeWindow), 'the top level window is not private');
 
   let rawTab = openTab(chromeWindow, 'data:text/html,<h1>Hi!</h1>', {
-  	isPrivate: true
+    isPrivate: true
   });
 
   // test that the tab is private

--- a/test/test-page-mod.js
+++ b/test/test-page-mod.js
@@ -3,17 +3,21 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const pageMod = require("sdk/page-mod");
+const { PageMod } = require("sdk/page-mod");
 const testPageMod = require("./pagemod-test-helpers").testPageMod;
 const { Loader } = require('sdk/test/loader');
 const tabs = require("sdk/tabs");
 const timer = require("sdk/timers");
 const { Cc, Ci } = require("chrome");
-const { open, getFrames, getMostRecentBrowserWindow } = require('sdk/window/utils');
+const { open, openDialog, getFrames, getMostRecentBrowserWindow } = require('sdk/window/utils');
 const windowUtils = require('sdk/deprecated/window-utils');
-const { getTabContentWindow, getActiveTab, openTab, closeTab } = require('sdk/tabs/utils');
-const { is } = require('sdk/system/xul-app');
+const windowHelpers = require('sdk/window/helpers');
+const { getTabContentWindow, getActiveTab, setTabURL, openTab, closeTab } = require('sdk/tabs/utils');
+const xulApp = require("sdk/system/xul-app");
 const { data } = require('sdk/self');
+const { isPrivate } = require('sdk/private-browsing');
+const { isTabPBSupported, isWindowPBSupported } = require('sdk/private-browsing/utils');
+const promise = require("sdk/core/promise");
 
 /* XXX This can be used to delay closing the test Firefox instance for interactive
  * testing or visual inspection. This test is registered first so that it runs
@@ -136,7 +140,7 @@ exports.testPageModIncludes = function(test) {
 
 exports.testPageModErrorHandling = function(test) {
   test.assertRaises(function() {
-      new pageMod.PageMod();
+      new PageMod();
     },
     'pattern is undefined',
     "PageMod() throws when 'include' option is not specified.");
@@ -339,7 +343,6 @@ exports.testRelatedTab = function(test) {
   test.waitUntilDone();
 
   let tab;
-  let { PageMod } = require("sdk/page-mod");
   let pageMod = new PageMod({
     include: "about:*",
     onAttach: function(worker) {
@@ -548,7 +551,7 @@ exports.testAttachToTabsOnly = function(test) {
           element.removeEventListener('DOMContentLoaded', onload, false);
           hiddenFrames.remove(hiddenFrame);
 
-          if (!is("Fennec")) {
+          if (!xulApp.is("Fennec")) {
             openToplevelWindow();
           }
           else {
@@ -955,7 +958,7 @@ exports.testExistingOnFrames = function(test) {
       return;
     }
 
-    let pagemodOnExisting = pageMod.PageMod({
+    let pagemodOnExisting = PageMod({
       include: ["*", "data:*"],
       attachTo: ["existing", "frame"],
       contentScriptWhen: 'ready',
@@ -990,7 +993,7 @@ exports.testExistingOnFrames = function(test) {
       }
     });
 
-    let pagemodOffExisting = pageMod.PageMod({
+    let pagemodOffExisting = PageMod({
       include: ["*", "data:*"],
       attachTo: ["frame"],
       contentScriptWhen: 'ready',
@@ -1051,3 +1054,60 @@ exports.testEvents = function(test) {
     }
   );
 };
+
+function openWebpage(url, enablePrivate) {
+  if (xulApp.is("Fennec")) {
+    let chromeWindow = getMostRecentBrowserWindow();
+    let rawTab = openTab(chromeWindow, url, {
+      isPrivate: enablePrivate
+    });
+    return {
+      close: function () {
+        closeTab(rawTab)
+        // Returns a resolved promise as there is no need to wait
+        return promise.resolve();
+      }
+    };
+  }
+  else {
+    let win = openDialog({
+      private: enablePrivate
+    });
+    win.addEventListener("load", function onLoad() {
+      win.removeEventListener("load", onLoad, false);
+      setTabURL(getActiveTab(win), url);
+    });
+    return {
+      close: function () {
+        return windowHelpers.close(win);
+      }
+    };
+  }
+}
+
+exports["test page-mod on private tab"] = function (test) {
+  test.waitUntilDone();
+  let privateUri = "data:text/html;charset=utf-8," +
+                   "<iframe src=\"data:text/html;charset=utf-8,frame\" />";
+  let nonPrivateUri = "data:text/html;charset=utf-8,non-private";
+
+  let pageMod = new PageMod({
+    include: "data:*",
+    onAttach: function(worker) {
+      if (isTabPBSupported || isWindowPBSupported) {
+        // When PB isn't supported, the page-mod will apply to all document
+        // as all of them will be non-private
+        test.assertEqual(worker.tab.url,
+                         nonPrivateUri,
+                         "page-mod should only attach to the non-private tab");
+      }
+      test.assert(!isPrivate(worker.tab),
+                  "The document is really non-private");
+      pageMod.destroy();
+      page1.close().then(page2.close).then(test.done.bind(test));
+    }
+  });
+
+  let page1 = openWebpage(privateUri, true);
+  let page2 = openWebpage(nonPrivateUri, false);
+}


### PR DESCRIPTION
Add necessary checks in page-mod.
Add a test in test-page-mod for when addon isn't using the package.json flag.
And added an addon with the flag in order to check for when the flag is set.

Based on top of PR #736.

https://bugzilla.mozilla.org/show_bug.cgi?id=834960
