### PR TITLE
Bug 793925: part 6 - Simplify manifest path by stripping package name in order to match path of the module from lib folder.

### DIFF
--- a/app-extension/bootstrap.js
+++ b/app-extension/bootstrap.js
@@ -92,16 +92,24 @@ function startup(data, reasonCode) {
     resourceHandler.setSubstitution(domain, resourcesURI);
 
     // Create path to URLs mapping supported by loader.
-    let paths = Object.keys(options.metadata).reduce(function(result, name) {
-      result[name + '/'] = prefixURI + name + '/lib/'
-      result[name + '/tests/'] = prefixURI + name + '/tests/'
-      return result
-    }, {
+    let paths = {
       // Relative modules resolve to add-on package lib
       './': prefixURI + name + '/lib/',
-      'toolkit/': 'resource://gre/modules/toolkit/',
-      '': 'resources:///modules/'
-    });
+      './tests/': prefixURI + name + '/tests/',
+      '': 'resource://gre/modules/commonjs/'
+    };
+
+    // Maps addon lib and tests ressource folders
+    paths[name + '/'] = prefixURI + name + '/lib/';
+    paths[name + '/tests/'] = prefixURI + name + '/tests/';
+    // We need to map tests folder when we run sdk tests whose package name
+    // is stripped
+    if (name == 'addon-sdk')
+      paths['tests/'] = prefixURI + name + '/tests/';
+
+    // Maps sdk module folders to their resource folder
+    paths['sdk/'] = prefixURI + 'addon-sdk/lib/sdk/';
+    paths['toolkit/'] = prefixURI + 'addon-sdk/lib/toolkit/';
 
     // Make version 2 of the manifest
     let manifest = options.manifest;
@@ -157,7 +165,7 @@ function startup(data, reasonCode) {
       }
     });
 
-    let module = cuddlefish.Module('addon-sdk/sdk/loader/cuddlefish', cuddlefishURI);
+    let module = cuddlefish.Module('sdk/loader/cuddlefish', cuddlefishURI);
     let require = cuddlefish.Require(loader, module);
 
     require('sdk/addon/runner').startup(reason, {

--- a/lib/sdk/loader/cuddlefish.js
+++ b/lib/sdk/loader/cuddlefish.js
@@ -88,8 +88,8 @@ function CuddlefishLoader(options) {
     // cache to avoid subsequent loads via `require`.
     modules: override({
       'toolkit/loader': loaderModule,
-      'addon-sdk/sdk/loader/cuddlefish': exports,
-      'addon-sdk/sdk/system/xul-app': xulappModule
+      'sdk/loader/cuddlefish': exports,
+      'sdk/system/xul-app': xulappModule
     }, options.modules),
     resolve: function resolve(id, requirer) {
       let entry = requirer && requirer in manifest && manifest[requirer];

--- a/python-lib/cuddlefish/__init__.py
+++ b/python-lib/cuddlefish/__init__.py
@@ -769,7 +769,7 @@ def run(arguments=sys.argv[1:], target_cfg=None, pkg_cfg=None,
         # This should be contained in the test runner package.
         # maybe just do: target_cfg.main = 'test-harness/run-tests'
         harness_options['main'] = 'sdk/test/runner'
-        harness_options['mainPath'] = manifest.get_manifest_entry("addon-sdk", "lib", "sdk/test/runner").get_path()
+        harness_options['mainPath'] = 'sdk/test/runner'
     else:
         harness_options['main'] = target_cfg.get('main')
         harness_options['mainPath'] = manifest.top_path

--- a/python-lib/cuddlefish/manifest.py
+++ b/python-lib/cuddlefish/manifest.py
@@ -59,13 +59,21 @@ class ManifestEntry:
 
     def get_path(self):
         name = self.moduleName
+
         if name.endswith(".js"):
             name = name[:-3]
+        items = []
+        # Only add package name for addons, so that system module paths match
+        # the path from the commonjs root directory and also match the loader
+        # mappings.
+        if self.packageName != "addon-sdk":
+            items.append(self.packageName)
+        # And for the same reason, do not append `lib/`.
         if self.sectionName == "tests":
-            path = "%s/%s/%s" % (self.packageName, self.sectionName, name)
-        else:
-            path = "%s/%s" % (self.packageName, name)
-        return path
+            items.append(self.sectionName)
+        items.append(name)
+
+        return "/".join(items)
 
     def get_entry_for_manifest(self):
         entry = { "packageName": self.packageName,

--- a/python-lib/cuddlefish/tests/test_linker.py
+++ b/python-lib/cuddlefish/tests/test_linker.py
@@ -48,10 +48,10 @@ class Basic(unittest.TestCase):
         def assertReqIs(modname, reqname, path):
             reqs = m["one/%s" % modname]["requirements"]
             self.failUnlessEqual(reqs[reqname], path)
-        assertReqIs("main", "panel", "addon-sdk/sdk/panel")
+        assertReqIs("main", "panel", "sdk/panel")
         assertReqIs("main", "two.js", "one/two")
         assertReqIs("main", "./two", "one/two")
-        assertReqIs("main", "sdk/tabs.js", "addon-sdk/sdk/tabs")
+        assertReqIs("main", "sdk/tabs.js", "sdk/tabs")
         assertReqIs("main", "./subdir/three", "one/subdir/three")
         assertReqIs("two", "main", "one/main")
         assertReqIs("subdir/three", "../main", "one/main")

--- a/test/commonjs-test-adapter/asserts.js
+++ b/test/commonjs-test-adapter/asserts.js
@@ -4,7 +4,7 @@
 
 "use strict";
 
-const AssertBase = require("test/assert").Assert;
+const AssertBase = require("sdk/test/assert").Assert;
 
 /**
  * Generates custom assertion constructors that may be bundled with a test

--- a/test/private-browsing/windows.js
+++ b/test/private-browsing/windows.js
@@ -4,9 +4,9 @@
 'use strict';
 
 const { pb, pbUtils } = require('./helper');
-const { openDialog } = require('window/utils');
-const { isPrivate } = require('private-browsing');
-const { browserWindows: windows } = require('windows');
+const { openDialog } = require('sdk/window/utils');
+const { isPrivate } = require('sdk/private-browsing');
+const { browserWindows: windows } = require('sdk/windows');
 
 exports.testPerWindowPrivateBrowsingGetter = function(assert, done) {
   let win = openDialog({

--- a/test/test-private-browsing.js
+++ b/test/test-private-browsing.js
@@ -9,7 +9,7 @@ const { merge } = require('sdk/util/object');
 const windows = require('sdk/windows').browserWindows;
 const winUtils = require('sdk/window/utils');
 const { is } = require('sdk/system/xul-app');
-const { isPrivate } = require('private-browsing');
+const { isPrivate } = require('sdk/private-browsing');
 
 // is global pb is enabled?
 if (pbUtils.isGlobalPBSupported) {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=793925
