### PR TITLE
Actually disable tests for global PB if not supported

### DIFF
--- a/test/addons/private-browsing-supported/main.js
+++ b/test/addons/private-browsing-supported/main.js
@@ -4,6 +4,8 @@
 'use strict';
 
 const { merge } = require('sdk/util/object');
+const app = require("sdk/system/xul-app");
+const { isGlobalPBSupported } = require('sdk/private-browsing/utils');
 
 merge(module.exports,
   require('./test-windows'),
@@ -12,7 +14,7 @@ merge(module.exports,
   require('./test-selection'),
   require('./test-panel'),
   require('./test-private-browsing'),
-  require('./test-global-private-browsing')
+  isGlobalPBSupported ? require('./test-global-private-browsing') : {}
 );
 
 require('sdk/test/runner').runTestsFromModule(module);

--- a/test/addons/private-browsing-supported/test-global-private-browsing.js
+++ b/test/addons/private-browsing-supported/test-global-private-browsing.js
@@ -142,12 +142,3 @@ exports.testWindowIteratorDoesNotIgnorePrivateWindows = function(assert, done) {
   });
   pb.activate();
 };
-
-if (!isGlobalPBSupported) {
-  module.exports = {
-    "test Unsupported Test": function UnsupportedTest (assert) {
-        assert.pass(
-          "Skipping global private browsing tests");
-    }
-  }
-}


### PR DESCRIPTION
(cherry picked from commit 81dbd8fd9e07e347696404a9e0e7761f5beac005) a=@erikvold

Conflicts:

```
test/addons/private-browsing-supported/main.js
```
