### PR TITLE
Make sure we get a stack trace on assertion

### DIFF
--- a/python-lib/cuddlefish/__init__.py
+++ b/python-lib/cuddlefish/__init__.py
@@ -386,6 +386,10 @@ def test_cfx(env_root, verbose):
     sys.stdout.flush(); sys.stderr.flush()
     olddir = os.getcwd()
     os.chdir(env_root)
+    # set the value of the environment variable XPCOM_DEBUG_BREAK to 'stack'
+    # before running the tests so we get a stack trace if we hit any
+    # assertions. This was added for bug 689291
+    os.environ["XPCOM_DEBUG_BREAK"] = "stack";
     retval = cuddlefish.tests.run(verbose)
     os.chdir(olddir)
     sys.stdout.flush(); sys.stderr.flush()


### PR DESCRIPTION
I'm no python wizard, so I don't know if this one-liner will work, but it doesn't seem to break cfx at least.
