### PR TITLE
Bug 855484: Wait for window load before checking for private browsing status in WindowTracker.

### DIFF
--- a/lib/sdk/deprecated/window-utils.js
+++ b/lib/sdk/deprecated/window-utils.js
@@ -76,10 +76,6 @@ function WindowTracker(delegate) {
 
 WindowTracker.prototype = {
   _regLoadingWindow: function _regLoadingWindow(window) {
-    // Bug 834961: ignore private windows when they are not supported
-    if (ignoreWindow(window))
-      return;
-
     this._loadingWindows.push(window);
     window.addEventListener('load', this, true);
   },
@@ -94,18 +90,20 @@ WindowTracker.prototype = {
   },
 
   _regWindow: function _regWindow(window) {
-    // Bug 834961: ignore private windows when they are not supported
-    if (ignoreWindow(window))
-      return;
-
     if (window.document.readyState == 'complete') {
       this._unregLoadingWindow(window);
+      // Bug 834961: ignore private windows if they are not supported
+      if (ignoreWindow(window))
+        return;
       this._delegate.onTrack(window);
     } else
       this._regLoadingWindow(window);
   },
 
   _unregWindow: function _unregWindow(window) {
+    // ignore private windows if they are not supported
+    if (ignoreWindow(window))
+      return;
     if (window.document.readyState == 'complete') {
       if (this._delegate.onUntrack)
         this._delegate.onUntrack(window);
@@ -130,9 +128,6 @@ WindowTracker.prototype = {
 
   observe: errors.catchAndLog(function observe(subject, topic, data) {
     var window = subject.QueryInterface(Ci.nsIDOMWindow);
-    // ignore private windows if they are not supported
-    if (ignoreWindow(window))
-      return;
     if (topic == 'domwindowopened')
       this._regWindow(window);
     else


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=855484
