### PR TITLE
Bug 793925 - Fix support of 3rd party packages.

### DIFF
--- a/app-extension/bootstrap.js
+++ b/app-extension/bootstrap.js
@@ -99,9 +99,13 @@ function startup(data, reasonCode) {
       '': 'resource://gre/modules/commonjs/'
     };
 
-    // Maps addon lib and tests ressource folders
-    paths[name + '/'] = prefixURI + name + '/lib/';
-    paths[name + '/tests/'] = prefixURI + name + '/tests/';
+    // Maps addon lib and tests ressource folders for each package
+    paths = Object.keys(options.metadata).reduce(function(result, name) {
+      result[name + '/'] = prefixURI + name + '/lib/'
+      result[name + '/tests/'] = prefixURI + name + '/tests/'
+      return result;
+    }, paths);
+
     // We need to map tests folder when we run sdk tests whose package name
     // is stripped
     if (name == 'addon-sdk')


### PR DESCRIPTION
While working on PR #800, I identified a regression with 3rd party packages.
We no longer map their lib folder in the xpi.

This code will be covered by tests from  PR #800.

https://bugzilla.mozilla.org/show_bug.cgi?id=793925
