### PR TITLE
Bug 839318: context-menu should overflow based on the number of visible menu items

### DIFF
--- a/lib/sdk/context-menu.js
+++ b/lib/sdk/context-menu.js
@@ -645,6 +645,12 @@ when(function() {
 // App specific UI code lives here, it should handle populating the context
 // menu and passing clicks etc. through to the items.
 
+function countVisibleItems(nodes) {
+  return Array.reduce(nodes, function(sum, node) {
+    return node.hidden ? sum : sum + 1;
+  }, 0);
+}
+
 let MenuWrapper = Class({
   initialize: function initialize(winWrapper, items, contextMenu) {
     this.winWrapper = winWrapper;
@@ -654,11 +660,17 @@ let MenuWrapper = Class({
     this.populated = false;
     this.menuMap = new Map();
 
-    this.contextMenu.addEventListener("popupshowing", this, false);
+    // updateItemVisibilities will run first, updateOverflowState will run after
+    // all other instances of this module have run updateItemVisibilities
+    this._updateItemVisibilities = this.updateItemVisibilities.bind(this);
+    this.contextMenu.addEventListener("popupshowing", this._updateItemVisibilities, true);
+    this._updateOverflowState = this.updateOverflowState.bind(this);
+    this.contextMenu.addEventListener("popupshowing", this._updateOverflowState, false);
   },
 
   destroy: function destroy() {
-    this.contextMenu.removeEventListener("popupshowing", this, false);
+    this.contextMenu.removeEventListener("popupshowing", this._updateOverflowState, false);
+    this.contextMenu.removeEventListener("popupshowing", this._updateItemVisibilities, true);
 
     if (!this.populated)
       return;
@@ -741,31 +753,11 @@ let MenuWrapper = Class({
 
     let menu = item.parentMenu;
     if (menu === this.items) {
+      // Insert into the overflow popup if it exists, otherwise the normal
+      // context menu
       menupopup = this.overflowPopup;
-
-      // If there isn't already an overflow menu then check if we need to
-      // create one, otherwise use the main context menu
-      if (!menupopup) {
+      if (!menupopup)
         menupopup = this.contextMenu;
-        let toplevel = this.topLevelItems;
-
-        if (toplevel.length >= MenuManager.overflowThreshold) {
-          // Create the overflow menu and move everything there
-          let overflowMenu = this.window.document.createElement("menu");
-          overflowMenu.setAttribute("class", OVERFLOW_MENU_CLASS);
-          overflowMenu.setAttribute("label", OVERFLOW_MENU_LABEL);
-          this.contextMenu.insertBefore(overflowMenu, this.separator.nextSibling);
-
-          menupopup = this.window.document.createElement("menupopup");
-          menupopup.setAttribute("class", OVERFLOW_POPUP_CLASS);
-          overflowMenu.appendChild(menupopup);
-
-          for (let xulNode of toplevel) {
-            menupopup.appendChild(xulNode);
-            this.updateXULClass(xulNode);
-          }
-        }
-      }
     }
     else {
       let xulNode = this.getXULNodeForItem(menu);
@@ -932,30 +924,18 @@ let MenuWrapper = Class({
       }
     }
     else if (parent == this.overflowPopup) {
+      // If there are no more items then remove the overflow menu and separator
       if (parent.childNodes.length == 0) {
-        // It's possible that this add-on had all the items in the overflow
-        // menu and they're now all gone, so remove the separator and overflow
-        // menu directly
-
         let separator = this.separator;
         separator.parentNode.removeChild(separator);
-        this.contextMenu.removeChild(parent.parentNode);
-      }
-      else if (parent.childNodes.length <= MenuManager.overflowThreshold) {
-        // Otherwise if the overflow menu is empty enough move everything in
-        // the overflow menu back to top level and remove the overflow menu
-
-        while (parent.firstChild) {
-          let node = parent.firstChild;
-          this.contextMenu.insertBefore(node, parent.parentNode);
-          this.updateXULClass(node);
-        }
         this.contextMenu.removeChild(parent.parentNode);
       }
     }
   },
 
-  handleEvent: function handleEvent(event) {
+  // Recurses through all the items owned by this module and sets their hidden
+  // state
+  updateItemVisibilities: function updateItemVisibilities(event) {
     try {
       if (event.type != "popupshowing")
         return;
@@ -970,28 +950,77 @@ let MenuWrapper = Class({
         this.populate(this.items);
       }
 
-      let separator = this.separator;
-      let popup = this.overflowMenu;
-
       let popupNode = event.target.triggerNode;
-      if (this.setVisibility(this.items, popupNode, PageContext().isCurrent(popupNode))) {
-        // Some of this instance's items are visible so make sure the separator
-        // and if necessary the overflow popup are visible
-        separator.hidden = false;
-        if (popup)
-          popup.hidden = false;
+      this.setVisibility(this.items, popupNode, PageContext().isCurrent(popupNode));
+    }
+    catch (e) {
+      console.exception(e);
+    }
+  },
+
+  // Counts the number of visible items across all modules and makes sure they
+  // are in the right place between the top level context menu and the overflow
+  // menu
+  updateOverflowState: function updateOverflowState(event) {
+    try {
+      if (event.type != "popupshowing")
+        return;
+      if (event.target != this.contextMenu)
+        return;
+
+      // The main items will be in either the top level context menu or the
+      // overflow menu at this point. Count the visible ones and if they are in
+      // the wrong place move them
+      let toplevel = this.topLevelItems;
+      let overflow = this.overflowItems;
+      let visibleCount = countVisibleItems(toplevel) +
+                         countVisibleItems(overflow);
+
+      if (visibleCount == 0) {
+        let separator = this.separator;
+        if (separator)
+          separator.hidden = true;
+        let overflowMenu = this.overflowMenu;
+        if (overflowMenu)
+          overflowMenu.hidden = true;
+      }
+      else if (visibleCount > MenuManager.overflowThreshold) {
+        this.separator.hidden = false;
+        let overflowPopup = this.overflowPopup;
+        if (overflowPopup)
+          overflowPopup.parentNode.hidden = false;
+
+        if (toplevel.length > 0) {
+          // The overflow menu shouldn't exist here but let's play it safe
+          if (!overflowPopup) {
+            let overflowMenu = this.window.document.createElement("menu");
+            overflowMenu.setAttribute("class", OVERFLOW_MENU_CLASS);
+            overflowMenu.setAttribute("label", OVERFLOW_MENU_LABEL);
+            this.contextMenu.insertBefore(overflowMenu, this.separator.nextSibling);
+
+            overflowPopup = this.window.document.createElement("menupopup");
+            overflowPopup.setAttribute("class", OVERFLOW_POPUP_CLASS);
+            overflowMenu.appendChild(overflowPopup);
+          }
+
+          for (let xulNode of toplevel) {
+            overflowPopup.appendChild(xulNode);
+            this.updateXULClass(xulNode);
+          }
+        }
       }
       else {
-        // We need to test whether any other instance has visible items.
-        // Get all the highest level items and see if any are visible.
-        let anyVisible = (Array.some(this.topLevelItems, function(item) !item.hidden)) ||
-                         (Array.some(this.overflowItems, function(item) !item.hidden));
+        this.separator.hidden = false;
 
-        // If any were visible make sure the separator and if necessary the
-        // overflow popup are visible, otherwise hide them
-        separator.hidden = !anyVisible;
-        if (popup)
-          popup.hidden = !anyVisible;
+        if (overflow.length > 0) {
+          // Move all the overflow nodes out of the overflow menu and position
+          // them immediately before it
+          for (let xulNode of overflow) {
+            this.contextMenu.insertBefore(xulNode, xulNode.parentNode.parentNode);
+            this.updateXULClass(xulNode);
+          }
+          this.contextMenu.removeChild(this.overflowMenu);
+        }
       }
     }
     catch (e) {

--- a/test/test-context-menu.js
+++ b/test/test-context-menu.js
@@ -1220,6 +1220,221 @@ exports.testMultipleModulesOverflowHidden2 = function (test) {
   });
 };
 
+
+// Checks that we don't overflow if there are more items than the overflow
+// threshold but not all of them are visible
+exports.testOverflowIgnoresHidden = function (test) {
+  test = new TestHelper(test);
+  let loader = test.newLoader();
+
+  let prefs = loader.loader.require("preferences-service");
+  prefs.set(OVERFLOW_THRESH_PREF, 2);
+
+  let allItems = [
+    new loader.cm.Item({
+      label: "item 0"
+    }),
+    new loader.cm.Item({
+      label: "item 1"
+    }),
+    new loader.cm.Item({
+      label: "item 2",
+      context: loader.cm.SelectorContext("a")
+    })
+  ];
+
+  test.showMenu(null, function (popup) {
+    // One should be hidden
+    test.checkMenu(allItems, [allItems[2]], []);
+    test.done();
+  });
+};
+
+
+// Checks that we don't overflow if there are more items than the overflow
+// threshold but not all of them are visible
+exports.testOverflowIgnoresHiddenMultipleModules1 = function (test) {
+  test = new TestHelper(test);
+  let loader0 = test.newLoader();
+  let loader1 = test.newLoader();
+
+  let prefs = loader0.loader.require("preferences-service");
+  prefs.set(OVERFLOW_THRESH_PREF, 2);
+
+  let allItems = [
+    new loader0.cm.Item({
+      label: "item 0"
+    }),
+    new loader0.cm.Item({
+      label: "item 1"
+    }),
+    new loader1.cm.Item({
+      label: "item 2",
+      context: loader1.cm.SelectorContext("a")
+    }),
+    new loader1.cm.Item({
+      label: "item 3",
+      context: loader1.cm.SelectorContext("a")
+    })
+  ];
+
+  test.showMenu(null, function (popup) {
+    // One should be hidden
+    test.checkMenu(allItems, [allItems[2], allItems[3]], []);
+    test.done();
+  });
+};
+
+
+// Checks that we don't overflow if there are more items than the overflow
+// threshold but not all of them are visible
+exports.testOverflowIgnoresHiddenMultipleModules2 = function (test) {
+  test = new TestHelper(test);
+  let loader0 = test.newLoader();
+  let loader1 = test.newLoader();
+
+  let prefs = loader0.loader.require("preferences-service");
+  prefs.set(OVERFLOW_THRESH_PREF, 2);
+
+  let allItems = [
+    new loader0.cm.Item({
+      label: "item 0"
+    }),
+    new loader0.cm.Item({
+      label: "item 1",
+      context: loader0.cm.SelectorContext("a")
+    }),
+    new loader1.cm.Item({
+      label: "item 2"
+    }),
+    new loader1.cm.Item({
+      label: "item 3",
+      context: loader1.cm.SelectorContext("a")
+    })
+  ];
+
+  test.showMenu(null, function (popup) {
+    // One should be hidden
+    test.checkMenu(allItems, [allItems[1], allItems[3]], []);
+    test.done();
+  });
+};
+
+
+// Checks that we don't overflow if there are more items than the overflow
+// threshold but not all of them are visible
+exports.testOverflowIgnoresHiddenMultipleModules3 = function (test) {
+  test = new TestHelper(test);
+  let loader0 = test.newLoader();
+  let loader1 = test.newLoader();
+
+  let prefs = loader0.loader.require("preferences-service");
+  prefs.set(OVERFLOW_THRESH_PREF, 2);
+
+  let allItems = [
+    new loader0.cm.Item({
+      label: "item 0",
+      context: loader0.cm.SelectorContext("a")
+    }),
+    new loader0.cm.Item({
+      label: "item 1",
+      context: loader0.cm.SelectorContext("a")
+    }),
+    new loader1.cm.Item({
+      label: "item 2"
+    }),
+    new loader1.cm.Item({
+      label: "item 3"
+    })
+  ];
+
+  test.showMenu(null, function (popup) {
+    // One should be hidden
+    test.checkMenu(allItems, [allItems[0], allItems[1]], []);
+    test.done();
+  });
+};
+
+
+// Tests that we transition between overflowing to non-overflowing to no items
+// and back again
+exports.testOverflowTransition = function (test) {
+  test = new TestHelper(test);
+  let loader = test.newLoader();
+
+  let prefs = loader.loader.require("preferences-service");
+  prefs.set(OVERFLOW_THRESH_PREF, 2);
+
+  let pItems = [
+    new loader.cm.Item({
+      label: "item 0",
+      context: loader.cm.SelectorContext("p")
+    }),
+    new loader.cm.Item({
+      label: "item 1",
+      context: loader.cm.SelectorContext("p")
+    })
+  ];
+
+  let aItems = [
+    new loader.cm.Item({
+      label: "item 2",
+      context: loader.cm.SelectorContext("a")
+    }),
+    new loader.cm.Item({
+      label: "item 3",
+      context: loader.cm.SelectorContext("a")
+    })
+  ];
+
+  let allItems = pItems.concat(aItems);
+
+  test.withTestDoc(function (window, doc) {
+    test.showMenu(doc.getElementById("link"), function (popup) {
+      // The menu should contain all items and will overflow
+      test.checkMenu(allItems, [], []);
+      popup.hidePopup();
+
+      test.showMenu(doc.getElementById("text"), function (popup) {
+        // Only contains hald the items and will not overflow
+        test.checkMenu(allItems, aItems, []);
+        popup.hidePopup();
+
+        test.showMenu(null, function (popup) {
+          // None of the items will be visible
+          test.checkMenu(allItems, allItems, []);
+          popup.hidePopup();
+
+          test.showMenu(doc.getElementById("text"), function (popup) {
+            // Only contains hald the items and will not overflow
+            test.checkMenu(allItems, aItems, []);
+            popup.hidePopup();
+
+            test.showMenu(doc.getElementById("link"), function (popup) {
+              // The menu should contain all items and will overflow
+              test.checkMenu(allItems, [], []);
+              popup.hidePopup();
+
+              test.showMenu(null, function (popup) {
+                // None of the items will be visible
+                test.checkMenu(allItems, allItems, []);
+                popup.hidePopup();
+
+                test.showMenu(doc.getElementById("link"), function (popup) {
+                  // The menu should contain all items and will overflow
+                  test.checkMenu(allItems, [], []);
+                  test.done();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+};
+
+
 // An item's click listener should work.
 exports.testItemClick = function (test) {
   test = new TestHelper(test);
@@ -2399,6 +2614,9 @@ TestHelper.prototype = {
     let mainNodes = this.browserWindow.document.querySelectorAll("#contentAreaContextMenu > ." + ITEM_CLASS);
     let overflowNodes = this.browserWindow.document.querySelectorAll("." + OVERFLOW_POPUP_CLASS + " > ." + ITEM_CLASS);
 
+    this.test.assert(mainNodes.length == 0 || overflowNodes.length == 0,
+                     "Should only see nodes at the top level or in overflow");
+
     let overflow = this.overflowSubmenu;
     if (this.shouldOverflow(total)) {
       this.test.assert(overflow && !overflow.hidden,
@@ -2409,12 +2627,15 @@ TestHelper.prototype = {
     else {
       this.test.assert(!overflow || overflow.hidden,
                        "overflow menu should not be present");
-      this.test.assertEqual(overflowNodes.length, 0,
-                            "should be no items in the overflow context menu");
+      // When visible nodes == 0 they could be in overflow or top level
+      if (total > 0) {
+        this.test.assertEqual(overflowNodes.length, 0,
+                              "should be no items in the overflow context menu");
+      }
     }
 
-    let nodes = this.shouldOverflow(total) ? overflowNodes : mainNodes;
-
+    // Iterate over wherever the nodes have ended up
+    let nodes = mainNodes.length ? mainNodes : overflowNodes;
     this.checkNodes(nodes, presentItems, absentItems, removedItems)
     let pos = 0;
   },
@@ -2429,6 +2650,11 @@ TestHelper.prototype = {
       // Removed items shouldn't be in the list
       if (removedItems.indexOf(item) >= 0)
         continue;
+
+      if (nodes.length <= pos) {
+        this.test.assert(false, "Not enough nodes");
+        return;
+      }
 
       let hidden = absentItems.indexOf(item) >= 0;
 


### PR DESCRIPTION
This removes the code that updates overflow when items are added or removed from the menu. When added if there is already an overflow then it adds there, otherwise it adds at top level.

When the context menu opens two stages run. First all the add-ons go through and set the visibility of their items. Then all the add-ons go and count how many visible items there are, if there are more than the overflow threshold then they make sure the items are in the overflow menu, if not they make sure they're at the top level. It's a little wasteful to have every add-on do this last stage, only one really needs to but it is also harmless.
