### PR TITLE
Bug 671305: Tabs fire events when loading from cache or non-DOM content

### DIFF
--- a/doc/module-source/sdk/tabs.md
+++ b/doc/module-source/sdk/tabs.md
@@ -169,6 +169,12 @@ This is an optional property.
 @prop [onReady] {function}
 A callback function that will be registered for 'ready' event.
 This is an optional property.
+@prop [onLoad] {function}
+A callback function that will be registered for 'load' event.
+This is an optional property.
+@prop [onPageShow] {function}
+A callback function that will be registered for 'pageshow' event.
+This is an optional property.
 @prop [onActivate] {function}
 A callback function that will be registered for 'activate' event.
 This is an optional property.
@@ -330,6 +336,47 @@ content can be used.
 
 @argument {Tab}
 Listeners are passed the tab object.
+</api>
+
+<api name="load">
+@event
+
+This event is emitted when the page for the tab's content is loaded. It is
+equivalent to the `load` event for the given content page.
+
+A single tab will emit this event every time the page is loaded: so it will be
+emitted again if the tab's location changes or the content is reloaded.
+
+After this event has been emitted, all properties relating to the tab's
+content can be used.
+
+This is fired after the `ready` event on DOM content pages and can be used
+for pages that do not have a `DOMContentLoaded` event, like images.
+
+@argument {Tab}
+Listeners are passed the tab object.
+</api>
+
+<api name="pageshow">
+@event
+
+This event is emitted when the page for the tab's content is potentially
+from the cache. It is equivilent to the [pageshow](https://developer.mozilla.org/en-US/docs/DOM/Mozilla_event_reference/pageshow) event for the given
+content page.
+
+After this event has been emitted, all properties relating to the tab's
+content can be used.
+
+While the `ready` and `load` events will not be fired when a user uses the back
+or forward buttons to navigate history, the `pageshow` event will be fired.
+If the `persisted` argument is true, then the contents were loaded from the
+bfcache.
+
+@argument {Tab}
+Listeners are passed the tab object.
+@argument {persisted}
+Listeners are passed a boolean value indicating whether or not the page
+was loaded from the [bfcache](https://developer.mozilla.org/en-US/docs/Working_with_BFCache) or not.
 </api>
 
 <api name="activate">

--- a/lib/sdk/tabs/common.js
+++ b/lib/sdk/tabs/common.js
@@ -20,6 +20,8 @@ function Options(options) {
     onOpen: { is: ["undefined", "function"] },
     onClose: { is: ["undefined", "function"] },
     onReady: { is: ["undefined", "function"] },
+    onLoad: { is: ["undefined", "function"] },
+    onPageShow: { is: ["undefined", "function"] },
     onActivate: { is: ["undefined", "function"] },
     onDeactivate: { is: ["undefined", "function"] }
   });

--- a/lib/sdk/tabs/events.js
+++ b/lib/sdk/tabs/events.js
@@ -12,6 +12,8 @@ const TAB_PREFIX = "Tab";
 
 const EVENTS = {
   ready: "DOMContentLoaded",
+  load: "load", // Used for non-HTML content
+  pageshow: "pageshow", // Used for cached content
   open: "TabOpen",
   close: "TabClose",
   activate: "TabSelect",

--- a/lib/sdk/windows/tabs-firefox.js
+++ b/lib/sdk/windows/tabs-firefox.js
@@ -52,6 +52,8 @@ const WindowTabTracker = Trait.compose({
 
     // Binding all methods used as event listeners to the instance.
     this._onTabReady = this._emitEvent.bind(this, "ready");
+    this._onTabLoad = this._emitEvent.bind(this, "load");
+    this._onTabPageShow = this._emitEvent.bind(this, "pageshow");
     this._onTabOpen = this._onTabEvent.bind(this, "open");
     this._onTabClose = this._onTabEvent.bind(this, "close");
     this._onTabActivate = this._onTabEvent.bind(this, "activate");
@@ -109,17 +111,23 @@ const WindowTabTracker = Trait.compose({
         return;
 
       // Setting up an event listener for ready events.
-      if (type === "open")
+      if (type === "open") {
         wrappedTab.on("ready", this._onTabReady);
+        wrappedTab.on("load", this._onTabLoad);
+        wrappedTab.on("pageshow", this._onTabPageShow);
+      }
 
       this._emitEvent(type, wrappedTab);
     }
   },
-  _emitEvent: function _emitEvent(type, tab) {
+  _emitEvent: function _emitEvent(type, tag) {
+    // Slices additional arguments and passes them into exposed
+    // listener like other events (for pageshow)
+    let args = Array.slice(arguments);
     // Notifies combined tab list that tab was added / removed.
-    tabs._emit(type, tab);
+    tabs._emit.apply(tabs, args);
     // Notifies contained tab list that window was added / removed.
-    this._tabs._emit(type, tab);
+    this._tabs._emit.apply(this._tabs, args);
   }
 });
 exports.WindowTabTracker = WindowTabTracker;

--- a/test/tabs/test-firefox-tabs.js
+++ b/test/tabs/test-firefox-tabs.js
@@ -8,6 +8,11 @@ const { Loader } = require('sdk/test/loader');
 const timer = require('sdk/timers');
 const { StringBundle } = require('sdk/deprecated/app-strings');
 
+const base64png = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYA" +
+                  "AABzenr0AAAASUlEQVRYhe3O0QkAIAwD0eyqe3Q993AQ3cBSUKpygfsNTy" +
+                  "N5ugbQpK0BAADgP0BRDWXWlwEAAAAAgPsA3rzDaAAAAHgPcGrpgAnzQ2FG" +
+                  "bWRR9AAAAABJRU5ErkJggg%3D%3D";
+
 // TEST: tabs.activeTab getter
 exports.testActiveTab_getter = function(test) {
   test.waitUntilDone();
@@ -178,10 +183,26 @@ exports.testTabProperties = function(test) {
         test.assertEqual(tab.index, 1, "index of the new tab matches");
         test.assertNotEqual(tab.getThumbnail(), null, "thumbnail of the new tab matches");
         test.assertNotEqual(tab.id, null, "a tab object always has an id property.");
-        closeBrowserWindow(window, function() test.done());
+        onReadyOrLoad(window);
+      },
+      onLoad: function(tab) {
+        test.assertEqual(tab.title, "foo", "title of the new tab matches");
+        test.assertEqual(tab.url, url, "URL of the new tab matches");
+        test.assert(tab.favicon, "favicon of the new tab is not empty");
+        test.assertEqual(tab.style, null, "style of the new tab matches");
+        test.assertEqual(tab.index, 1, "index of the new tab matches");
+        test.assertNotEqual(tab.getThumbnail(), null, "thumbnail of the new tab matches");
+        test.assertNotEqual(tab.id, null, "a tab object always has an id property.");
+        onReadyOrLoad(window);
       }
     });
   });
+
+  let count = 0;
+  function onReadyOrLoad (window) {
+    if (count++)
+      closeBrowserWindow(window, function() test.done());
+  }
 };
 
 // TEST: tab properties
@@ -960,6 +981,101 @@ exports['test unique tab ids'] = function(test) {
   // run!
   next(0);
 }
+
+// related to Bug 671305
+exports.testOnLoadEventWithDOM = function(test) {
+  test.waitUntilDone();
+
+  openBrowserWindow(function(window, browser) {
+    let tabs = require('sdk/tabs');
+    let count = 0;
+    tabs.on('load', function onLoad(tab) {
+      test.assertEqual(tab.title, 'tab', 'tab passed in as arg, load called');
+      if (!count++) {
+        tab.reload();
+      }
+      else {
+        // end of test
+        tabs.removeListener('load', onLoad);
+        test.pass('onLoad event called on reload');
+        closeBrowserWindow(window, function() test.done());
+      }
+    });
+
+    // open a about: url
+    tabs.open({
+      url: 'data:text/html;charset=utf-8,<title>tab</title>',
+      inBackground: true
+    });
+  });
+};
+
+// related to Bug 671305
+exports.testOnLoadEventWithImage = function(test) {
+  test.waitUntilDone();
+
+  openBrowserWindow(function(window, browser) {
+    let tabs = require('sdk/tabs');
+    let count = 0;
+    tabs.on('load', function onLoad(tab) {
+      if (!count++) {
+        tab.reload();
+      }
+      else {
+        // end of test
+        tabs.removeListener('load', onLoad);
+        test.pass('onLoad event called on reload with image');
+        closeBrowserWindow(window, function() test.done());
+      }
+    });
+
+    // open a image url
+    tabs.open({
+      url: base64png,
+      inBackground: true
+    });
+  });
+};
+
+exports.testOnPageShowEvent = function (test) {
+  test.waitUntilDone();
+
+  let firstUrl = 'about:home';
+  let secondUrl = 'about:newtab';
+  
+  openBrowserWindow(function(window, browser) {
+    let tabs = require('sdk/tabs');
+
+    tabs.on('pageshow', function onPageShow(tab, persisted) {
+      if (!persisted) return;
+      tabs.removeListener('pageshow', onPageShow);
+      test.pass('pageshow event called on history.back()');
+      closeBrowserWindow(window, function() test.done());
+    });
+
+    tabs.on('load', function onReady(tab) {
+      if (tab.url === firstUrl) {
+        // This is ugly, even using the load event,
+        // the page may not be cached by then to go to a URL
+        // to ensure that going "back" will access it page
+        // from the bfcache
+        timer.setTimeout(function() {
+          tab.url = secondUrl;
+        }, 1000);
+      }
+      else {
+        tabs.removeListener('load', onReady);
+        tab.attach({
+          contentScript: 'setTimeout(function () { window.history.back(); }, 0)'
+        });
+      }
+    });
+
+    tabs.open({
+      url: firstUrl
+    });
+  });
+};
 
 /******************* helpers *********************/
 


### PR DESCRIPTION
- Add `pageshow` and `load` events for bfcache loading and loading non-DOM content specifically
- Also `onPageShow` and `onLoad` constructor options
