### PR TITLE
Bug 839271: Use the inner window ID to cache workers so we get a new one if the outer window doesn't change.

### DIFF
--- a/lib/sdk/context-menu.js
+++ b/lib/sdk/context-menu.js
@@ -373,7 +373,6 @@ function getItemWorkerForWindow(item, window) {
       emit(item, "message", msg);
     },
     onDetach: function() {
-      console.log("Worker detach");
       internal(item).workerMap.delete(id);
     }
   });

--- a/test/test-context-menu.js
+++ b/test/test-context-menu.js
@@ -481,7 +481,7 @@ exports.testURLContextRemove = function (test) {
 };
 
 // Loading a new page in the same tab should correctly start a new worker for
-// and content scripts
+// any content scripts
 exports.testPageReload = function (test) {
   test = new TestHelper(test);
   let loader = test.newLoader();
@@ -496,6 +496,7 @@ exports.testPageReload = function (test) {
     doc.body.setAttribute("showItem", "true");
 
     test.showMenu(null, function (popup) {
+      // With the attribute true the item should be visible in the menu
       test.checkMenu([item], [], []);
       test.hideMenu(function() {
         let browser = this.tabBrowser.getBrowserForTab(this.tab)
@@ -508,6 +509,9 @@ exports.testPageReload = function (test) {
             doc.body.setAttribute("showItem", "false");
 
             test.showMenu(null, function (popup) {
+              // In the new document with the attribute false the item should be
+              // hidden, but if the contentScript hasn't been reloaded it will
+              // still see the old value
               test.checkMenu([item], [item], []);
 
               test.done();


### PR DESCRIPTION
This changes to cache against the inner window ID rather than the outer window object. The test checks an attribute in the document that changes during the test, if a new worker isn't created it sees the old value and the test fails.
