### PR TITLE
Fix for bug 824638 - Add-on keeps getting "TypeError: node.href is undefined" for an <a> containing an <img>

### DIFF
--- a/doc/module-source/sdk/context-menu.md
+++ b/doc/module-source/sdk/context-menu.md
@@ -12,23 +12,23 @@ Introduction
 ------------
 
 The `context-menu` API provides a simple, declarative way to add items to the
-page's context menu.  You can add items that perform an action when clicked,
+page's context menu. You can add items that perform an action when clicked,
 submenus, and menu separators.
 
 Instead of manually adding items when particular contexts occur and then
 removing them when those contexts go away, you *bind* items to contexts, and the
-adding and removing is automatically handled for you.  Items are bound to
-contexts in much the same way that event listeners are bound to events.  When
+adding and removing is automatically handled for you. Items are bound to
+contexts in much the same way that event listeners are bound to events. When
 the user invokes the context menu, all of the items bound to the current context
-are automatically added to the menu.  If no items are bound, none are added.
+are automatically added to the menu. If no items are bound, none are added.
 Likewise, any items that were previously in the menu but are not bound to the
-current context are automatically removed from the menu.  You never need to
+current context are automatically removed from the menu. You never need to
 manually remove your items from the menu unless you want them to never appear
 again.
 
 For example, if your add-on needs to add a context menu item whenever the
 user visits a certain page, don't create the item when that page loads, and
-don't remove it when the page unloads.  Rather, create your item only once and
+don't remove it when the page unloads. Rather, create your item only once and
 supply a context that matches the target URL.
 
 Context menu items are displayed in the order created or in the case of sub
@@ -43,27 +43,27 @@ Specifying Contexts
 -------------------
 
 As its name implies, the context menu should be reserved for the occurrence of
-specific contexts.  Contexts can be related to page content or the page itself,
+specific contexts. Contexts can be related to page content or the page itself,
 but they should never be external to the page.
 
 For example, a good use of the menu would be to show an "Edit Image" item when
-the user right-clicks an image in the page.  A bad use would be to show a
+the user right-clicks an image in the page. A bad use would be to show a
 submenu that listed all the user's tabs, since tabs aren't related to the page
 or the node the user clicked to open the menu.
 
 ### The Page Context
 
-First of all, you may not need to specify a context at all.  When a top-level
-item does not specify a context, the page context applies.  An item that is in a
+First of all, you may not need to specify a context at all. When a top-level
+item does not specify a context, the page context applies. An item that is in a
 submenu is visible unless you specify a context.
 
 The *page context* occurs when the user invokes the context menu on a
-non-interactive portion of the page.  Try right-clicking a blank spot in this
-page, or on text.  Make sure that no text is selected.  The menu that appears
-should contain the items "Back", "Forward", "Reload", "Stop", and so on.  This
+non-interactive portion of the page. Try right-clicking a blank spot in this
+page, or on text. Make sure that no text is selected. The menu that appears
+should contain the items "Back", "Forward", "Reload", "Stop", and so on. This
 is the page context.
 
-The page context is appropriate when your item acts on the page as a whole.  It
+The page context is appropriate when your item acts on the page as a whole. It
 does not occur when the user invokes the context menu on a link, image, or other
 non-text node, or while a selection exists.
 
@@ -79,7 +79,7 @@ like this:
       context: cm.URLContext("*.mozilla.org")
     });
 
-These contexts may be specified by calling the following constructors.  Each is
+These contexts may be specified by calling the following constructors. Each is
 exported by the `context-menu` module.
 
 <table>
@@ -121,10 +121,10 @@ exported by the `context-menu` module.
     </code></td>
     <td>
       This context occurs when the menu is invoked on pages with particular
-      URLs.  <code>matchPattern</code> is a match pattern string or an array of
-      match pattern strings.  When <code>matchPattern</code> is an array, the
+      URLs. <code>matchPattern</code> is a match pattern string or an array of
+      match pattern strings. When <code>matchPattern</code> is an array, the
       context occurs when the menu is invoked on a page whose URL matches any of
-      the patterns.  These are the same match pattern strings that you use with
+      the patterns. These are the same match pattern strings that you use with
       the <a href="modules/sdk/page-mod.html"><code>page-mod</code></a>
       <code>include</code> property.
       <a href="modules/sdk/page-mod/match-pattern.html">Read more about patterns</a>.
@@ -135,14 +135,14 @@ exported by the `context-menu` module.
       array
     </td>
     <td>
-      An array of any of the other types.  This context occurs when all contexts
+      An array of any of the other types. This context occurs when all contexts
       in the array occur.
     </td>
   </tr>
 </table>
 
 Menu items also have a `context` property that can be used to add and remove
-declarative contexts after construction.  For example:
+declarative contexts after construction. For example:
 
     var context = require("sdk/context-menu").SelectorContext("img");
     myMenuItem.context.add(context);
@@ -153,19 +153,19 @@ all of those contexts occur.
 
 ### In Content Scripts
 
-The declarative contexts are handy but not very powerful.  For instance, you
+The declarative contexts are handy but not very powerful. For instance, you
 might want your menu item to appear for any page that has at least one image,
 but declarative contexts won't help you there.
 
 When you need more control over the context in which your menu items are
-shown, you can use content scripts.  Like other APIs in the SDK, the
+shown, you can use content scripts. Like other APIs in the SDK, the
 `context-menu` API uses
 [content scripts](dev-guide/guides/content-scripts/index.html) to let your
-add-on interact with pages in the browser.  Each menu item you create in the
+add-on interact with pages in the browser. Each menu item you create in the
 top-level context menu can have a content script.
 
 A special event named `"context"` is emitted in your content scripts whenever
-the context menu is about to be shown.  If you register a listener function for
+the context menu is about to be shown. If you register a listener function for
 this event and it returns true, the menu item associated with the listener's
 content script is shown in the menu.
 
@@ -179,17 +179,17 @@ that contains at least one image:
                      '});'
     });
 
-Note that the listener function has a parameter called `node`.  This is the node
-in the page that the user context-clicked to invoke the menu.  You can use it to
+Note that the listener function has a parameter called `node`. This is the node
+in the page that the user context-clicked to invoke the menu. You can use it to
 determine whether your item should be shown.
 
 You can both specify declarative contexts and listen for contexts in a content
-script.  In that case, the declarative contexts are evaluated first, and your
+script. In that case, the declarative contexts are evaluated first, and your
 item is shown only when all declarative contexts are current and your
 context listener returns true.
 
 If any declarative contexts are not current, then your context listener
-is never called. This example takes advantage of that fact.  The listener
+is never called. This example takes advantage of that fact. The listener
 can be assured that `node` will always be an image:
 
     var cm = require("sdk/context-menu");
@@ -232,7 +232,7 @@ Handling Menu Item Clicks
 -------------------------
 
 In addition to using content scripts to listen for the `"context"` event as
-described above, you can use content scripts to handle item clicks.  When the
+described above, you can use content scripts to handle item clicks. When the
 user clicks your menu item, an event named `"click"` is emitted in the item's
 content script.
 
@@ -307,7 +307,7 @@ info: contextmenu-example: clicked: P
 ### The "data" Argument ###
 
 `data` is the `data` property of the menu item
-that was clicked.  Note that when you have a hierarchy of menu items the click
+that was clicked. Note that when you have a hierarchy of menu items the click
 event will be sent to the content script of the item clicked and all ancestors
 so be sure to verify that the `data` value passed matches the item you expect.
 You can use this to simplify click handling by providing just a single click
@@ -329,10 +329,10 @@ listener on a `Menu` that reacts to clicks for any child items.:
 ### Communicating With the Add-on ###
 
 Often you will need to collect some kind of information in the click listener
-and perform an action unrelated to content.  To communicate to the menu item
+and perform an action unrelated to content. To communicate to the menu item
 associated with the content script, the content script can call the
 `postMessage` function attached to the global `self` object, passing it some
-JSON-able data.  The menu item's `"message"` event listener will be called with
+JSON-able data. The menu item's `"message"` event listener will be called with
 that data.
 
     var cm = require("sdk/context-menu");
@@ -354,7 +354,7 @@ Updating a Menu Item's Label
 Each menu item must be created with a label, but you can change its label later
 using a couple of methods.
 
-The simplest method is to set the menu item's `label` property.  This example
+The simplest method is to set the menu item's `label` property. This example
 updates the item's label based on the number of times it's been clicked:
 
     var numClicks = 0;
@@ -368,13 +368,13 @@ updates the item's label based on the number of times it's been clicked:
       }
     });
 
-Sometimes you might want to update the label based on the context.  For
+Sometimes you might want to update the label based on the context. For
 instance, if your item performs a search with the user's selected text, it would
-be nice to display the text in the item to provide feedback to the user.  In
-these cases you can use the second method.  Recall that your content scripts can
+be nice to display the text in the item to provide feedback to the user. In
+these cases you can use the second method. Recall that your content scripts can
 listen for the `"context"` event and if your listeners return true, the items
-associated with the content scripts are shown in the menu.  In addition to
-returning true, your `"context"` listeners can also return strings.  When a
+associated with the content scripts are shown in the menu. In addition to
+returning true, your `"context"` listeners can also return strings. When a
 `"context"` listener returns a string, it becomes the item's new label.
 
 This item implements the aforementioned search example:
@@ -392,7 +392,7 @@ This item implements the aforementioned search example:
     });
 
 The `"context"` listener gets the window's current selection, truncating it if
-it's too long, and includes it in the returned string.  When the item is shown,
+it's too long, and includes it in the returned string. When the item is shown,
 its label will be "Search Google for `text`", where `text` is the truncated
 selection.
 
@@ -401,9 +401,9 @@ More Examples
 -------------
 
 For conciseness, these examples create their content scripts as strings and use
-the `contentScript` property.  In your own add-on, you will probably want to
+the `contentScript` property. In your own add-on, you will probably want to
 create your content scripts in separate files and pass their URLs using the
-`contentScriptFile` property.  See
+`contentScriptFile` property. See
 [Working with Content Scripts](dev-guide/guides/content-scripts/index.html)
 for more information.
 
@@ -516,14 +516,14 @@ A labeled menu item that can perform an action when clicked.
 @param options {object}
   An object with the following keys:
   @prop label {string}
-    The item's label.  It must either be a string or an object that implements
+    The item's label. It must either be a string or an object that implements
     `toString()`.
   @prop [image] {string}
-    The item's icon, a string URL.  The URL can be remote, a reference to an
+    The item's icon, a string URL. The URL can be remote, a reference to an
     image in the add-on's `data` directory, or a data URI.
   @prop [data] {string}
-    An optional arbitrary value to associate with the item.  It must be either a
-    string or an object that implements `toString()`.  It will be passed to
+    An optional arbitrary value to associate with the item. It must be either a
+    string or an object that implements `toString()`. It will be passed to
     click listeners.
   @prop [context] {value}
     If the item is contained in the top-level context menu, this declaratively
@@ -539,43 +539,43 @@ A labeled menu item that can perform an action when clicked.
     use to interact with the page.
   @prop [onMessage] {function}
     If the item is contained in the top-level context menu, this function will
-    be called when the content script calls `self.postMessage`.  It will be
+    be called when the content script calls `self.postMessage`. It will be
     passed the data that was passed to `postMessage`.
 </api>
 
 <api name="label">
 @property {string}
-  The menu item's label.  You can set this after creating the item to update its
+  The menu item's label. You can set this after creating the item to update its
   label later.
 </api>
 
 <api name="image">
 @property {string}
-  The item's icon, a string URL.  The URL can be remote, a reference to an image
-  in the add-on's `data` directory, or a data URI.  You can set this after
-  creating the item to update its image later.  To remove the item's image, set
+  The item's icon, a string URL. The URL can be remote, a reference to an image
+  in the add-on's `data` directory, or a data URI. You can set this after
+  creating the item to update its image later. To remove the item's image, set
   it to `null`.
 </api>
 
 <api name="data">
 @property {string}
-  An optional arbitrary value to associate with the item.  It must be either a
-  string or an object that implements `toString()`.  It will be passed to
-  click listeners.  You can set this after creating the item to update its data
+  An optional arbitrary value to associate with the item. It must be either a
+  string or an object that implements `toString()`. It will be passed to
+  click listeners. You can set this after creating the item to update its data
   later.
 </api>
 
 <api name="context">
 @property {list}
   A list of declarative contexts for which the menu item will appear in the
-  context menu.  Contexts can be added by calling `context.add()` and removed by
+  context menu. Contexts can be added by calling `context.add()` and removed by
   called `context.remove()`.
 </api>
 
 <api name="parentMenu">
 @property {Menu}
   The item's parent `Menu`, or `null` if the item is contained in the top-level
-  context menu.  This property is read-only.  To add the item to a new menu,
+  context menu. This property is read-only. To add the item to a new menu,
   call that menu's `addItem()` method.
 </api>
 
@@ -594,7 +594,7 @@ A labeled menu item that can perform an action when clicked.
 <api name="destroy">
 @method
   Permanently removes the item from its parent menu and frees its resources.
-  The item must not be used afterward.  If you need to remove the item from its
+  The item must not be used afterward. If you need to remove the item from its
   parent menu but use it afterward, call `removeItem()` on the parent menu
   instead.
 </api>
@@ -624,13 +624,13 @@ A labeled menu item that expands into a submenu.
 @param options {object}
   An object with the following keys:
   @prop label {string}
-    The item's label.  It must either be a string or an object that implements
+    The item's label. It must either be a string or an object that implements
     `toString()`.
   @prop items {array}
-    An array of menu items that the menu will contain.  Each must be an `Item`,
+    An array of menu items that the menu will contain. Each must be an `Item`,
     `Menu`, or `Separator`.
   @prop [image] {string}
-    The menu's icon, a string URL.  The URL can be remote, a reference to an
+    The menu's icon, a string URL. The URL can be remote, a reference to an
     image in the add-on's `data` directory, or a data URI.
   @prop [context] {value}
     If the menu is contained in the top-level context menu, this declaratively
@@ -646,43 +646,43 @@ A labeled menu item that expands into a submenu.
     use to interact with the page.
   @prop [onMessage] {function}
     If the menu is contained in the top-level context menu, this function will
-    be called when the content script calls `self.postMessage`.  It will be
+    be called when the content script calls `self.postMessage`. It will be
     passed the data that was passed to `postMessage`.
 </api>
 
 <api name="label">
 @property {string}
-  The menu's label.  You can set this after creating the menu to update its
+  The menu's label. You can set this after creating the menu to update its
   label later.
 </api>
 
 <api name="items">
 @property {array}
-  An array containing the items in the menu.  The array is read-only, meaning
-  that modifications to it will not affect the menu.  However, setting this
+  An array containing the items in the menu. The array is read-only, meaning
+  that modifications to it will not affect the menu. However, setting this
   property to a new array will replace all the items currently in the menu with
   the items in the new array.
 </api>
 
 <api name="image">
 @property {string}
-  The menu's icon, a string URL.  The URL can be remote, a reference to an image
-  in the add-on's `data` directory, or a data URI.  You can set this after
-  creating the menu to update its image later.  To remove the menu's image, set
+  The menu's icon, a string URL. The URL can be remote, a reference to an image
+  in the add-on's `data` directory, or a data URI. You can set this after
+  creating the menu to update its image later. To remove the menu's image, set
   it to `null`.
 </api>
 
 <api name="context">
 @property {list}
   A list of declarative contexts for which the menu will appear in the context
-  menu.  Contexts can be added by calling `context.add()` and removed by called
+  menu. Contexts can be added by calling `context.add()` and removed by called
   `context.remove()`.
 </api>
 
 <api name="parentMenu">
 @property {Menu}
   The menu's parent `Menu`, or `null` if the menu is contained in the top-level
-  context menu.  This property is read-only.  To add the menu to a new menu,
+  context menu. This property is read-only. To add the menu to a new menu,
   call that menu's `addItem()` method.
 </api>
 
@@ -700,9 +700,9 @@ A labeled menu item that expands into a submenu.
 
 <api name="addItem">
 @method
-  Appends a menu item to the end of the menu.  If the item is already contained
+  Appends a menu item to the end of the menu. If the item is already contained
   in another menu or in the top-level context menu, it's automatically removed
-  first.  If the item is already contained in this menu it will just be moved
+  first. If the item is already contained in this menu it will just be moved
   to the end of the menu.
 @param item {Item,Menu,Separator}
   The `Item`, `Menu`, or `Separator` to add to the menu.
@@ -710,7 +710,7 @@ A labeled menu item that expands into a submenu.
 
 <api name="removeItem">
 @method
-  Removes the given menu item from the menu.  If the menu does not contain the
+  Removes the given menu item from the menu. If the menu does not contain the
   item, this method does nothing.
 @param item {Item,Menu,Separator}
   The menu item to remove from the menu.
@@ -719,7 +719,7 @@ A labeled menu item that expands into a submenu.
 <api name="destroy">
 @method
   Permanently removes the menu from its parent menu and frees its resources.
-  The menu must not be used afterward.  If you need to remove the menu from its
+  The menu must not be used afterward. If you need to remove the menu from its
   parent menu but use it afterward, call `removeItem()` on the parent menu
   instead.
 </api>
@@ -741,7 +741,7 @@ from the content script. The message can be any
 
 <api name="Separator">
 @class
-A menu separator.  Separators can be contained only in `Menu`s, not in the
+A menu separator. Separators can be contained only in `Menu`s, not in the
 top-level context menu.
 
 <api name="Separator">
@@ -751,14 +751,14 @@ top-level context menu.
 
 <api name="parentMenu">
 @property {Menu}
-  The separator's parent `Menu`.  This property is read-only.  To add the
+  The separator's parent `Menu`. This property is read-only. To add the
   separator to a new menu, call that menu's `addItem()` method.
 </api>
 
 <api name="destroy">
 @method
   Permanently removes the separator from its parent menu and frees its
-  resources.  The separator must not be used afterward.  If you need to remove
+  resources. The separator must not be used afterward. If you need to remove
   the separator from its parent menu but use it afterward, call `removeItem()`
   on the parent menu instead.
 </api>
@@ -769,7 +769,7 @@ top-level context menu.
 @class
 <api name="PageContext">
 @constructor
-  Creates a page context.  See Specifying Contexts above.
+  Creates a page context. See Specifying Contexts above.
 </api>
 </api>
 
@@ -777,7 +777,7 @@ top-level context menu.
 @class
 <api name="SelectionContext">
 @constructor
-  Creates a context that occurs when a page contains a selection.  See
+  Creates a context that occurs when a page contains a selection. See
   Specifying Contexts above.
 </api>
 </api>
@@ -786,7 +786,7 @@ top-level context menu.
 @class
 <api name="SelectorContext">
 @constructor
-  Creates a context that matches a given CSS selector.  See Specifying Contexts
+  Creates a context that matches a given CSS selector. See Specifying Contexts
   above.
 @param selector {string}
   A CSS selector.
@@ -797,7 +797,7 @@ top-level context menu.
 @class
 <api name="URLContext">
 @constructor
-  Creates a context that matches pages with particular URLs.  See Specifying
+  Creates a context that matches pages with particular URLs. See Specifying
   Contexts above.
 @param matchPattern {string,array}
   A [match pattern](modules/sdk/page-mod/match-pattern.html) string, regexp or an


### PR DESCRIPTION
There are two commits here: this first commit is the one that fixes this bug, and is the main one to review. While updating it I noticed that this file uses two spaces after a period, which is inconsistent with all the other docs. The second commit fixes that.
