### PR TITLE
Bug 855354: Stop using chrome console object in content script API implementation.

### DIFF
--- a/lib/sdk/content/content-worker.js
+++ b/lib/sdk/content/content-worker.js
@@ -224,7 +224,7 @@ const ContentWorker = Object.freeze({
     });
   },
 
-  injectMessageAPI: function injectMessageAPI(exports, pipe) {
+  injectMessageAPI: function injectMessageAPI(exports, pipe, console) {
 
     let { eventEmitter: port, emit : portEmit } =
       ContentWorker.createEventEmitter(pipe.emit.bind(null, "event"));
@@ -293,7 +293,7 @@ const ContentWorker = Object.freeze({
 
     ContentWorker.injectConsole(exports, pipe);
     ContentWorker.injectTimers(exports, chromeAPI, pipe, exports.console);
-    ContentWorker.injectMessageAPI(exports, pipe);
+    ContentWorker.injectMessageAPI(exports, pipe, exports.console);
     if ( options !== undefined ) {
       ContentWorker.injectOptions(exports, options);
     }

--- a/lib/sdk/test/loader.js
+++ b/lib/sdk/test/loader.js
@@ -51,7 +51,11 @@ exports.LoaderWithHookedConsole = function (module, callback) {
         warn: hook.bind("warn"),
         error: hook.bind("error"),
         debug: hook.bind("debug"),
-        exception: hook.bind("exception")
+        exception: hook.bind("exception"),
+        __exposedProps__: {
+          log: "rw", info: "rw", warn: "rw", error: "rw", debug: "rw",
+          exception: "rw"
+        }
       }
     }),
     messages: messages


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=855354
