### PR TITLE
Bug 866333 Issue with port.on(event, listener) when event coincides with Object property, in which case an exception is thrown

### DIFF
--- a/lib/sdk/deprecated/events.js
+++ b/lib/sdk/deprecated/events.js
@@ -92,7 +92,7 @@ const eventEmitter =  {
    */
   _listeners: function listeners(type) {
     let events = this._events || (this._events = {});
-    return events[type] || (events[type] = []);
+    return (events.hasOwnProperty(type) && events[type]) || (events[type] = []);
   },
 
   /**


### PR DESCRIPTION
For example, if one creates a Panel object and then tries to add a listener to 'watch' event on it like so:

panel.port.on("watch", function() {});

One'll get a 'listeners.indexOf is not a function' exception at runtime. This is because in this case a value of a nonstandard Object.prototype.watch property is returned and not event listeners array as excepted.
