### PR TITLE
Bug 678238: Only one panel should be shown at a time

### DIFF
--- a/doc/module-source/sdk/panel.md
+++ b/doc/module-source/sdk/panel.md
@@ -31,6 +31,8 @@ in preparation for the next time it is shown.
 Your add-on can receive notifications when a panel is shown or hidden by
 listening to its `show` and `hide` events.
 
+Opening a panel will close an already opened panel.
+
 <div class="warning">
 If your add-on has
 <a href="modules/sdk/private-browsing.html#Opting into private browsing">opted into private browsing</a>,

--- a/lib/sdk/panel.js
+++ b/lib/sdk/panel.js
@@ -17,6 +17,7 @@ const { validateOptions: valid } = require('./deprecated/api-utils');
 const { Symbiont } = require('./content/content');
 const { EventEmitter } = require('./deprecated/events');
 const { setTimeout } = require('./timers');
+const { on, off, emit } = require('./system/events');
 const runtime = require('./system/runtime');
 const { getDocShell } = require("./frame/utils");
 const { getWindow } = require('./panel/window');
@@ -26,7 +27,8 @@ const { isWindowPBSupported } = require('./private-browsing/utils');
 const XUL_NS = "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul",
       ON_SHOW = 'popupshown',
       ON_HIDE = 'popuphidden',
-      validNumber = { is: ['number', 'undefined', 'null'] };
+      validNumber = { is: ['number', 'undefined', 'null'] },
+      ADDON_ID = require('./self').id;
 
 if (isPrivateBrowsingSupported && isWindowPBSupported) {
   throw Error('The panel module cannot be used with per-window private browsing at the moment, see Bug 816257');
@@ -68,6 +70,9 @@ const Panel = Symbiont.resolve({
   constructor: function Panel(options) {
     this._onShow = this._onShow.bind(this);
     this._onHide = this._onHide.bind(this);
+    this._onAnyPanelShow = this._onAnyPanelShow.bind(this);
+    on('sdk-panel-show', this._onAnyPanelShow);
+
     this.on('inited', this._onSymbiontInit.bind(this));
     this.on('propertyChange', this._onChange.bind(this));
 
@@ -91,6 +96,7 @@ const Panel = Symbiont.resolve({
     this._removeAllListeners('hide');
     this._removeAllListeners('propertyChange');
     this._removeAllListeners('inited');
+    off('sdk-panel-show', this._onAnyPanelShow);
     // defer cleanup to be performed after panel gets hidden
     this._xulPanel = null;
     this._symbiontDestructor(this);
@@ -126,6 +132,7 @@ const Panel = Symbiont.resolve({
 
     let document = anchorWindow.document;
     let xulPanel = this._xulPanel;
+    let panel = this;
     if (!xulPanel) {
       xulPanel = this._xulPanel = document.createElementNS(XUL_NS, 'panel');
       xulPanel.setAttribute("type", "arrow");
@@ -210,13 +217,21 @@ const Panel = Symbiont.resolve({
     xulPanel.firstChild.style.width = width + "px";
     xulPanel.firstChild.style.height = height + "px";
 
+    // Only display xulPanel if Panel.hide() was not called
+    // after Panel.show(), but before xulPanel.openPopup
+    // was loaded
+    emit('sdk-panel-show', { data: ADDON_ID, subject: xulPanel });
+
     // Wait for the XBL binding to be constructed
     function waitForBinding() {
       if (!xulPanel.openPopup) {
         setTimeout(waitForBinding, 50);
         return;
       }
-      xulPanel.openPopup(anchor, position, x, y);
+
+      if (xulPanel.state !== 'hiding') {
+        xulPanel.openPopup(anchor, position, x, y);
+      }
     }
     waitForBinding();
 
@@ -336,6 +351,16 @@ const Panel = Symbiont.resolve({
       this._emit('error', e);
     }
   },
+
+  /**
+   * When any panel is displayed, system-wide, close `this`
+   * panel unless it's the most recently displayed panel
+   */
+  _onAnyPanelShow: function _onAnyPanelShow(e) {
+    if (e.subject !== this._xulPanel)
+      this.hide();
+  },
+
   /**
    * Notification that panel was fully initialized.
    */

--- a/test/test-panel.js
+++ b/test/test-panel.js
@@ -287,7 +287,10 @@ exports["test Anchor And Arrow"] = function(assert, done) {
   const { Panel } = require('sdk/panel');
 
   let count = 0;
-  function newPanel(tab, anchor) {
+  let queue = [];
+  let tab;
+
+  function newPanel(anchor) {
     let panel = Panel({
       contentURL: "data:text/html;charset=utf-8,<html><body style='padding: 0; margin: 0; " +
                   "background: gray; text-align: center;'>Anchor: " +
@@ -295,16 +298,22 @@ exports["test Anchor And Arrow"] = function(assert, done) {
       width: 200,
       height: 100,
       onShow: function () {
-        count++;
         panel.destroy();
-        if (count==5) {
-          assert.pass("All anchored panel test displayed");
-          tab.close(function () {
-            done();
-          });
-        }
+        next();
       }
     });
+    queue.push({ panel: panel, anchor: anchor });
+  }
+
+  function next () {
+    if (!queue.length) {
+      assert.pass("All anchored panel test displayed");
+      tab.close(function () {
+        done();
+      });
+      return;
+    }
+    let { panel, anchor } = queue.shift();
     panel.show(anchor);
   }
 
@@ -321,22 +330,22 @@ exports["test Anchor And Arrow"] = function(assert, done) {
 
   tabs.open({
     url: url,
-    onReady: function(tab) {
+    onReady: function(_tab) {
+      tab = _tab;
       let browserWindow = Cc["@mozilla.org/appshell/window-mediator;1"].
                       getService(Ci.nsIWindowMediator).
                       getMostRecentWindow("navigator:browser");
       let window = browserWindow.content;
-      newPanel(tab, window.document.getElementById('tl'));
-      newPanel(tab, window.document.getElementById('tr'));
-      newPanel(tab, window.document.getElementById('bl'));
-      newPanel(tab, window.document.getElementById('br'));
+      newPanel(window.document.getElementById('tl'));
+      newPanel(window.document.getElementById('tr'));
+      newPanel(window.document.getElementById('bl'));
+      newPanel(window.document.getElementById('br'));
       let anchor = browserWindow.document.getElementById("identity-box");
-      newPanel(tab, anchor);
+      newPanel(anchor);
+
+      next();
     }
   });
-
-
-
 };
 
 exports["test Panel Text Color"] = function(assert, done) {
@@ -684,6 +693,39 @@ exports['test Style Applied Only Once'] = function (assert, done) {
     panel.removeListener('show', init);
     panel.port.emit('ping', 10);
   }
+};
+
+exports['test Only One Panel Open Concurrently'] = function (assert, done) {
+  const loader = Loader(module);
+  const { Panel } = loader.require('sdk/panel')
+
+  let panelA = Panel({
+    contentURL: 'about:buildconfig'
+  });
+
+  let panelB = Panel({
+    contentURL: 'about:buildconfig',
+    onShow: function () {
+      // When loading two panels simulataneously, only the second
+      // should be shown, never showing the first
+      assert.equal(panelA.isShowing, false, 'First panel is hidden');
+      assert.equal(panelB.isShowing, true, 'Second panel is showing');
+      panelC.show();
+    }
+  });
+
+  let panelC = Panel({
+    contentURL: 'about:buildconfig',
+    onShow: function () {
+      assert.equal(panelA.isShowing, false, 'First panel is hidden');
+      assert.equal(panelB.isShowing, false, 'Second panel is hidden');
+      assert.equal(panelC.isShowing, true, 'Third panel is showing');
+      done();
+    }
+  });
+
+  panelA.show();
+  panelB.show();
 };
 
 try {


### PR DESCRIPTION
- Allows only one panel open at a time, across entire platform (can make it add-on specific, though)
- Side effect of fixing behaviour of immediately calling `panel.hide()` after `panel.show()` would cause the `xulPanel` to display anyway, since it occurs after the hide -- previous test in suite for this did not pass when standalone
- Added test for one panel open concurrently, as well as refactored other test that relied on multiple panels being open
