### PR TITLE
Bug 732294 - Panel constructor lacks a way to set position of panel other than "centered"

### DIFF
--- a/doc/module-source/sdk/panel.md
+++ b/doc/module-source/sdk/panel.md
@@ -421,7 +421,73 @@ Creates a panel.
     The width of the panel in pixels. Optional.
   @prop [height] {number}
     The height of the panel in pixels. Optional.
-  @prop [focus] {boolean}
+  @prop [position] {object}
+    The position of the panel.
+    Ignored if the panel is opened by a widget.
+
+    You can set as value an object that has one or more of the following
+    properites: `top`, `right`, `bottom` and `left`. Their values are expressed
+    in pixels. Any other properties will be ignored.
+
+    The default alignment is centered, so for example panel can be displayed in
+    the center of the bottom corner by leaving off vertical axis:
+
+        // Show the panel to the centered horizontally and aligned to the bottom
+        // of the content area
+        require("sdk/panel").Panel({
+          position: {
+           bottom: 0
+          }
+        }).show();
+
+        // Show the panel to the centered vertically and aligned to the left o
+        // the content area
+        require("sdk/panel").Panel({
+          position: {
+            left: 0
+          }
+        }).show();
+
+        // Centered panel, default behavior
+        require("sdk/panel").Panel({}).show();
+
+    In the same way of their CSS counterpart, setting both `top` and `bottom`,
+    or `left` and `right`, will results in calculated the `height` and `width`:
+
+        // Show the panel centered horizontally, that is distant 40px
+        // from the top and 100px from the bottom.
+        require("sdk/panel").Panel({
+          position: {
+            top: 40,
+            bottom: 100
+          }
+        }).show();
+
+    Set implicitly `height` in this example, will makes the panel ignore the
+    `bottom` property, as the CSS homonym properties does:
+
+        // Show the panel centered horizontally, that is distant 40px from the top
+        // and has 400px as height
+        require("sdk/panel").Panel({
+          position: {
+            top: 40,
+            bottom: 100,
+          },
+          height: 400
+        }).show();
+
+        // This is equivalent to:
+
+        require("panel").Panel({
+          position {
+            top: 40
+          },
+          height: 400
+        }).show();
+
+    The same principle is applied for `width`, `left` and `right`.
+
+  @prop [focus=true] {boolean}
     Set to `false` to prevent taking the focus away when the panel is shown.
     Only turn this off if necessary, to prevent accessibility issue.
     Optional, default to `true`.
@@ -575,6 +641,22 @@ The message to send.  Must be stringifiable to JSON.
 <api name="show">
 @method
 Displays the panel.
+
+If the `options` argument is given, it will be shallow merged with the options
+provided in the constructor: the `options` passed in the `show` method takes
+the precedence.
+It's useful for temporary changes, without touching the default values.
+
+@param options {object}
+  Showing options for the panel, with the following keys:
+  @prop [width] {number}
+    The width of the panel in pixels. Optional.
+  @prop [height] {number}
+    The height of the panel in pixels. Optional.
+  @prop [position] {object}
+    The position of the panel. Optional. See [Panel's options](./modules/sdk/panel.html#Panel%28options%29) for further details.
+  @prop [focus=true] {boolean}
+    Set to `false` to prevent taking the focus away when the panel is shown.
 </api>
 
 <api name="hide">

--- a/lib/sdk/lang/type.js
+++ b/lib/sdk/lang/type.js
@@ -32,6 +32,21 @@ function isNull(value) {
 exports.isNull = isNull;
 
 /**
+ * Returns `true` if value is `null` or `undefined`.
+ * It's equivalent to `== null`, but resolve the ambiguity of the writer
+ * intention, makes clear that he's clearly checking both `null` and `undefined`
+ * values, and it's not a typo for `=== null`.
+ */
+function isNil(value) {
+  return value === null || value === undefined;
+}
+exports.isNil = isNil;
+
+function isBoolean(value) {
+  return typeof value === "boolean";
+}
+exports.isBoolean = isBoolean;
+/**
  * Returns `true` if value is a string.
  * @examples
  *    isString("moe"); // true

--- a/lib/sdk/view/core.js
+++ b/lib/sdk/view/core.js
@@ -24,3 +24,6 @@ getNodeView.define(function(value) {
 });
 
 exports.getNodeView = getNodeView;
+
+let getActiveView = method("getActiveView");
+exports.getActiveView = getActiveView;

--- a/lib/sdk/widget.js
+++ b/lib/sdk/widget.js
@@ -435,7 +435,7 @@ const WidgetViewTrait = LightTrait.compose(EventEmitterTrait, LightTrait({
       // This kind of ugly workaround, instead we should implement
       // `getNodeView` for the `Widget` class itself, but that's kind of
       // hard without cleaning things up.
-      this.panel.show(getNodeView.implement({}, function() domNode));
+      this.panel.show(null, getNodeView.implement({}, function() domNode));
   },
 
   _isInWindow: function WidgetView__isInWindow(window) {

--- a/lib/sdk/window/utils.js
+++ b/lib/sdk/window/utils.js
@@ -341,6 +341,12 @@ function getFrames(window) {
 }
 exports.getFrames = getFrames;
 
+function getScreenPixelsPerCSSPixel(window) {
+  return window.QueryInterface(Ci.nsIInterfaceRequestor).
+                getInterface(Ci.nsIDOMWindowUtils).screenPixelsPerCSSPixel;
+}
+exports.getScreenPixelsPerCSSPixel = getScreenPixelsPerCSSPixel;
+
 function getOwnerBrowserWindow(node) {
   /**
   Takes DOM node and returns browser window that contains it.

--- a/test/addons/private-browsing-supported/test-global-private-browsing.js
+++ b/test/addons/private-browsing-supported/test-global-private-browsing.js
@@ -70,7 +70,7 @@ exports.testShowPanelAndWidgetOnPrivateWindow = function(assert, done) {
                 }
               });
             }
-          }).show(window.gBrowser);
+          }).show(null, window.gBrowser);
         },
         onUntrack: function(window) {
           if (window === myPrivateWindow) {

--- a/test/test-panel.js
+++ b/test/test-panel.js
@@ -318,7 +318,7 @@ exports["test Anchor And Arrow"] = function(assert, done) {
       return;
     }
     let { panel, anchor } = queue.shift();
-    panel.show(anchor);
+    panel.show(null, anchor);
   }
 
   let tabs= require("sdk/tabs");
@@ -462,6 +462,7 @@ exports["test Change Content URL"] = function(assert, done) {
     contentURL: "about:blank",
     contentScript: "self.port.emit('ready', document.location.href);"
   });
+
   let count = 0;
   panel.port.on("ready", function (location) {
     count++;
@@ -651,7 +652,7 @@ if (isWindowPBSupported) {
         showTries++;
         panel.show();
         showTries++;
-        panel.show(browserWindow.gBrowser);
+        panel.show(null, browserWindow.gBrowser);
 
         return promise;
       }).
@@ -703,9 +704,9 @@ if (isWindowPBSupported) {
           }
         });
         showTries++;
-        panel.show(window.gBrowser);
+        panel.show(null, window.gBrowser);
         showTries++;
-        panel.show(browserWindow.gBrowser);
+        panel.show(null, browserWindow.gBrowser);
 
         return promise;
       }).
@@ -753,7 +754,7 @@ exports['test Style Applied Only Once'] = function (assert, done) {
       'self.port.on("check",function() { self.port.emit("count", document.getElementsByTagName("style").length); });' +
       'self.port.on("ping", function (count) { self.port.emit("pong", count); });'
   });
-  
+
   panel.port.on('count', function (styleCount) {
     assert.equal(styleCount, 1, 'should only have one style');
     done();
@@ -836,7 +837,7 @@ else if (isGlobalPBSupported) {
         assert.ok(isPrivate(window), 'window is private');
         assert.equal(getWindow(window.gBrowser), window, 'private window elements returns window');
         assert.equal(getWindow(activeWindow.gBrowser), activeWindow, 'active window elements returns window');
-        
+
         pb.once('stop', done);
         pb.deactivate();
       })

--- a/test/test-window-utils-global-private-browsing.js
+++ b/test/test-window-utils-global-private-browsing.js
@@ -61,7 +61,7 @@ exports.testShowPanelAndWidgetOnPrivateWindow = function(assert, done) {
                 }
               });
             }
-          }).show(window.gBrowser);
+          }).show(null, window.gBrowser);
         },
         onUntrack: function(window) {
           if (window === myPrivateWindow) {


### PR DESCRIPTION
Implements the API described in [JEP Panel Positioning](https://github.com/mozilla/addon-sdk/wiki/JEP-Panel-positioning) and discussed in [etherpad](https://etherpad.mozilla.org/panel-positioning).

As result of the discussion the anchored Panel are removed from this iteration.
