### PR TITLE
Bug 841766 - We should warn users when magical require is used

### DIFF
--- a/examples/annotator/lib/main.js
+++ b/examples/annotator/lib/main.js
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var widgets = require('widget');
-var pageMod = require('page-mod');
-var data = require('self').data;
-var panels = require('panel');
-var simpleStorage = require('simple-storage');
-var notifications = require("notifications");
+var widgets = require('sdk/widget');
+var pageMod = require('sdk/page-mod');
+var data = require('sdk/self').data;
+var panels = require('sdk/panel');
+var simpleStorage = require('sdk/simple-storage');
+var notifications = require("sdk/notifications");
 
 /*
 Global variables
@@ -188,7 +188,7 @@ in the browser.
       this.postMessage(simpleStorage.storage.annotations);
     },
     onMessage: function(message) {
-      require('tabs').open(message);
+      require('sdk/tabs').open(message);
     }
   });
 

--- a/examples/library-detector/lib/main.js
+++ b/examples/library-detector/lib/main.js
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const tabs = require('tabs');
-const widgets = require('widget');
-const data = require('self').data;
-const pageMod = require('page-mod');
-const panel = require('panel');
+const tabs = require('sdk/tabs');
+const widgets = require('sdk/widget');
+const data = require('sdk/self').data;
+const pageMod = require('sdk/page-mod');
+const panel = require('sdk/panel');
 
 const ICON_WIDTH = 16;
 

--- a/examples/reading-data/lib/main.js
+++ b/examples/reading-data/lib/main.js
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var self = require("self");
-var panels = require("addon-kit/panel");
-var widgets = require("addon-kit/widget");
+var self = require("sdk/self");
+var panels = require("sdk/panel");
+var widgets = require("sdk/widget");
 
 function replaceMom(html) {
   return html.replace("World", "Mom");

--- a/examples/reading-data/tests/test-main.js
+++ b/examples/reading-data/tests/test-main.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var m = require("main");
-var self = require("self");
+var self = require("sdk/self");
 
 exports.testReplace = function(test) {
   var input = "Hello World";

--- a/examples/reddit-panel/lib/main.js
+++ b/examples/reddit-panel/lib/main.js
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var data = require("self").data;
+var data = require("sdk/self").data;
 
-var reddit_panel = require("panel").Panel({
+var reddit_panel = require("sdk/panel").Panel({
   width: 240,
   height: 320,
   contentURL: "http://www.reddit.com/.mobile?keep_extension=True",
@@ -13,10 +13,10 @@ var reddit_panel = require("panel").Panel({
 });
 
 reddit_panel.port.on("click", function(url) {
-  require("tabs").open(url);
+  require("sdk/tabs").open(url);
 });
 
-require("widget").Widget({
+require("sdk/widget").Widget({
   id: "open-reddit-btn",
   label: "Reddit",
   contentURL: "http://www.reddit.com/static/favicon.ico",

--- a/examples/reddit-panel/tests/test-main.js
+++ b/examples/reddit-panel/tests/test-main.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var m = require("main");
-var self = require("self");
+var self = require("sdk/self");
 
 exports.testMain = function(test) {
   var callbacks = { quit: function() {

--- a/lib/sdk/deprecated/window-utils.js
+++ b/lib/sdk/deprecated/window-utils.js
@@ -205,17 +205,17 @@ Object.defineProperties(exports, {
  */
 exports.getInnerId = deprecateFunction(getInnerId,
   'require("window-utils").getInnerId is deprecated, ' +
-  'please use require("window/utils").getInnerId instead'
+  'please use require("sdk/window/utils").getInnerId instead'
 );
 
 exports.getOuterId = deprecateFunction(getOuterId,
   'require("window-utils").getOuterId is deprecated, ' +
-  'please use require("window/utils").getOuterId instead'
+  'please use require("sdk/window/utils").getOuterId instead'
 );
 
 exports.isBrowser = deprecateFunction(isBrowser,
   'require("window-utils").isBrowser is deprecated, ' +
-  'please use require("window/utils").isBrowser instead'
+  'please use require("sdk/window/utils").isBrowser instead'
 );
 
 exports.hiddenWindow = appShellService.hiddenDOMWindow;

--- a/lib/sdk/private-browsing.js
+++ b/lib/sdk/private-browsing.js
@@ -73,7 +73,8 @@ exports.isPrivate = function(thing) {
 
 function deprecateEvents(func) deprecateEvent(
   func,
-   'The require("private-browsing") module\'s "start" and "stop" events are deprecated.',
+   'The require("sdk/private-browsing") module\'s "start" and "stop" events ' +
+   'are deprecated.',
   ['start', 'stop']
 );
 

--- a/lib/sdk/private-browsing/utils.js
+++ b/lib/sdk/private-browsing/utils.js
@@ -80,8 +80,9 @@ let setMode = defer(function setMode(value) {
 });
 exports.setMode = deprecateFunction(
   setMode,
-  'require("private-browsing").activate and require("private-browsing").deactivate ' +
-  'is deprecated.'
+  'require("sdk/private-browsing").activate and ' +
+  'require("sdk/private-browsing").deactivate ' +
+  'are deprecated.'
 );
 
 let getMode = function getMode(chromeWin) {

--- a/lib/sdk/test/harness.js
+++ b/lib/sdk/test/harness.js
@@ -257,9 +257,9 @@ function cleanup() {
 
   // dump the coverobject
   if (Object.keys(coverObject).length){
-    const self = require('self');
+    const self = require('sdk/self');
     const {pathFor} = require("sdk/system");
-    let file = require('file');
+    let file = require('sdk/io/file');
     const {env} = require('sdk/system/environment');
     console.log("CWD:", env.PWD);
     let out = file.join(env.PWD,'coverstats-'+self.id+'.json');

--- a/lib/sdk/window/browser.js
+++ b/lib/sdk/window/browser.js
@@ -14,7 +14,7 @@ const { EventTarget } = require('../event/target');
 const { getOwnerWindow: getPBOwnerWindow } = require('../private-browsing/window/utils');
 const { deprecateUsage } = require('../util/deprecate');
 
-const ERR_FENNEC_MSG = 'This method is not yet supported by Fennec, consider using require("tabs") instead';
+const ERR_FENNEC_MSG = 'This method is not yet supported by Fennec, consider using require("sdk/tabs") instead';
 
 const BrowserWindow = Class({
   initialize: function initialize(options) {
@@ -41,7 +41,7 @@ const BrowserWindow = Class({
   get isPrivateBrowsing() {
     deprecateUsage('`browserWindow.isPrivateBrowsing` is deprecated, please ' +
                  'consider using ' +
-                 '`require("private-browsing").isPrivate(browserWindow)` ' +
+                 '`require("sdk/private-browsing").isPrivate(browserWindow)` ' +
                  'instead.');
     return isWindowPrivate(windowNS(this).window);
   }

--- a/lib/sdk/windows/dom.js
+++ b/lib/sdk/windows/dom.js
@@ -29,7 +29,7 @@ const WindowDom = Trait.compose({
   get isPrivateBrowsing() {
     deprecateUsage('`browserWindow.isPrivateBrowsing` is deprecated, please ' +
                    'consider using ' +
-                   '`require("private-browsing").isPrivate(browserWindow)` ' +
+                   '`require("sdk/private-browsing").isPrivate(browserWindow)` ' +
                    'instead.');
     return isWindowPrivate(this._window);
   }

--- a/lib/sdk/windows/fennec.js
+++ b/lib/sdk/windows/fennec.js
@@ -13,7 +13,7 @@ const { method } = require('../lang/functional');
 const { EventTarget } = require('../event/target');
 const { List, addListItem } = require('../util/list');
 
-const ERR_FENNEC_MSG = 'This method is not yet supported by Fennec, consider using require("tabs") instead';
+const ERR_FENNEC_MSG = 'This method is not yet supported by Fennec, consider using require("sdk/tabs") instead';
 
 // NOTE: On Fennec there is only one window.
 

--- a/python-lib/cuddlefish/tests/addons/simplest-test/main.js
+++ b/python-lib/cuddlefish/tests/addons/simplest-test/main.js
@@ -6,10 +6,10 @@ const { Cc, Ci } = require("chrome");
 
 exports.main = function(options, callbacks) {
   // Close Firefox window. Firefox should quit.
-  require("api-utils/window-utils").activeBrowserWindow.close();
+  require("sdk/deprecated/window-utils").activeBrowserWindow.close();
 
   // But not on Mac where it stay alive! We have to request application quit.
-  if (require("api-utils/runtime").OS == "Darwin") {
+  if (require("sdk/system/runtime").OS == "Darwin") {
     let appStartup = Cc['@mozilla.org/toolkit/app-startup;1'].
                      getService(Ci.nsIAppStartup);
     appStartup.quit(appStartup.eAttemptQuit);

--- a/python-lib/cuddlefish/tests/linker-files/one/lib/main.js
+++ b/python-lib/cuddlefish/tests/linker-files/one/lib/main.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var panel = require("panel");
+var panel = require("sdk/panel");
 var two = require("two.js");
 var a = require("./two");
 var b = require("sdk/tabs.js");

--- a/python-lib/cuddlefish/tests/linker-files/seven/lib/main.js
+++ b/python-lib/cuddlefish/tests/linker-files/seven/lib/main.js
@@ -2,5 +2,5 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var self = require("self"); // trigger inclusion of data
+var self = require("sdk/self"); // trigger inclusion of data
 exports.main = function () { console.log("main"); };

--- a/python-lib/cuddlefish/tests/linker-files/three-deps/three-a/lib/main.js
+++ b/python-lib/cuddlefish/tests/linker-files/three-deps/three-a/lib/main.js
@@ -4,5 +4,5 @@
 
 exports.main = 42;
 require("./subdir/subfile");
-require("self"); // trigger inclusion of our data/ directory
+require("sdk/self"); // trigger inclusion of our data/ directory
 

--- a/python-lib/cuddlefish/tests/test_linker.py
+++ b/python-lib/cuddlefish/tests/test_linker.py
@@ -48,7 +48,7 @@ class Basic(unittest.TestCase):
         def assertReqIs(modname, reqname, path):
             reqs = m["one/%s" % modname]["requirements"]
             self.failUnlessEqual(reqs[reqname], path)
-        assertReqIs("main", "panel", "sdk/panel")
+        assertReqIs("main", "sdk/panel", "sdk/panel")
         assertReqIs("main", "two.js", "one/two")
         assertReqIs("main", "./two", "one/two")
         assertReqIs("main", "sdk/tabs.js", "sdk/tabs")

--- a/test/addons/content-permissions/main.js
+++ b/test/addons/content-permissions/main.js
@@ -3,9 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const xulApp = require("xul-app");
-const { PageMod } = require("page-mod");
-const tabs = require("tabs");
+const xulApp = require("sdk/xul-app");
+const { PageMod } = require("sdk/page-mod");
+const tabs = require("sdk/tabs");
 
 exports.testCrossDomainIframe = function(assert, done) {
   let serverPort = 8099;

--- a/test/addons/layout-change/package.json
+++ b/test/addons/layout-change/package.json
@@ -1,3 +1,4 @@
 {
-  "id": "test-layout-change"
+  "id": "test-layout-change",
+  "ignore-deprecated-path": true
 }

--- a/test/addons/private-browsing-supported/test-panel.js
+++ b/test/addons/private-browsing-supported/test-panel.js
@@ -7,7 +7,7 @@ const { defer } = require('sdk/core/promise');
 const BROWSER = 'chrome://browser/content/browser.xul';
 
 exports.testRequirePanel = function(assert) {
-  require('panel');
+  require('sdk/panel');
   assert.ok('the panel module should not throw an error');
 };
 

--- a/test/addons/require/package.json
+++ b/test/addons/require/package.json
@@ -1,4 +1,5 @@
 {
   "id": "test-require",
-  "packages": "packages"
+  "packages": "packages",
+  "ignore-deprecated-path": true
 }

--- a/test/windows/test-fennec-windows.js
+++ b/test/windows/test-fennec-windows.js
@@ -10,7 +10,7 @@ const WM = Cc['@mozilla.org/appshell/window-mediator;1'].
            getService(Ci.nsIWindowMediator);
 const { browserWindows } = require('sdk/windows');
 
-const ERR_MSG = 'This method is not yet supported by Fennec, consider using require("tabs") instead';
+const ERR_MSG = 'This method is not yet supported by Fennec, consider using require("sdk/tabs") instead';
 
 // TEST: browserWindows.length for Fennec
 exports.testBrowserWindowsLength = function(test) {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=841766

Still a work in progress as I haven't found how to avoid these deprecation message in `layout-change` and `require` test addons that are explicitely using old require paths to ensure that the mapping works...
