### PR TITLE
Bug 793925: part 3 - Use absolute path for tests and load each of them in its own loader as the main module.

### DIFF
--- a/lib/sdk/deprecated/unit-test-finder.js
+++ b/lib/sdk/deprecated/unit-test-finder.js
@@ -11,7 +11,8 @@ module.metadata = {
 const file = require("../io/file");
 const memory = require('./memory');
 const suites = require('@test/options').allTestModules;
-
+const { Loader } = require("sdk/test/loader");
+const cuddlefish = require("sdk/loader/cuddlefish");
 
 const NOT_TESTS = ['setup', 'teardown'];
 
@@ -52,7 +53,11 @@ TestFinder.prototype = {
 
     suites.forEach(
       function(suite) {
-        var module = require(suite);
+        // Load each test file as a main module in its own loader instance
+        // `suite` is defined by cuddlefish/manifest.py:ManifestBuilder.build
+        var loader = Loader(module);
+        var module = cuddlefish.main(loader, suite);
+
         if (self.testInProcess)
           for each (let name in Object.keys(module).sort()) {
             if(NOT_TESTS.indexOf(name) === -1 && filter(suite, name)) {

--- a/python-lib/cuddlefish/manifest.py
+++ b/python-lib/cuddlefish/manifest.py
@@ -229,7 +229,8 @@ class ManifestBuilder:
                 # search for all tests. self.test_modules will be passed
                 # through the harness-options.json file in the
                 # .allTestModules property.
-                self.test_modules.append(testname)
+                # Pass the absolute module path.
+                self.test_modules.append(tme.get_path())
 
         # include files used by the loader
         for em in self.extra_modules:

--- a/python-lib/cuddlefish/tests/test_xpi.py
+++ b/python-lib/cuddlefish/tests/test_xpi.py
@@ -328,7 +328,7 @@ class SmallXPI(unittest.TestCase):
                                               [target_cfg.name, "addon-sdk"])
         m = manifest.build_manifest(target_cfg, pkg_cfg, deps, scan_tests=True)
         self.failUnlessEqual(sorted(m.get_all_test_modules()),
-                             sorted(["test-one", "test-two"]))
+                             sorted(["three/tests/test-one", "three/tests/test-two"]))
         # the current __init__.py code omits limit_to=used_files for 'cfx
         # test', so all test files are included in the XPI. But the test
         # runner will only execute the tests that m.get_all_test_modules()
@@ -371,7 +371,7 @@ class SmallXPI(unittest.TestCase):
         m = manifest.build_manifest(target_cfg, pkg_cfg, deps, scan_tests=True,
                                     test_filter_re=FILTER)
         self.failUnlessEqual(sorted(m.get_all_test_modules()),
-                             sorted(["test-one"]))
+                             sorted(["three/tests/test-one"]))
         # the current __init__.py code omits limit_to=used_files for 'cfx
         # test', so all test files are included in the XPI. But the test
         # runner will only execute the tests that m.get_all_test_modules()


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=793925
