### PR TITLE
Bug 858248: Give testWaitUntilTimeoutInCallback longer to complete.

### DIFF
--- a/test/test-unit-test.js
+++ b/test/test-unit-test.js
@@ -114,7 +114,7 @@ exports.testWaitUntilErrorInCallback = function(test) {
 }
 
 exports.testWaitUntilTimeoutInCallback = function(test) {
-  test.waitUntilDone(1000);
+  test.waitUntilDone();
 
   let expected = [];
   let message = 0;


### PR DESCRIPTION
Right now it has to complete within 1 second. This switches to the default which is 5 minutes.
