### PR TITLE
Bug 816257 - Detraitify panel implementation.

### DIFF
--- a/lib/sdk/content/loader.js
+++ b/lib/sdk/content/loader.js
@@ -14,18 +14,22 @@ const { EventEmitter } = require('../deprecated/events');
 const { validateOptions } = require('../deprecated/api-utils');
 const { URL } = require('../url');
 const file = require('../io/file');
+const { contract } = require('../util/contract');
 
 const LOCAL_URI_SCHEMES = ['resource', 'data'];
 
 // Returns `null` if `value` is `null` or `undefined`, otherwise `value`.
-function ensureNull(value) {
-  return value == null ? null : value;
-}
+function ensureNull(value) value == null ? null : value
 
 // map of property validations
 const valid = {
   contentURL: {
+    is: ['undefined', 'null', 'string'],
+    map: ensureNull,
     ok: function (value) {
+      if (value === null)
+        return true;
+
       try {
         URL(value);
       }
@@ -202,3 +206,5 @@ const Loader = EventEmitter.compose({
   _contentScript: null
 });
 exports.Loader = Loader;
+
+exports.contract = contract(valid);

--- a/lib/sdk/content/worker.js
+++ b/lib/sdk/content/worker.js
@@ -463,48 +463,55 @@ const Worker = EventEmitter.compose({
   constructor: function Worker(options) {
     options = options || {};
 
-    if ('window' in options)
-      this._window = options.window;
     if ('contentScriptFile' in options)
       this.contentScriptFile = options.contentScriptFile;
     if ('contentScriptOptions' in options)
       this.contentScriptOptions = options.contentScriptOptions;
     if ('contentScript' in options)
       this.contentScript = options.contentScript;
-    if ('onError' in options)
-      this.on('error', options.onError);
-    if ('onMessage' in options)
-      this.on('message', options.onMessage);
-    if ('onDetach' in options)
-      this.on('detach', options.onDetach);
+
+    this._setListeners(options);
 
     // Internal feature that is only used by SDK unit tests.
     // See `PRIVATE_KEY` definition for more information.
     if ('exposeUnlockKey' in options && options.exposeUnlockKey === PRIVATE_KEY)
       this._expose_key = true;
 
+    unload.ensure(this._public, "destroy");
+
+    // Ensure that worker._port is initialized for contentWorker to be able
+    // to send events during worker initialization.
+    this.port;
+
+    this._documentUnload = this._documentUnload.bind(this);
+    this._pageShow = this._pageShow.bind(this);
+    this._pageHide = this._pageHide.bind(this);
+
+    if ("window" in options) this._attach(options.window);
+  },
+
+  _setListeners: function(options) {
+    if ('onError' in options)
+      this.on('error', options.onError);
+    if ('onMessage' in options)
+      this.on('message', options.onMessage);
+    if ('onDetach' in options)
+      this.on('detach', options.onDetach);
+  },
+
+  _attach: function(window) {
+    this._window = window;
     // Track document unload to destroy this worker.
     // We can't watch for unload event on page's window object as it
     // prevents bfcache from working:
     // https://developer.mozilla.org/En/Working_with_BFCache
     this._windowID = getInnerId(this._window);
-    observers.add("inner-window-destroyed",
-                  this._documentUnload = this._documentUnload.bind(this));
+    observers.add("inner-window-destroyed", this._documentUnload);
 
     // Listen to pagehide event in order to freeze the content script
     // while the document is frozen in bfcache:
-    this._window.addEventListener("pageshow",
-                                  this._pageShow = this._pageShow.bind(this),
-                                  true);
-    this._window.addEventListener("pagehide",
-                                  this._pageHide = this._pageHide.bind(this),
-                                  true);
-
-    unload.ensure(this._public, "destroy");
-
-    // Ensure that worker._port is initialized for contentWorker to be able
-    // to send use event during WorkerSandbox(this)
-    this.port;
+    this._window.addEventListener("pageshow", this._pageShow, true);
+    this._window.addEventListener("pagehide", this._pageHide, true);
 
     // will set this._contentWorker pointing to the private API:
     this._contentWorker = WorkerSandbox(this);

--- a/lib/sdk/core/disposable.js
+++ b/lib/sdk/core/disposable.js
@@ -13,33 +13,49 @@ let { Class } = require("./heritage");
 let { on, off } = require('../system/events');
 let unloadSubject = require('@loader/unload');
 
-function DisposeHandler(disposable) {
-  return function onDisposal({subject}) {
-    if (subject.wrappedJSObject === unloadSubject) {
-      off("sdk:loader:destroy", onDisposal);
-      disposable.destroy();
+let disposables = WeakMap();
+
+function initialize(instance) {
+  // Create an event handler that will dispose instance on unload.
+  function handler(event) {
+    if (event.subject.wrappedJSObject === unloadSubject) {
+      dispose(instance);
+      instance.dispose();
     }
   }
+
+  // Form weak reference between disposable instance and an unload event
+  // handler associated with it. This will make sure that event handler can't
+  // be garbage collected as long as instance is referenced. Also note that
+  // system events intentionally hold weak reference to an event handler, this
+  // will let GC claim both instance and an unload handler before actual add-on
+  // unload if instance contains no other references.
+  disposables.set(instance, handler);
+  on("sdk:loader:destroy", handler);
 }
+exports.initialize = initialize;
+
+function dispose(instance) {
+  // Disposes given instance by removing it from weak map so that handler can
+  // be GC-ed even if references to instance are kept. Also unregister unload
+  // handler.
+
+  let handler = disposables.get(instance);
+  if (handler) off("sdk:loader:destroy", handler);
+  disposables.delete(instance);
+}
+exports.dispose = dispose;
 
 // Base type that takes care of disposing it's instances on add-on unload.
 // Also makes sure to remove unload listener if it's already being disposed.
 let Disposable = Class({
-  initialize: function dispose() {
-    this.setupDisposal();
+  initialize: function setupDisposable() {
+    // First setup instance before initializing it's disposal. If instance
+    // fails to initialize then there is no instance to be disposed at the
+    // unload.
     this.setup.apply(this, arguments);
+    initialize(this);
   },
-  setupDisposal: function setupDisposal() {
-    // Create `onDisposal` handler that will be invoked on unload of
-    // the add-on, unless this is destroyed earlier.
-    Object.defineProperty(this, "onDisposal", { value: DisposeHandler(this) });
-    on("sdk:loader:destroy", this.onDisposal);
-  },
-  teardownDisposable: function tearDisposal() {
-    // Removes `onDisposal` handler so that it won't be invoked on unload.
-    off("sdk:loader:destroy", this.onDisposal);
-  },
-
   setup: function setup() {
     // Implement your initialize logic here.
   },
@@ -50,9 +66,8 @@ let Disposable = Class({
   destroy: function destroy() {
     // Destroying disposable removes unload handler so that attempt to dispose
     // won't be made at unload & delegates to dispose.
-    this.teardownDisposable();
+    dispose(this);
     this.dispose();
   }
 });
-
 exports.Disposable = Disposable;

--- a/lib/sdk/event/core.js
+++ b/lib/sdk/event/core.js
@@ -17,6 +17,8 @@ const { ns } = require('../core/namespace');
 
 const event = ns();
 
+const EVENT_TYPE_PATTERN = /^on([A-Z]\w+$)/;
+
 // Utility function to access given event `target` object's event listeners for
 // the specific event `type`. If listeners for this type does not exists they
 // will be created.
@@ -158,3 +160,26 @@ function count(target, type) {
   return observers(target, type).length;
 }
 exports.count = count;
+
+/**
+ * Registers listeners on the given event `target` from the given `listeners`
+ * dictionary. Iterates over the listeners and if property name matches name
+ * pattern `onEventType` and property is a function, then registers it as
+ * an `eventType` listener on `target`.
+ *
+ * @param {Object} target
+ *    The type of event.
+ * @param {Object} listeners
+ *    Dictionary of listeners.
+ */
+function setListeners(target, listeners) {
+  Object.keys(listeners || {}).forEach(function onEach(key) {
+    let match = EVENT_TYPE_PATTERN.exec(key);
+    let type = match && match[1].toLowerCase();
+    let listener = listeners[key];
+
+    if (type && typeof(listener) === 'function')
+      on(target, type, listener);
+  });
+}
+exports.setListeners = setListeners;

--- a/lib/sdk/event/target.js
+++ b/lib/sdk/event/target.js
@@ -10,11 +10,9 @@ module.metadata = {
   "stability": "stable"
 };
 
-const { on, once, off } = require('./core');
+const { on, once, off, setListeners } = require('./core');
 const { method } = require('../lang/functional');
 const { Class } = require('../core/heritage');
-
-const EVENT_TYPE_PATTERN = /^on([A-Z]\w+$)/;
 
 /**
  * `EventTarget` is an exemplar for creating an objects that can be used to
@@ -27,18 +25,13 @@ const EventTarget = Class({
    * given `options` and registers listeners for the ones that look like an
    * event listeners.
    */
+  /**
+   * Method initializes `this` event source. It goes through properties of a
+   * given `options` and registers listeners for the ones that look like an
+   * event listeners.
+   */
   initialize: function initialize(options) {
-    options = options || {};
-    // Go through each property and registers event listeners for those
-    // that have a name matching following pattern (`onEventType`).
-    Object.keys(options).forEach(function onEach(key) {
-      let match = EVENT_TYPE_PATTERN.exec(key);
-      let type = match && match[1].toLowerCase();
-      let listener = options[key];
-
-      if (type && typeof(listener) === 'function')
-        this.on(type, listener);
-    }, this);
+    setListeners(this, options);
   },
   /**
    * Registers an event `listener` that is called every time events of

--- a/lib/sdk/event/utils.js
+++ b/lib/sdk/event/utils.js
@@ -99,3 +99,6 @@ exports.merge = merge;
 
 function expand(f, inputs) merge(map(f, inputs))
 exports.expand = expand;
+
+function pipe(from, to) on(from, "*", emit.bind(emit, to))
+exports.pipe = pipe;

--- a/lib/sdk/panel.js
+++ b/lib/sdk/panel.js
@@ -14,405 +14,238 @@ module.metadata = {
 
 const { Ci } = require("chrome");
 const { validateOptions: valid } = require('./deprecated/api-utils');
-const { Symbiont } = require('./content/content');
-const { EventEmitter } = require('./deprecated/events');
 const { setTimeout } = require('./timers');
-const { on, off, emit } = require('./system/events');
-const runtime = require('./system/runtime');
-const { getDocShell } = require("./frame/utils");
-const { getWindow } = require('./panel/window');
 const { isPrivateBrowsingSupported } = require('./self');
 const { isWindowPBSupported } = require('./private-browsing/utils');
-const { getNodeView } = require('./view/core');
+const { Class } = require("./core/heritage");
+const { merge } = require("./util/object");
+const { WorkerHost, Worker, detach, attach } = require("./worker/utils");
+const { Disposable } = require("./core/disposable");
+const { contract: loaderContract } = require("./content/loader");
+const { contract } = require("./util/contract");
+const { on, off, emit, setListeners } = require("./event/core");
+const { EventTarget } = require("./event/target");
+const domPanel = require("./panel/utils");
+const { events } = require("./panel/events");
+const systemEvents = require("./system/events");
+const { filter, pipe } = require("./event/utils");
+const { getNodeView } = require("./view/core");
 
-const XUL_NS = "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul",
-      ON_SHOW = 'popupshown',
-      ON_HIDE = 'popuphidden',
-      validNumber = { is: ['number', 'undefined', 'null'] },
-      validBoolean = { is: ['boolean', 'undefined', 'null'] },
-      ADDON_ID = require('./self').id;
-
-if (isPrivateBrowsingSupported && isWindowPBSupported) {
+if (isPrivateBrowsingSupported && isWindowPBSupported)
   throw Error('The panel module cannot be used with per-window private browsing at the moment, see Bug 816257');
+
+let isArray = Array.isArray;
+let assetsURI = require("./self").data.url();
+
+function isAddonContent({ contentURL }) {
+  return typeof(contentURL) === "string" && contentURL.indexOf(assetsURI) === 0;
 }
 
-/**
- * Emits show and hide events.
- */
-const Panel = Symbiont.resolve({
-  constructor: '_init',
-  _onInit: '_onSymbiontInit',
-  destroy: '_symbiontDestructor',
-  _documentUnload: '_workerDocumentUnload'
-}).compose({
-  _frame: Symbiont.required,
-  _init: Symbiont.required,
-  _onSymbiontInit: Symbiont.required,
-  _symbiontDestructor: Symbiont.required,
-  _emit: Symbiont.required,
-  on: Symbiont.required,
-  removeListener: Symbiont.required,
+function hasContentScript({ contentScript, contentScriptFile }) {
+  return (isArray(contentScript) ? contentScript.length > 0 :
+         !!contentScript) ||
+         (isArray(contentScriptFile) ? contentScriptFile.length > 0 :
+         !!contentScriptFile);
+}
 
-  _inited: false,
+function requiresAddonGlobal(model) {
+  return isAddonContent(model) && !hasContentScript(model);
+}
 
-  /**
-   * If set to `true` frame loaders between xul panel frame and
-   * hidden frame are swapped. If set to `false` frame loaders are
-   * set back to normal. Setting the value that was already set will
-   * have no effect.
-   */
-  set _frameLoadersSwapped(value) {
-    if (this.__frameLoadersSwapped == value) return;
-    this._frame.QueryInterface(Ci.nsIFrameLoaderOwner)
-      .swapFrameLoaders(this._viewFrame);
-    this.__frameLoadersSwapped = value;
-  },
-  __frameLoadersSwapped: false,
+function getAttachEventType(model) {
+  let when = model.contentScriptWhen;
+  return requiresAddonGlobal(model) ? "sdk-panel-content-changed" :
+         when === "start" ? "sdk-panel-content-changed" :
+         when === "end" ? "sdk-panel-document-loaded" :
+         when === "ready" ? "sdk-panel-content-loaded" :
+         null;
+}
 
-  constructor: function Panel(options) {
-    this._onShow = this._onShow.bind(this);
-    this._onHide = this._onHide.bind(this);
-    this._onAnyPanelShow = this._onAnyPanelShow.bind(this);
-    on('sdk-panel-show', this._onAnyPanelShow);
 
-    this.on('inited', this._onSymbiontInit.bind(this));
-    this.on('propertyChange', this._onChange.bind(this));
+let number = { is: ['number', 'undefined', 'null'] };
+let boolean = { is: ['boolean', 'undefined', 'null'] };
 
-    options = options || {};
-    if ('onShow' in options)
-      this.on('show', options.onShow);
-    if ('onHide' in options)
-      this.on('hide', options.onHide);
-    if ('width' in options)
-      this.width = options.width;
-    if ('height' in options)
-      this.height = options.height;
-    if ('contentURL' in options)
-      this.contentURL = options.contentURL;
-    if ('focus' in options) {
-      var value = options.focus;
-      var validatedValue = valid({ $: value }, { $: validBoolean }).$;
-      this._focus =
-        (typeof validatedValue == 'boolean') ? validatedValue : this._focus;
+let panelContract = contract(merge({
+  width: number,
+  height: number,
+  focus: boolean,
+}, loaderContract.rules));
+
+
+function isDisposed(panel) !views.has(panel);
+
+let panels = new WeakMap();
+let models = new WeakMap();
+let views = new WeakMap();
+let workers = new WeakMap();
+
+function viewFor(panel) views.get(panel)
+exports.viewFor = viewFor;
+
+function modelFor(panel) models.get(panel)
+function panelFor(view) panels.get(view)
+function workerFor(panel) workers.get(panel)
+
+// Utility function takes `panel` instance and makes sure it will be
+// automatically hidden as soon as other panel is shown.
+let setupAutoHide = new function() {
+  let refs = new WeakMap();
+
+  return function setupAutoHide(panel) {
+    // Create system event listener that reacts to any panel showing and
+    // hides given `panel` if it's not the one being shown.
+    function listener({subject}) {
+      // It could be that listener is not GC-ed in the same cycle as
+      // panel in such case we remove listener manually.
+      let view = viewFor(panel);
+      if (!view) systemEvents.off("sdk-panel-show", listener);
+      else if (subject !== view) panel.hide();
     }
 
-    this._init(options);
+    // system event listener is intentionally weak this way we'll allow GC
+    // to claim panel if it's no longer referenced by an add-on code. This also
+    // helps minimizing cleanup required on unload.
+    systemEvents.on("sdk-panel-show", listener);
+    // To make sure listener is not claimed by GC earlier than necessary we
+    // associate it with `panel` it's associated with. This way it won't be
+    // GC-ed earlier than `panel` itself.
+    refs.set(panel, listener);
+  }
+}
+
+const Panel = Class({
+  implements: [
+    // Generate accessors for the validated properties that update model on
+    // set and return values from model on get.
+    panelContract.properties(modelFor),
+    EventTarget,
+    Disposable
+  ],
+  extends: WorkerHost(workerFor),
+  setup: function setup(options) {
+    let model = merge({
+      width: 320,
+      height: 240,
+      focus: true,
+    }, panelContract(options));
+    models.set(this, model);
+
+    // Setup listeners.
+    setListeners(this, options);
+
+    // Setup view
+    let view = domPanel.make();
+    panels.set(view, this);
+    views.set(this, view);
+
+    // Load panel content.
+    domPanel.setURL(view, model.contentURL);
+
+    setupAutoHide(this);
+
+    let worker = new Worker(options);
+    workers.set(this, worker);
+
+    // pipe events from worker to a panel.
+    pipe(worker, this);
   },
-  _destructor: function _destructor() {
+  dispose: function dispose() {
     this.hide();
-    this._removeAllListeners('show');
-    this._removeAllListeners('hide');
-    this._removeAllListeners('propertyChange');
-    this._removeAllListeners('inited');
-    off('sdk-panel-show', this._onAnyPanelShow);
-    // defer cleanup to be performed after panel gets hidden
-    this._xulPanel = null;
-    this._symbiontDestructor(this);
-    this._removeAllListeners();
-  },
-  destroy: function destroy() {
-    this._destructor();
+    off(this);
+
+    detach(workerFor(this));
+
+    domPanel.dispose(viewFor(this));
+
+    // Release circular reference between view and panel instance. This
+    // way view will be GC-ed. And panel as well once all the other refs
+    // will be removed from it.
+    views.delete(this);
   },
   /* Public API: Panel.width */
-  get width() this._width,
-  set width(value)
-    this._width = valid({ $: value }, { $: validNumber }).$ || this._width,
-  _width: 320,
+  get width() modelFor(this).width,
+  set width(value) this.resize(value, this.height),
   /* Public API: Panel.height */
-  get height() this._height,
-  set height(value)
-    this._height =  valid({ $: value }, { $: validNumber }).$ || this._height,
-  _height: 240,
+  get height() modelFor(this).height,
+  set height(value) this.resize(this.width, value),
+
   /* Public API: Panel.focus */
-  get focus() this._focus,
-  _focus: true,
+  get focus() modelFor(this).focus,
+
+  get contentURL() modelFor(this).contentURL,
+  set contentURL(value) {
+    let model = modelFor(this);
+    model.contentURL = panelContract({ contentURL: value }).contentURL;
+    domPanel.setURL(viewFor(this), model.contentURL);
+  },
 
   /* Public API: Panel.isShowing */
-  get isShowing() !!this._xulPanel && this._xulPanel.state == "open",
+  get isShowing() !isDisposed(this) && domPanel.isOpen(viewFor(this)),
 
   /* Public API: Panel.show */
   show: function show(anchor) {
-    anchor = anchor ? getNodeView(anchor) : null;
-    let anchorWindow = getWindow(anchor);
+    let model = modelFor(this);
+    let view = viewFor(this);
+    let anchorView = getNodeView(anchor);
 
-    // If there is no open window, or the anchor is in a private window
-    // then we will not be able to display the panel
-    if (!anchorWindow) {
-      return;
-    }
+    if (!isDisposed(this))
+      domPanel.show(view, model.width, model.height, model.focus, anchorView);
 
-    let document = anchorWindow.document;
-    let xulPanel = this._xulPanel;
-    let panel = this;
-    if (!xulPanel) {
-      xulPanel = this._xulPanel = document.createElementNS(XUL_NS, 'panel');
-      xulPanel.setAttribute("type", "arrow");
-
-      // One anonymous node has a big padding that doesn't work well with
-      // Jetpack, as we would like to display an iframe that completely fills
-      // the panel.
-      // -> Use a XBL wrapper with inner stylesheet to remove this padding.
-      let css = ".panel-inner-arrowcontent, .panel-arrowcontent {padding: 0;}";
-      let originalXBL = "chrome://global/content/bindings/popup.xml#arrowpanel";
-      let binding =
-      '<bindings xmlns="http://www.mozilla.org/xbl">' +
-        '<binding id="id" extends="' + originalXBL + '">' +
-          '<resources>' +
-            '<stylesheet src="data:text/css;charset=utf-8,' +
-              document.defaultView.encodeURIComponent(css) + '"/>' +
-          '</resources>' +
-        '</binding>' +
-      '</bindings>';
-      xulPanel.style.MozBinding = 'url("data:text/xml;charset=utf-8,' +
-        document.defaultView.encodeURIComponent(binding) + '")';
-
-      let frame = document.createElementNS(XUL_NS, 'iframe');
-      frame.setAttribute('type', 'content');
-      frame.setAttribute('flex', '1');
-      frame.setAttribute('transparent', 'transparent');
-
-      if (runtime.OS === "Darwin") {
-        frame.style.borderRadius = "6px";
-        frame.style.padding = "1px";
-      }
-
-      // Load an empty document in order to have an immediatly loaded iframe,
-      // so swapFrameLoaders is going to work without having to wait for load.
-      frame.setAttribute("src","data:;charset=utf-8,");
-
-      xulPanel.appendChild(frame);
-      document.getElementById("mainPopupSet").appendChild(xulPanel);
-    }
-    let { width, height, focus } = this, x, y, position;
-
-    if (!anchor) {
-      // Open the popup in the middle of the window.
-      x = document.documentElement.clientWidth / 2 - width / 2;
-      y = document.documentElement.clientHeight / 2 - height / 2;
-      position = null;
-    }
-    else {
-      // Open the popup by the anchor.
-      let rect = anchor.getBoundingClientRect();
-
-      let window = anchor.ownerDocument.defaultView;
-
-      let zoom = window.mozScreenPixelsPerCSSPixel;
-      let screenX = rect.left + window.mozInnerScreenX * zoom;
-      let screenY = rect.top + window.mozInnerScreenY * zoom;
-
-      // Set up the vertical position of the popup relative to the anchor
-      // (always display the arrow on anchor center)
-      let horizontal, vertical;
-      if (screenY > window.screen.availHeight / 2 + height)
-        vertical = "top";
-      else
-        vertical = "bottom";
-
-      if (screenY > window.screen.availWidth / 2 + width)
-        horizontal = "left";
-      else
-        horizontal = "right";
-
-      let verticalInverse = vertical == "top" ? "bottom" : "top";
-      position = vertical + "center " + verticalInverse + horizontal;
-
-      // Allow panel to flip itself if the panel can't be displayed at the
-      // specified position (useful if we compute a bad position or if the
-      // user moves the window and panel remains visible)
-      xulPanel.setAttribute("flip","both");
-    }
-
-    // Resize the iframe instead of using panel.sizeTo
-    // because sizeTo doesn't work with arrow panels
-    xulPanel.firstChild.style.width = width + "px";
-    xulPanel.firstChild.style.height = height + "px";
-
-    // Only display xulPanel if Panel.hide() was not called
-    // after Panel.show(), but before xulPanel.openPopup
-    // was loaded
-    emit('sdk-panel-show', { data: ADDON_ID, subject: xulPanel });
-
-    // Prevent the panel from getting focus when showing up
-    // if focus is set to false
-    xulPanel.setAttribute("noautofocus",!focus);
-
-    // Wait for the XBL binding to be constructed
-    function waitForBinding() {
-      if (!xulPanel.openPopup) {
-        setTimeout(waitForBinding, 50);
-        return;
-      }
-
-      if (xulPanel.state !== 'hiding') {
-        xulPanel.openPopup(anchor, position, x, y);
-      }
-    }
-    waitForBinding();
-
-    return this._public;
+    return this;
   },
+
   /* Public API: Panel.hide */
   hide: function hide() {
-    // The popuphiding handler takes care of swapping back the frame loaders
-    // and removing the XUL panel from the application window, we just have to
-    // trigger it by hiding the popup.
-    // XXX Sometimes I get "TypeError: xulPanel.hidePopup is not a function"
-    // when quitting the host application while a panel is visible.  To suppress
-    // them, this now checks for "hidePopup" in xulPanel before calling it.
-    // It's not clear if there's an actual issue or the error is just normal.
-    let xulPanel = this._xulPanel;
-    if (xulPanel && "hidePopup" in xulPanel)
-      xulPanel.hidePopup();
-    return this._public;
+    // Quit immediately if panel is disposed or there is no state change.
+    domPanel.close(viewFor(this));
+
+    return this;
   },
 
   /* Public API: Panel.resize */
   resize: function resize(width, height) {
-    this.width = width;
-    this.height = height;
-    // Resize the iframe instead of using panel.sizeTo
-    // because sizeTo doesn't work with arrow panels
-    let xulPanel = this._xulPanel;
-    if (xulPanel) {
-      xulPanel.firstChild.style.width = width + "px";
-      xulPanel.firstChild.style.height = height + "px";
-    }
-  },
+    let model = modelFor(this);
+    let view = viewFor(this);
+    let change = panelContract({
+      width: width || model.width,
+      height: height || model.height
+    });
 
-  // While the panel is visible, this is the XUL <panel> we use to display it.
-  // Otherwise, it's null.
-  get _xulPanel() this.__xulPanel,
-  set _xulPanel(value) {
-    let xulPanel = this.__xulPanel;
-    if (value === xulPanel) return;
-    if (xulPanel) {
-      xulPanel.removeEventListener(ON_HIDE, this._onHide, false);
-      xulPanel.removeEventListener(ON_SHOW, this._onShow, false);
-      xulPanel.parentNode.removeChild(xulPanel);
-    }
-    if (value) {
-      value.addEventListener(ON_HIDE, this._onHide, false);
-      value.addEventListener(ON_SHOW, this._onShow, false);
-    }
-    this.__xulPanel = value;
-  },
-  __xulPanel: null,
-  get _viewFrame() this.__xulPanel.children[0],
-  /**
-   * When the XUL panel becomes hidden, we swap frame loaders back to move
-   * the content of the panel to the hidden frame & remove panel element.
-   */
-  _onHide: function _onHide() {
-    try {
-      this._frameLoadersSwapped = false;
-      this._xulPanel = null;
-      this._emit('hide');
-    } catch(e) {
-      this._emit('error', e);
-    }
-  },
+    model.width = change.width
+    model.height = change.height
 
-  /**
-   * Retrieve computed text color style in order to apply to the iframe
-   * document. As MacOS background is dark gray, we need to use skin's
-   * text color.
-   */
-  _applyStyleToDocument: function _applyStyleToDocument() {
-    if (this._defaultStyleApplied)
-      return;
-    try {
-      let win = this._xulPanel.ownerDocument.defaultView;
-      let node = win.document.getAnonymousElementByAttribute(
-        this._xulPanel, "class", "panel-arrowcontent");
-      if (!node) {
-        // Before bug 764755, anonymous content was different:
-        // TODO: Remove this when targeting FF16+
-        node = win.document.getAnonymousElementByAttribute(
-          this._xulPanel, "class", "panel-inner-arrowcontent");
-      }
-      let textColor = win.getComputedStyle(node).getPropertyValue("color");
-      let doc = this._xulPanel.firstChild.contentDocument;
-      let style = doc.createElement("style");
-      style.textContent = "body { color: " + textColor + "; }";
-      let container = doc.head ? doc.head : doc.documentElement;
+    domPanel.resize(view, model.width, model.height);
 
-      if (container.firstChild)
-        container.insertBefore(style, container.firstChild);
-      else
-        container.appendChild(style);
-      this._defaultStyleApplied = true;
-    }
-    catch(e) {
-      console.error("Unable to apply panel style");
-      console.exception(e);
-    }
-  },
-
-  /**
-   * When the XUL panel becomes shown, we swap frame loaders between panel
-   * frame and hidden frame to preserve state of the content dom.
-   */
-  _onShow: function _onShow() {
-    try {
-      if (!this._inited) { // defer if not initialized yet
-        this.on('inited', this._onShow.bind(this));
-      } else {
-        this._frameLoadersSwapped = true;
-        this._applyStyleToDocument();
-        this._emit('show');
-      }
-    } catch(e) {
-      this._emit('error', e);
-    }
-  },
-
-  /**
-   * When any panel is displayed, system-wide, close `this`
-   * panel unless it's the most recently displayed panel
-   */
-  _onAnyPanelShow: function _onAnyPanelShow(e) {
-    if (e.subject !== this._xulPanel)
-      this.hide();
-  },
-
-  /**
-   * Notification that panel was fully initialized.
-   */
-  _onInit: function _onInit() {
-    this._inited = true;
-
-    // Avoid panel document from resizing the browser window
-    // New platform capability added through bug 635673
-    let docShell = getDocShell(this._frame);
-    if (docShell && "allowWindowControl" in docShell)
-      docShell.allowWindowControl = false;
-
-    // perform all deferred tasks like initSymbiont, show, hide ...
-    // TODO: We're publicly exposing a private event here; this
-    // 'inited' event should really be made private, somehow.
-    this._emit('inited');
-  },
-
-  // Catch document unload event in order to rebind load event listener with
-  // Symbiont._initFrame if Worker._documentUnload destroyed the worker
-  _documentUnload: function(subject, topic, data) {
-    if (this._workerDocumentUnload(subject, topic, data)) {
-      this._initFrame(this._frame);
-      return true;
-    }
-    return false;
-  },
-
-  _onChange: function _onChange(e) {
-    this._frameLoadersSwapped = false;
-    if ('contentURL' in e && this._frame) {
-      // Cleanup the worker before injecting the content script in the new
-      // document
-      this._workerCleanup();
-      this._initFrame(this._frame);
-    }
+    return this;
   }
 });
-exports.Panel = function(options) Panel(options)
-exports.Panel.prototype = Panel.prototype;
+exports.Panel = Panel;
+
+// Filter panel events to only panels that are create by this module.
+let panelEvents = filter(function({target}) panelFor(target), events);
+
+// Panel events emitted after panel has being shown.
+let shows = filter(function({type}) type === "sdk-panel-shown", panelEvents);
+
+// Panel events emitted after panel became hidden.
+let hides = filter(function({type}) type === "sdk-panel-hidden", panelEvents);
+
+// Panel events emitted after content inside panel is ready. For different
+// panels ready may mean different state based on `contentScriptWhen` attribute.
+// Weather given event represents readyness is detected by `getAttachEventType`
+// helper function.
+let ready = filter(function({type, target})
+  getAttachEventType(modelFor(panelFor(target))) === type, panelEvents);
+
+// Panel events emitted after content document in the panel has changed.
+let change = filter(function({type}) type === "sdk-panel-content-changed",
+                    panelEvents);
+
+// Forward panel show / hide events to panel's own event listeners.
+on(shows, "data", function({target}) emit(panelFor(target), "show"));
+on(hides, "data", function({target}) emit(panelFor(target), "hide"));
+
+on(ready, "data", function({target}) {
+  let worker = workerFor(panelFor(target));
+  attach(worker, domPanel.getContentDocument(target).defaultView);
+});

--- a/lib/sdk/panel/events.js
+++ b/lib/sdk/panel/events.js
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+// This module basically translates system/events to a SDK standard events
+// so that `map`, `filter` and other utilities could be used with them.
+
+module.metadata = {
+  "stability": "experimental"
+};
+
+const events = require("../system/events");
+const { emit } = require("../event/core");
+
+let channel = {};
+
+function forward({ subject, type, data })
+  emit(channel, "data", { target: subject, type: type, data: data });
+
+["sdk-panel-show", "sdk-panel-hide", "sdk-panel-shown",
+ "sdk-panel-hidden", "sdk-panel-content-changed", "sdk-panel-content-loaded",
+ "sdk-panel-document-loaded"
+].forEach(function(type) events.on(type, forward));
+
+exports.events = channel;

--- a/lib/sdk/panel/utils.js
+++ b/lib/sdk/panel/utils.js
@@ -1,0 +1,322 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+module.metadata = {
+  "stability": "unstable"
+};
+
+const { Cc, Ci } = require("chrome");
+const { setTimeout } = require("../timers");
+const { platform } = require("../system");
+const { getMostRecentBrowserWindow, getOwnerBrowserWindow,
+        getHiddenWindow } = require("../window/utils");
+const { create: createFrame, swapFrameLoaders } = require("../frame/utils");
+const { window: addonWindow } = require("../addon/window");
+const events = require("../system/events");
+
+
+const XUL_NS = "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";
+
+function open(panel, width, height, anchor) {
+  // Wait for the XBL binding to be constructed
+  if (!panel.openPopup) setTimeout(open, 50, panel, width, height, anchor);
+  else display(panel, width, height, anchor);
+}
+exports.open = open;
+
+function isOpen(panel) {
+  return panel.state === "open"
+}
+exports.isOpen = isOpen;
+
+
+function close(panel) {
+  // Sometimes "TypeError: panel.hidePopup is not a function" is thrown
+  // when quitting the host application while a panel is visible.  To suppress
+  // these errors, check for "hidePopup" in panel before calling it.
+  // It's not clear if there's an issue or it's expected behavior.
+
+  return panel.hidePopup && panel.hidePopup();
+}
+exports.close = close
+
+
+function resize(panel, width, height) {
+  // Resize the iframe instead of using panel.sizeTo
+  // because sizeTo doesn't work with arrow panels
+  panel.firstChild.style.width = width + "px";
+  panel.firstChild.style.height = height + "px";
+}
+exports.resize = resize
+
+function display(panel, width, height, anchor) {
+  let document = panel.ownerDocument;
+  let x = null;
+  let y = null;
+  let position = null;
+
+  // Panel XBL has some SDK incompatible styling decisions. We shim panel
+  // instances until proper fix for Bug 859504 is shipped.
+  shimDefaultStyle(panel);
+
+  if (!anchor) {
+    // Open the popup in the middle of the window.
+    x = document.documentElement.clientWidth / 2 - width / 2;
+    y = document.documentElement.clientHeight / 2 - height / 2;
+    position = null;
+  }
+  else {
+    // Open the popup by the anchor.
+    let rect = anchor.getBoundingClientRect();
+
+    let window = anchor.ownerDocument.defaultView;
+
+    let zoom = window.mozScreenPixelsPerCSSPixel;
+    let screenX = rect.left + window.mozInnerScreenX * zoom;
+    let screenY = rect.top + window.mozInnerScreenY * zoom;
+
+    // Set up the vertical position of the popup relative to the anchor
+    // (always display the arrow on anchor center)
+    let horizontal, vertical;
+    if (screenY > window.screen.availHeight / 2 + height)
+      vertical = "top";
+    else
+      vertical = "bottom";
+
+    if (screenY > window.screen.availWidth / 2 + width)
+      horizontal = "left";
+    else
+      horizontal = "right";
+
+    let verticalInverse = vertical == "top" ? "bottom" : "top";
+    position = vertical + "center " + verticalInverse + horizontal;
+
+    // Allow panel to flip itself if the panel can't be displayed at the
+    // specified position (useful if we compute a bad position or if the
+    // user moves the window and panel remains visible)
+    panel.setAttribute("flip", "both");
+  }
+
+  // Resize the iframe instead of using panel.sizeTo
+  // because sizeTo doesn't work with arrow panels
+  panel.firstChild.style.width = width + "px";
+  panel.firstChild.style.height = height + "px";
+
+  panel.openPopup(anchor, position, x, y);
+}
+exports.display = display;
+
+// This utility function is just a workaround until Bug 859504 has shipped.
+function shimDefaultStyle(panel) {
+  let document = panel.ownerDocument;
+  // Please note that `panel` needs to be part of document in order to reach
+  // it's anonymous nodes. One of the anonymous node has a big padding which
+  // doesn't work well since panel frame needs to fill all of the panel.
+  // XBL binding is a not the best option as it's applied asynchronously, and
+  // makes injected frames behave in strange way. Also this feels a lot
+  // cheaper to do.
+  ["panel-inner-arrowcontent", "panel-arrowcontent"].forEach(function(value) {
+    let node = document.getAnonymousElementByAttribute(panel, "class", value);
+      if (node) node.style.padding = 0;
+  });
+}
+
+function show(panel, width, height, focus, anchor) {
+  // Prevent the panel from getting focus when showing up
+  // if focus is set to false
+  panel.setAttribute("noautofocus", !focus);
+
+
+  let window = anchor && getOwnerBrowserWindow(anchor);
+  let { document } = window ? window : getMostRecentBrowserWindow();
+  attach(panel, document);
+  open(panel, width, height, anchor);
+}
+exports.show = show
+
+function setupPanelFrame(frame) {
+  frame.setAttribute("flex", 1);
+  frame.setAttribute("transparent", "transparent");
+  frame.setAttribute("showcaret", true);
+  frame.setAttribute("autocompleteenabled", true);
+  if (platform === "darwin") {
+    frame.style.borderRadius = "6px";
+    frame.style.padding = "1px";
+  }
+}
+
+let EVENT_NAMES = {
+  "popupshowing": "sdk-panel-show",
+  "popuphiding": "sdk-panel-hide",
+  "popupshown": "sdk-panel-shown",
+  "popuphidden": "sdk-panel-hidden",
+  "document-element-inserted": "sdk-panel-content-changed",
+  "DOMContentLoaded": "sdk-panel-content-loaded",
+  "load": "sdk-panel-document-loaded"
+};
+
+function make(document) {
+  document = document || getMostRecentBrowserWindow().document;
+  let panel = document.createElementNS(XUL_NS, "panel");
+  panel.setAttribute("type", "arrow");
+
+  // Note that panel is a parent of `viewFrame` who's `docShell` will be
+  // configured at creation time. If `panel` and there for `viewFrame` won't
+  // have an owner document attempt to access `docShell` will throw. There
+  // for we attach panel to a document.
+  attach(panel, document);
+
+  let frameOptions =  {
+    allowJavascript: true,
+    allowPlugins: true,
+    allowAuth: true,
+    allowWindowControl: false,
+    // Need to override `nodeName` to use `iframe` as `browsers` save session
+    // history and in consequence do not dispatch "inner-window-destroyed"
+    // notifications.
+    browser: false,
+    // Note that use of this URL let's use swap frame loaders earlier
+    // than if we used default "about:blank".
+    uri: "data:text/plain;charset=utf-8,"
+  };
+
+  let backgroundFrame = createFrame(addonWindow, frameOptions);
+  setupPanelFrame(backgroundFrame);
+
+  let viewFrame = createFrame(panel, frameOptions);
+  setupPanelFrame(viewFrame);
+
+  function onDisplayChange({type}) {
+    try { swapFrameLoaders(backgroundFrame, viewFrame); }
+    catch(error) { console.exception(error); }
+    events.emit(EVENT_NAMES[type], { subject: panel });
+  }
+
+  function onContentReady({target, type}) {
+    if (target === getContentDocument(panel)) {
+      style(panel);
+      events.emit(EVENT_NAMES[type], { subject: panel });
+    }
+  }
+
+  function onContentLoad({target, type}) {
+    if (target === getContentDocument(panel))
+      events.emit(EVENT_NAMES[type], { subject: panel });
+  }
+
+  function onContentChange({subject, type}) {
+    let document = subject;
+    if (document === getContentDocument(panel) && document.defaultView)
+      events.emit(EVENT_NAMES[type], { subject: panel });
+  }
+
+  function onPanelStateChange({type}) {
+    events.emit(EVENT_NAMES[type], { subject: panel })
+  }
+
+  panel.addEventListener("popupshowing", onDisplayChange, false);
+  panel.addEventListener("popuphiding", onDisplayChange, false);
+  panel.addEventListener("popupshown", onPanelStateChange, false);
+  panel.addEventListener("popuphidden", onPanelStateChange, false);
+
+  // Panel content document can be either in panel `viewFrame` or in
+  // a `backgroundFrame` depending on panel state. Listeners are set
+  // on both to avoid setting and removing listeners on panel state changes.
+
+  panel.addEventListener("DOMContentLoaded", onContentReady, true);
+  backgroundFrame.addEventListener("DOMContentLoaded", onContentReady, true);
+
+  panel.addEventListener("load", onContentLoad, true);
+  backgroundFrame.addEventListener("load", onContentLoad, true);
+
+  events.on("document-element-inserted", onContentChange);
+
+
+  panel.backgroundFrame = backgroundFrame;
+
+  // Store event listener on the panel instance so that it won't be GC-ed
+  // while panel is alive.
+  panel.onContentChange = onContentChange;
+
+  return panel;
+}
+exports.make = make;
+
+function attach(panel, document) {
+  document = document || getMostRecentBrowserWindow().document;
+  let container = document.getElementById("mainPopupSet");
+  if (container !== panel.parentNode) {
+    detach(panel);
+    document.getElementById("mainPopupSet").appendChild(panel);
+  }
+}
+exports.attach = attach;
+
+function detach(panel) {
+  if (panel.parentNode) panel.parentNode.removeChild(panel);
+}
+exports.detach = detach;
+
+function dispose(panel) {
+  panel.backgroundFrame.parentNode.removeChild(panel.backgroundFrame);
+  panel.backgroundFrame = null;
+  events.off("document-element-inserted", panel.onContentChange);
+  panel.onContentChange = null;
+  detach(panel);
+}
+exports.dispose = dispose;
+
+function style(panel) {
+  /**
+  Injects default OS specific panel styles into content document that is loaded
+  into given panel. Optionally `document` of the browser window can be
+  given to inherit styles from it, by default it will use either panel owner
+  document or an active browser's document. It should not matter though unless
+  Firefox decides to style windows differently base on profile or mode like
+  chrome for example.
+  **/
+
+  try {
+    let document = panel.ownerDocument;
+    let contentDocument = getContentDocument(panel);
+    let window = document.defaultView;
+    let node = document.getAnonymousElementByAttribute(panel, "class",
+                                                       "panel-arrowcontent") ||
+               // Before bug 764755, anonymous content was different:
+               // TODO: Remove this when targeting FF16+
+                document.getAnonymousElementByAttribute(panel, "class",
+                                                        "panel-inner-arrowcontent");
+
+    let color = window.getComputedStyle(node).getPropertyValue("color");
+
+    let style = contentDocument.createElement("style");
+    style.id = "sdk-panel-style";
+    style.textContent = "body { color: " + color + "; }";
+
+    let container = contentDocument.head ? contentDocument.head :
+                    contentDocument.documentElement;
+
+    if (container.firstChild)
+      container.insertBefore(style, container.firstChild);
+    else
+      container.appendChild(style);
+  }
+  catch (error) {
+    console.error("Unable to apply panel style");
+    console.exception(error);
+  }
+}
+exports.style = style;
+
+function getContentFrame(panel) isOpen(panel) ? panel.firstChild :
+                                                panel.backgroundFrame
+exports.getContentFrame = getContentFrame;
+
+function getContentDocument(panel) getContentFrame(panel).contentDocument
+exports.getContentDocument = getContentDocument;
+
+function setURL(panel, url) getContentFrame(panel).setAttribute("src", url)
+exports.setURL = setURL;

--- a/lib/sdk/util/array.js
+++ b/lib/sdk/util/array.js
@@ -101,3 +101,15 @@ function fromIterator(iterator) {
   return array;
 }
 exports.fromIterator = fromIterator;
+
+
+function find(array, predicate) {
+  var index = 0;
+  var count = array.length;
+  while (index < count) {
+    var value = array[index];
+    if (predicate(value)) return value;
+    else index = index + 1;
+  }
+}
+exports.find = find;

--- a/lib/sdk/util/contract.js
+++ b/lib/sdk/util/contract.js
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+module.metadata = {
+  "stability": "unstable"
+};
+
+const { validateOptions: valid } = require("../deprecated/api-utils");
+
+// Function takes property validation rules and returns function that given
+// an `options` object will return validated / normalized options back. If
+// option(s) are invalid validator will throw exception described by rules.
+// Returned will also have contain `rules` property with a given validation
+// rules and `properties` function that can be used to generate validated
+// property getter and setters can be mixed into prototype. For more details
+// see `properties` function below.
+function contract(rules) {
+  function validator(options) {
+    return valid(options || {}, rules);
+  }
+  validator.rules = rules
+  validator.properties = function(modelFor) {
+    return properties(modelFor, rules);
+  }
+  return validator;
+}
+exports.contract = contract
+
+// Function takes `modelFor` instance state model accessor functions and
+// a property validation rules and generates object with getters and setters
+// that can be mixed into prototype. Property accessors update model for the
+// given instance. If you wish to react to property updates you can always
+// override setters to put specific logic.
+function properties(modelFor, rules) {
+  let descriptor = Object.keys(rules).reduce(function(descriptor, name) {
+    descriptor[name] = {
+      get: function() { return modelFor(this)[name] },
+      set: function(value) {
+        let change = {};
+        change[name] = value;
+        modelFor(this)[name] = valid(change, rules)[name];
+      }
+    }
+    return descriptor
+  }, {});
+  return Object.create(Object.prototype, descriptor);
+}
+exports.properties = properties

--- a/lib/sdk/window/utils.js
+++ b/lib/sdk/window/utils.js
@@ -340,3 +340,21 @@ function getFrames(window) {
   }, [])
 }
 exports.getFrames = getFrames;
+
+function getOwnerBrowserWindow(node) {
+  /**
+  Takes DOM node and returns browser window that contains it.
+  **/
+
+  let window = node.ownerDocument.defaultView.top;
+  // If anchored window is browser then it's target browser window.
+  if (isBrowser(window)) return window;
+  // Otherwise iterate over each browser window and find a one that
+  // contains browser for the anchored window document.
+  let document = window.document;
+  let browsers = windows("navigator:browser", { includePrivate: true });
+  return array.find(browsers, function isTargetBrowser(window) {
+    return !!window.gBrowser.getBrowserForDocument(document);
+  });
+}
+exports.getOwnerBrowserWindow = getOwnerBrowserWindow;

--- a/lib/sdk/worker/utils.js
+++ b/lib/sdk/worker/utils.js
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+module.metadata = {
+  "stability": "unstable"
+};
+
+// This module attempts to hide trait based nature of the worker so that
+// code depending on workers could be de-trait-ified without changing worker
+// implementation.
+
+const { Worker: WorkerTrait } = require("../content/worker");
+const { Loader } = require("../content/loader");
+const { merge } = require("../util/object");
+const { emit } = require("../event/core");
+
+const LegacyWorker = WorkerTrait.resolve({
+  _setListeners: "__setListeners",
+}).compose(Loader, {
+  _setListeners: function() {},
+  attach: function(window) this._attach(window),
+  detach: function() this._workerCleanup()
+});
+
+// Weak map that stores mapping between regular worker instances and
+// legacy trait based worker instances.
+let traits = new WeakMap();
+
+function traitFor(worker) traits.get(worker, null);
+
+function WorkerHost(workerFor) {
+  // Define worker properties that just proxy to a wrapped trait.
+  return ["postMessage", "port", "url", "tab"].reduce(function(proto, name) {
+    Object.defineProperty(proto, name, {
+      enumerable: true,
+      configurable: false,
+      get: function() traitFor(workerFor(this))[name],
+      set: function(value) traitFor(workerFor(this))[name] = value
+    });
+    return proto;
+  }, {});
+}
+exports.WorkerHost = WorkerHost;
+
+// Type representing worker instance.
+function Worker(options) {
+  let worker = Object.create(Worker.prototype);
+  let trait = new LegacyWorker(options);
+  ["pageshow", "pagehide", "detach", "message", "error"].forEach(function(key) {
+    trait.on(key, function() {
+      emit.apply(emit, [worker, key].concat(Array.slice(arguments)));
+      // Workaround lack of ability to listen on all events by emulating
+      // such ability. This will become obsolete once Bug 821065 is fixed.
+      emit.apply(emit, [worker, "*", key].concat(Array.slice(arguments)));
+    });
+  });
+  traits.set(worker, trait);
+  return worker;
+}
+exports.Worker = Worker;
+
+function detach(worker) {
+  let trait = traitFor(worker);
+  if (trait) trait.detach();
+}
+exports.detach = detach;
+
+function attach(worker, window) {
+  let trait = traitFor(worker);
+  // Cleanup the worker before injecting the content script into a new document.
+  trait.attach(window);
+}
+exports.attach = attach;

--- a/test/test-content-loader.js
+++ b/test/test-content-loader.js
@@ -11,16 +11,6 @@ exports['test:contentURL'] = function(test) {
       value, emitted = 0, changes = 0;
 
   test.assertRaises(
-    function() loader.contentURL = undefined,
-    'The `contentURL` option must be a valid URL.',
-    'Must throw an exception if `contentURL` is not URL.'
-  );
-   test.assertRaises(
-    function() loader.contentURL = null,
-    'The `contentURL` option must be a valid URL.',
-    'Must throw an exception if `contentURL` is not URL.'
-  );
-  test.assertRaises(
     function() loader.contentURL = 4,
     'The `contentURL` option must be a valid URL.',
     'Must throw an exception if `contentURL` is not URL.'

--- a/test/test-disposable.js
+++ b/test/test-disposable.js
@@ -163,4 +163,29 @@ exports["test loader unloads do not affect other loaders"] = function(assert) {
   assert.equal(disposals, 2, "2 destroy calls");
 }
 
+exports["test disposables that throw"] = function(assert) {
+  let loader = Loader(module);
+  let { Disposable } = loader.require("sdk/core/disposable");
+
+  let disposals = 0
+
+  let Foo = Class({
+    extends: Disposable,
+    setup: function setup(a, b) {
+      throw Error("Boom!")
+    },
+    dispose: function dispose() {
+      disposals = disposals + 1
+    }
+  })
+
+  assert.throws(function() {
+    let foo1 = Foo()
+  }, /Boom/, "disposable constructors may throw");
+
+  loader.unload();
+
+  assert.equal(disposals, 0, "no disposal if constructor threw");
+}
+
 require('test').run(exports);

--- a/test/test-panel.js
+++ b/test/test-panel.js
@@ -516,19 +516,10 @@ exports["test Automatic Destroy"] = function(assert) {
   assert.pass("check automatic destroy");
 };
 
-exports["test Wait For Init Then Show Then Destroy"] = makeEventOrderTest({
-  test: function(assert, done, expect, panel) {
-    expect('inited', function() { panel.show(); }).
-      then('show', function() { panel.destroy(); }).
-      then('hide', function() { done(); });
-  }
-});
-
-exports["test Show Then Wait For Init Then Destroy"] = makeEventOrderTest({
+exports["test Show Then Destroy"] = makeEventOrderTest({
   test: function(assert, done, expect, panel) {
     panel.show();
-    expect('inited').
-      then('show', function() { panel.destroy(); }).
+    expect('show', function() { panel.destroy(); }).
       then('hide', function() { done(); });
   }
 });


### PR DESCRIPTION
This change lays foundation for followup change that will add compatibility for panels in the private browsing mode.
It also lays foundation for de-tratification work by implementing adapter modules for working with symbiont & worker
traits.
## Overview
- Implement adapter `sdk/worker/utils` module, providing temporary solution
  for detraitification of APIs that depend on worker / symbiont.
- Refactor `Worker` constructor into small methods so that worker can be instantiated
  without window reference it will be attached to.
- Factor out `EventTarget`s initialize into `setListeners` utility function to avoid complexity
  involved with calling super constructor.
- Implement `pipe` utility function for piping events from one event source to other.
- Factor out parts of panel code that deal with DOM into `sdk/panel/utils` module.
- Start emitting observer notifications for panel events (if unclear why see [Bug 843235](https://bugzilla.mozilla.org/show_bug.cgi?id=843235))
- Implement `sdk/util/contract` module to simplify / sugar property validation.
