### PR TITLE
Bug 845812 - Remove the magic that forces to overload Firefox module when  cfx test is launched from SDK root folder.

### DIFF
--- a/python-lib/cuddlefish/__init__.py
+++ b/python-lib/cuddlefish/__init__.py
@@ -786,14 +786,6 @@ def run(arguments=sys.argv[1:], target_cfg=None, pkg_cfg=None,
 
     harness_options.update(build)
 
-    # When cfx is run from sdk root directory, we will strip sdk modules and
-    # override them with local modules.
-    # So that integration tools will continue to work and use local modules
-    if os.getcwd() == env_root:
-        options.bundle_sdk = True
-        options.force_use_bundled_sdk = False
-        options.overload_modules = True
-
     extra_environment = {}
     if command == "test":
         # This should be contained in the test runner package.


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=845812
