### PR TITLE
bug 842448 - Deprecate window.isPrivateBrowsing in favor of require('private-browsing').isPrivate()

### DIFF
--- a/doc/module-source/sdk/windows.md
+++ b/doc/module-source/sdk/windows.md
@@ -182,6 +182,13 @@ tabs in this window, not all tabs in all windows. This property is read-only.
 <api name="isPrivateBrowsing">
 @property {boolean}
 Returns `true` if the window is in private browsing mode, and `false` otherwise.
+
+<div class="warning">
+  This property is deprecated.
+  From version 1.14, please consider using following code instead:<br/>
+  <code>require("private-browsing").isPrivate(browserWindow)</code>
+</div>
+
 </api>
 
 <api name="activate">

--- a/lib/sdk/window/browser.js
+++ b/lib/sdk/window/browser.js
@@ -9,9 +9,10 @@ const { on, off, once } = require('../event/core');
 const { method } = require('../lang/functional');
 const { getWindowTitle } = require('./utils');
 const unload = require('../system/unload');
-const { getMode } = require('../private-browsing/utils');
+const { isWindowPrivate } = require('../private-browsing/utils');
 const { EventTarget } = require('../event/target');
 const { getOwnerWindow: getPBOwnerWindow } = require('../private-browsing/window/utils');
+const { deprecateUsage } = require('../util/deprecate');
 
 const ERR_FENNEC_MSG = 'This method is not yet supported by Fennec, consider using require("tabs") instead';
 
@@ -37,7 +38,13 @@ const BrowserWindow = Class({
   on: method(on),
   removeListener: method(off),
   once: method(once),
-  get isPrivateBrowsing() getMode(windowNS(this).window),
+  get isPrivateBrowsing() {
+    deprecateUsage('`browserWindow.isPrivateBrowsing` is deprecated, please ' +
+                 'consider using ' +
+                 '`require("private-browsing").isPrivate(browserWindow)` ' +
+                 'instead.');
+    return isWindowPrivate(windowNS(this).window);
+  }
 });
 exports.BrowserWindow = BrowserWindow;
 

--- a/lib/sdk/windows/dom.js
+++ b/lib/sdk/windows/dom.js
@@ -5,7 +5,8 @@
 
 const { Trait } = require('../deprecated/traits');
 const { getWindowTitle } = require('../window/utils');
-const { getMode } = require('../private-browsing/utils');
+const { isWindowPrivate } = require('../private-browsing/utils');
+const { deprecateUsage } = require('../util/deprecate');
 
 module.metadata = {
   "stability": "unstable"
@@ -27,7 +28,11 @@ const WindowDom = Trait.compose({
     return this._public;
   },
   get isPrivateBrowsing() {
-    return getMode(this._window);
+    deprecateUsage('`browserWindow.isPrivateBrowsing` is deprecated, please ' +
+                   'consider using ' +
+                   '`require("private-browsing").isPrivate(browserWindow)` ' +
+                   'instead.');
+    return isWindowPrivate(this._window);
   }
 });
 exports.WindowDom = WindowDom;

--- a/test/test-private-browsing.js
+++ b/test/test-private-browsing.js
@@ -12,6 +12,7 @@ const winUtils = require('sdk/window/utils');
 const { isPrivateBrowsingSupported } = require('sdk/self');
 const { is } = require('sdk/system/xul-app');
 const { isPrivate } = require('sdk/private-browsing');
+const { LoaderWithHookedConsole } = require("sdk/test/loader");
 
 // is global pb is enabled?
 if (pbUtils.isGlobalPBSupported) {
@@ -47,7 +48,14 @@ exports.testIsPrivateDefaults = function(test) {
 };
 
 exports.testWindowDefaults = function(test) {
-  test.assertEqual(windows.activeWindow.isPrivateBrowsing, false, 'window is not private browsing by default');
+  // Ensure that browserWindow still works while being deprecated
+  let { loader, messages } = LoaderWithHookedConsole(module);
+  let windows = loader.require("sdk/windows").browserWindows;
+  test.assertEqual(windows.activeWindow.isPrivateBrowsing, false,
+                   'window is not private browsing by default');
+  test.assertMatches(messages[0].msg, /DEPRECATED.+isPrivateBrowsing/,
+                     'isPrivateBrowsing is deprecated');
+
   let chromeWin = winUtils.getMostRecentBrowserWindow();
   test.assertEqual(pbUtils.getMode(chromeWin), false);
   test.assertEqual(pbUtils.isWindowPrivate(chromeWin), false);


### PR DESCRIPTION
Based on top of PR #816.

https://bugzilla.mozilla.org/show_bug.cgi?id=842448
