### PR TITLE
Fix bug 856403 - Upstream the indexed-db changes from 854323 to the SDK repo

### DIFF
--- a/lib/sdk/indexed-db.js
+++ b/lib/sdk/indexed-db.js
@@ -58,7 +58,6 @@ exports.IDBTransaction = Ci.nsIIDBTransaction;
 exports.IDBOpenDBRequest = Ci.nsIIDBOpenDBRequest;
 exports.IDBVersionChangeEvent = Ci.nsIIDBVersionChangeEvent;
 exports.IDBDatabase = Ci.nsIIDBDatabase;
-exports.IDBFactory = Ci.nsIIDBFactory;
 exports.IDBIndex = Ci.nsIIDBIndex;
 exports.IDBObjectStore = Ci.nsIIDBObjectStore;
 exports.IDBRequest = Ci.nsIIDBRequest;

--- a/test/test-indexed-db.js
+++ b/test/test-indexed-db.js
@@ -9,8 +9,8 @@ if (xulApp.versionInRange(xulApp.platformVersion, "16.0a1", "*")) {
 new function tests() {
 
 const { indexedDB, IDBKeyRange, DOMException, IDBCursor, IDBTransaction,
-        IDBOpenDBRequest, IDBVersionChangeEvent, IDBDatabase, IDBFactory,
-        IDBIndex, IDBObjectStore, IDBRequest
+        IDBOpenDBRequest, IDBVersionChangeEvent, IDBDatabase, IDBIndex, 
+        IDBObjectStore, IDBRequest
       } = require("sdk/indexed-db");
 
 exports["test indexedDB is frozen"] = function(assert){
@@ -25,7 +25,7 @@ exports["test indexedDB is frozen"] = function(assert){
 exports["test db variables"] = function(assert) {
   [ indexedDB, IDBKeyRange, DOMException, IDBCursor, IDBTransaction,
     IDBOpenDBRequest, IDBOpenDBRequest, IDBVersionChangeEvent,
-    IDBDatabase, IDBFactory, IDBIndex, IDBObjectStore, IDBRequest
+    IDBDatabase, IDBIndex, IDBObjectStore, IDBRequest
   ].forEach(function(value) {
     assert.notEqual(typeof(value), "undefined", "variable is defined");
   });


### PR DESCRIPTION
Bug 854323 removed part of indexed-db tree-wide in mozilla-central, including parts of the addon-sdk. We need to get those changes into the SDK tree to fix our tests.
