### PR TITLE
Bug 855086: Timeouts and empty tests aren't logged correctly.

### DIFF
--- a/lib/sdk/deprecated/unit-test.js
+++ b/lib/sdk/deprecated/unit-test.js
@@ -270,6 +270,12 @@ TestRunner.prototype = {
       this.waitUntilCallback = null;
       if (this.test.passed == 0 && this.test.failed == 0) {
         this._logTestFailed("empty test");
+        if ("testMessage" in this.console) {
+          this.console.testMessage(false, false, this.test.name, "Empty test");
+        }
+        else {
+          this.console.error("fail:", "Empty test")
+        }
         this.failed++;
         this.test.failed++;
       }
@@ -414,6 +420,12 @@ TestRunner.prototype = {
 
     function tiredOfWaiting() {
       self._logTestFailed("timed out");
+      if ("testMessage" in self.console) {
+        self.console.testMessage(false, false, self.test.name, "Timed out");
+      }
+      else {
+        self.console.error("fail:", "Timed out")
+      }
       if (self.waitUntilCallback) {
         self.waitUntilCallback(true);
         self.waitUntilCallback = null;

--- a/lib/sdk/test/runner.js
+++ b/lib/sdk/test/runner.js
@@ -26,7 +26,8 @@ function runTests(findAndRunTests) {
         stdout.write("No tests were run\n");
       exit(0);
     } else {
-      printFailedTests(tests, cfxArgs.verbose, stdout.write);
+      if (cfxArgs.verbose || cfxArgs.parseable)
+        printFailedTests(tests, stdout.write);
       exit(1);
     }
   };
@@ -50,10 +51,7 @@ function runTests(findAndRunTests) {
   }, 0);
 }
 
-function printFailedTests(tests, verbose, print) {
-  if (!verbose)
-    return;
-
+function printFailedTests(tests, print) {
   let iterationNumber = 0;
   let singleIteration = tests.testRuns.length == 1;
   let padding = singleIteration ? "" : "  ";


### PR DESCRIPTION
Properly logs a message to the console for these cases rather than leaving it up to the summary at the end. Also makes that summary display even on tinderbox.
