### PR TITLE
Fix bug 843823 - Document last-pb-context-exited event in private browsing module

### DIFF
--- a/doc/module-source/sdk/private-browsing.md
+++ b/doc/module-source/sdk/private-browsing.md
@@ -139,10 +139,11 @@ To do this with the SDK, you can listen to the system event named
 
     var events = require("sdk/system/events");
 
-    events.on("last-pb-context-exited", function (event) {
+    function listener(event) {
       console.log("last private window closed");
-      // clean up any cached private data here
-    });
+    }
+
+    events.on("last-pb-context-exited", listener);
 
 ## Working with Firefox 19 ##
 


### PR DESCRIPTION
This includes @wbamberg's commit from #876, and addresses @erikvold's review comment about the example needing a strong reference to avoid being garbage collected.
