### PR TITLE
Bug 839814: Returning undefined from a context listener should hide the menu item.

### DIFF
--- a/lib/sdk/context-menu.js
+++ b/lib/sdk/context-menu.js
@@ -325,11 +325,11 @@ function hasMatchingContext(contexts, popupNode) {
 }
 
 // Gets the matched context from any worker for this item. If there is no worker
-// or no matched context then returns null.
+// or no matched context then returns false.
 function getCurrentWorkerContext(item, popupNode) {
   let worker = getItemWorkerForWindow(item, popupNode.ownerDocument.defaultView);
-  if (!worker)
-    return null;
+  if (!worker || !worker.anyContextListeners())
+    return true;
   return worker.getMatchedContext(popupNode);
 }
 
@@ -346,10 +346,10 @@ function isItemVisible(item, popupNode, defaultVisibility) {
     return false;
 
   let context = getCurrentWorkerContext(item, popupNode);
-  if (typeof(context) === "string")
+  if (typeof(context) === "string" && context != "")
     item.label = context;
 
-  return context !== false;
+  return !!context;
 }
 
 // Gets the item's content script worker for a window, creating one if necessary


### PR DESCRIPTION
This has one other fix. When a context listener returns an empty string we hide the menu but don't change the label. Labels should never be able to be empty. This is a slight change to the old context-menu module which would throw an exception and behave randomly in this case so I think it's safe to say no-one is using it and this new behaviour seems sane.

Also threw in a bunch of tests for the odd case where there are multiple context listeners and making sure that we do the right thing there (verified against the old context-menu).
