### PR TITLE
Bug 856913, fix match pattern wildcard to not match invalid domains

### DIFF
--- a/lib/sdk/page-mod/match-pattern.js
+++ b/lib/sdk/page-mod/match-pattern.js
@@ -96,8 +96,15 @@ MatchPattern.prototype = {
       return true;
     if (this.exactURL && this.exactURL == urlStr)
       return true;
+
+    // Tests the urlStr against domain and check if
+    // wildcard submitted (*.domain.com), it only allows
+    // subdomains (sub.domain.com) or from the root (http://domain.com)
+    // and reject non-matching domains (otherdomain.com)
+    // bug 856913
     if (this.domain && url.host &&
-        url.host.slice(-this.domain.length) == this.domain)
+         (url.host === this.domain ||
+          url.host.slice(-this.domain.length - 1) === "." + this.domain))
       return true;
     if (this.urlPrefix && 0 == urlStr.indexOf(this.urlPrefix))
       return true;

--- a/test/test-match-pattern.js
+++ b/test/test-match-pattern.js
@@ -33,6 +33,8 @@ exports.testMatchPatternTestTrue = function(test) {
 
   ok(/.*zilla.*/, "https://bugzilla.redhat.com/show_bug.cgi?id=569753");
   ok(/https:.*zilla.*/, "https://bugzilla.redhat.com/show_bug.cgi?id=569753");
+  ok('*.sample.com', 'http://ex.sample.com/foo.html');
+  ok('*.amp.le.com', 'http://ex.amp.le.com');
 };
 
 exports.testMatchPatternTestFalse = function(test) {
@@ -70,6 +72,14 @@ exports.testMatchPatternTestFalse = function(test) {
   ok(/.*zilla/, "https://bugzilla.redhat.com/show_bug.cgi?id=569753");
   ok(/.*Zilla.*/, "https://bugzilla.redhat.com/show_bug.cgi?id=655464"); // bug 655464
   ok(/https:.*zilla/, "https://bugzilla.redhat.com/show_bug.cgi?id=569753");
+
+  // bug 856913
+  ok('*.ign.com', 'http://www.design.com');
+  ok('*.ign.com', 'http://design.com');
+  ok('*.zilla.com', 'http://bugzilla.mozilla.com');
+  ok('*.zilla.com', 'http://mo-zilla.com');
+  ok('*.amp.le.com', 'http://amp-le.com');
+  ok('*.amp.le.com', 'http://examp.le.com');
 };
 
 exports.testMatchPatternErrors = function(test) {


### PR DESCRIPTION
Fixes instances when the following URLs were valid for the match patterns

```
  ok('*.ign.com', 'http://www.design.com');
  ok('*.ign.com', 'http://design.com');
  ok('*.zilla.com', 'http://bugzilla.mozilla.com');
  ok('*.zilla.com', 'http://mo-zilla.com');
```
