### PR TITLE
bug 844898, html examples for panels should declare text encoding 

### DIFF
--- a/doc/module-source/sdk/panel.md
+++ b/doc/module-source/sdk/panel.md
@@ -242,6 +242,7 @@ Finally, the "text-entry.html" file defines the `<textarea>` element:
 &lt;html&gt;
 
 &lt;head&gt;
+  &lt;meta charset="utf-8"&gt;
   &lt;style type="text/css" media="all"&gt;
     textarea {
       margin: 10px;


### PR DESCRIPTION
See bug https://bugzilla.mozilla.org/show_bug.cgi?id=844898
