### PR TITLE
Bug 857750 - TEST-UNEXPECTED-FAIL | tests/test-self.testSelf | self.loadReason is always `startup` on test runs ("install" != "startup")

### DIFF
--- a/test/test-self.js
+++ b/test/test-self.js
@@ -6,6 +6,7 @@
 
 const {Cc, Ci, Cu, Cm, components} = require('chrome');
 Cu.import("resource://gre/modules/AddonManager.jsm", this);
+const xulApp = require("sdk/system/xul-app");
 
 exports.testSelf = function(test) {
   var self = require("sdk/self");
@@ -30,8 +31,12 @@ exports.testSelf = function(test) {
   test.assert(self.name == "addon-sdk", "self.name is addon-sdk");
 
   // loadReason may change here, as we change the way tests addons are installed
-  test.assertEqual(self.loadReason, "startup",
-                   "self.loadReason is always `startup` on test runs");
+  // Bug 854937 fixed loadReason and is now install
+  let testLoadReason = xulApp.versionInRange(xulApp.platformVersion,
+                                             "22.0a1", "*") ? "install"
+                                                            : "startup";
+  test.assertEqual(self.loadReason, testLoadReason,
+                   "self.loadReason is either startup or install on test runs");
 
   test.assertEqual(self.isPrivateBrowsingSupported, false,
                    'usePrivateBrowsing property is false by default');


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=857750
