### PR TITLE
Bug 833783: followup, fix exception when calling destroy multiple times.

### DIFF
--- a/lib/sdk/tabs/tab-firefox.js
+++ b/lib/sdk/tabs/tab-firefox.js
@@ -57,9 +57,11 @@ const TabTrait = Trait.compose(EventEmitter, {
   },
   destroy: function destroy() {
     this._removeAllListeners();
-    this._browser.removeEventListener(EVENTS.ready.dom, this._onReady, true);
-    this._tab = null;
-    TABS.splice(TABS.indexOf(this), 1);
+    if (this._tab) {
+      this._browser.removeEventListener(EVENTS.ready.dom, this._onReady, true);
+      this._tab = null;
+      TABS.splice(TABS.indexOf(this), 1);
+    }
   },
 
   /**

--- a/test/test-tab.js
+++ b/test/test-tab.js
@@ -121,6 +121,10 @@ exports["test behavior on close"] = function(assert, done) {
                      "After being closed, tab attributes are undefined (url)");
         assert.equal(tab.index, undefined,
                      "After being closed, tab attributes are undefined (index)");
+        // Ensure that we can call destroy multiple times without throwing
+        tab.destroy();
+        tab.destroy();
+
         done();
       });
     }


### PR DESCRIPTION
Followup for PR #765 / bug 833783.
