### PR TITLE
Bug 860419 - Let users choose whether addon supports private browsing.

### DIFF
--- a/lib/sdk/deprecated/window-utils.js
+++ b/lib/sdk/deprecated/window-utils.js
@@ -24,7 +24,7 @@ const appShellService = Cc['@mozilla.org/appshell/appShellService;1'].
                         getService(Ci.nsIAppShellService);
 
 // Bug 834961: ignore private windows when they are not supported
-function getWindows() windows(null, { includePrivate: isPrivateBrowsingSupported || isGlobalPBSupported });
+function getWindows() windows(null, { includePrivate: isPrivateBrowsingSupported() || isGlobalPBSupported });
 
 /**
  * An iterator for XUL windows currently in the application.

--- a/lib/sdk/panel.js
+++ b/lib/sdk/panel.js
@@ -31,9 +31,6 @@ const systemEvents = require("./system/events");
 const { filter, pipe } = require("./event/utils");
 const { getNodeView } = require("./view/core");
 
-if (isPrivateBrowsingSupported && isWindowPBSupported)
-  throw Error('The panel module cannot be used with per-window private browsing at the moment, see Bug 816257');
-
 let isArray = Array.isArray;
 let assetsURI = require("./self").data.url();
 

--- a/lib/sdk/panel/window.js
+++ b/lib/sdk/panel/window.js
@@ -11,7 +11,7 @@ const { isGlobalPBSupported } = require('../private-browsing/utils');
 function getWindow(anchor) {
   let window;
   let windows = getWindows("navigator:browser", {
-    includePrivate: isPrivateBrowsingSupported || isGlobalPBSupported
+    includePrivate: isPrivateBrowsingSupported() || isGlobalPBSupported
   });
 
   if (anchor) {

--- a/lib/sdk/private-browsing/utils.js
+++ b/lib/sdk/private-browsing/utils.js
@@ -52,9 +52,9 @@ let isWindowPBSupported = exports.isWindowPBSupported =
 // checks that per-tab private browsing is implemented
 let isTabPBSupported = exports.isTabPBSupported =
                        !pbService && !!PrivateBrowsingUtils && is('Fennec') && satisfiesVersion(version, '>=20.0*');
-                       
+
 function ignoreWindow(window) {
-  return !isPrivateBrowsingSupported && isWindowPrivate(window) && !isGlobalPBSupported;
+  return !isPrivateBrowsingSupported() && isWindowPrivate(window) && !isGlobalPBSupported;
 }
 exports.ignoreWindow = ignoreWindow;
 

--- a/lib/sdk/self.js
+++ b/lib/sdk/self.js
@@ -8,7 +8,7 @@ module.metadata = {
   "stability": "stable"
 };
 
-const { CC } = require('chrome');
+const { CC, Cc, Ci } = require('chrome');
 const { id, name, prefixURI, rootURI, metadata,
         version, loadReason } = require('@loader/options');
 
@@ -37,5 +37,15 @@ exports.data = Object.freeze({
     return readURISync(uri(path));
   }
 });
-exports.isPrivateBrowsingSupported = ((metadata.permissions || {})['private-browsing'] === true) ?
-                                     true : false;
+
+
+// Private browsing is only supported if user manually enabled add-on in
+// private browsing.
+
+const prefService = Cc['@mozilla.org/preferences-service;1'].
+                    getService(Ci.nsIPrefService).
+                    QueryInterface(Ci.nsIPrefBranch);
+
+const PB_PREF_NAME = "extensions." + id + "." + "allowPrivateBrowsing";
+exports.isPrivateBrowsingSupported = function()
+  prefService.getBoolPref(PB_PREF_NAME)

--- a/lib/sdk/tabs/tabs-firefox.js
+++ b/lib/sdk/tabs/tabs-firefox.js
@@ -10,7 +10,8 @@ const { isPrivate } = require('../private-browsing');
 const { isWindowPBSupported } = require('../private-browsing/utils')
 const { isPrivateBrowsingSupported } = require('sdk/self');
 
-const supportPrivateTabs = isPrivateBrowsingSupported && isWindowPBSupported;
+function isPrivateTabsSupported()
+  isPrivateBrowsingSupported() && isWindowPBSupported;
 
 Object.defineProperties(tabs, {
   open: { value: function open(options) {
@@ -27,7 +28,7 @@ Object.defineProperties(tabs, {
     let activeWindow = windows.activeWindow;
     let privateState = !!options.isPrivate;
     // if the active window is in the state that we need then use it
-    if (!supportPrivateTabs || privateState === isPrivate(activeWindow)) {
+    if (!isPrivateTabsSupported() || privateState === isPrivate(activeWindow)) {
       activeWindow.tabs.open(options);
     }
     else {

--- a/lib/sdk/tabs/utils.js
+++ b/lib/sdk/tabs/utils.js
@@ -19,7 +19,9 @@ const { isPrivateBrowsingSupported } = require('../self');
 const { isGlobalPBSupported } = require('../private-browsing/utils');
 
 // Bug 834961: ignore private windows when they are not supported
-function getWindows() windows(null, { includePrivate: isPrivateBrowsingSupported || isGlobalPBSupported });
+function getWindows() windows(null, {
+  includePrivate: isPrivateBrowsingSupported() || isGlobalPBSupported
+});
 
 function activateTab(tab, window) {
   let gBrowser = getTabBrowserForTab(tab);

--- a/lib/sdk/windows/firefox.js
+++ b/lib/sdk/windows/firefox.js
@@ -70,7 +70,7 @@ const BrowserWindowTrait = Trait.compose(
         this._tabOptions = [ Options(options.url) ];
       }
 
-      this._isPrivate = isPrivateBrowsingSupported && !!options.isPrivate;
+      this._isPrivate = isPrivateBrowsingSupported() && !!options.isPrivate;
 
       this._load();
 
@@ -218,7 +218,7 @@ const browserWindows = Trait.resolve({ toString: null }).compose(
         // `tabs` option is under review and may be removed.
         options = {
           tabs: [Options(options)],
-          isPrivate: isPrivateBrowsingSupported && options.isPrivate
+          isPrivate: isPrivateBrowsingSupported() && options.isPrivate
         };
       }
       return BrowserWindow(options);

--- a/lib/sdk/windows/tabs-fennec.js
+++ b/lib/sdk/windows/tabs-fennec.js
@@ -26,7 +26,8 @@ const mainWindow = windowNS(browserWindows.activeWindow).window;
 
 const ERR_FENNEC_MSG = 'This method is not yet supported by Fennec';
 
-const supportPrivateTabs = isPrivateBrowsingSupported && isTabPBSupported;
+function isPrivateTabsSupported()
+  isPrivateBrowsingSupported() && isTabPBSupported;
 
 const Tabs = Class({
   implements: [ List ],
@@ -57,7 +58,7 @@ const Tabs = Class({
 
     let rawTab = openTab(windowNS(activeWin).window, options.url, {
       inBackground: options.inBackground,
-      isPrivate: supportPrivateTabs && options.isPrivate
+      isPrivate: isPrivateTabsSupported() && options.isPrivate
     });
 
     // by now the tab has been created

--- a/python-lib/cuddlefish/tests/test_xpi.py
+++ b/python-lib/cuddlefish/tests/test_xpi.py
@@ -85,16 +85,18 @@ class PrefsTests(unittest.TestCase):
                u'pref("extensions.jid1-fZHqN9JfrDBa8A@jetpack.test2", "\u00FCnic\u00F8d\u00E9");',
                u'pref("extensions.jid1-fZHqN9JfrDBa8A@jetpack.test3", "1");',
                u'pref("extensions.jid1-fZHqN9JfrDBa8A@jetpack.test4", "red");',
+               u'pref("extensions.jid1-fZHqN9JfrDBa8A@jetpack.allowPrivateBrowsing", false);'
                ]
         self.failUnlessEqual(prefsjs, "\n".join(exp)+"\n")
 
     def testPackageWithNoPrefs(self):
         self.makexpi('no-prefs')
-        self.failIf('options.xul' in self.xpi.namelist())
+        self.failUnless('options.xul' in self.xpi.namelist())
         self.failUnlessEqual(self.xpi_harness_options["jetpackID"],
                              "jid1-fZHqN9JfrDBa8A@jetpack")
         prefsjs = self.xpi.read('defaults/preferences/prefs.js').decode("utf-8")
-        self.failUnlessEqual(prefsjs, "")
+        exp = [u'pref("extensions.jid1-fZHqN9JfrDBa8A@jetpack.allowPrivateBrowsing", false);']
+        self.failUnlessEqual(prefsjs, "\n".join(exp)+"\n")
 
 
 class Bug588119Tests(unittest.TestCase):

--- a/python-lib/cuddlefish/tests/test_xpi.py
+++ b/python-lib/cuddlefish/tests/test_xpi.py
@@ -238,7 +238,8 @@ class SmallXPI(unittest.TestCase):
         build = packaging.generate_build_for_target(pkg_cfg, target_cfg.name,
                                                     used_deps,
                                                     include_tests=False)
-        options = {'main': target_cfg.main}
+        options = {'main': target_cfg.main,
+                   'jetpackID': target_cfg.name + '@jetpack'}
         options.update(build)
         basedir = self.make_basedir()
         xpi_name = os.path.join(basedir, "contents.xpi")
@@ -255,6 +256,7 @@ class SmallXPI(unittest.TestCase):
                     # one in tests/static-files/xpi-template doesn't
                     "harness-options.json",
                     "install.rdf",
+                    "options.xul",
                     "defaults/preferences/prefs.js",
                     "resources/",
                     "resources/addon-sdk/",
@@ -341,7 +343,8 @@ class SmallXPI(unittest.TestCase):
         build = packaging.generate_build_for_target(pkg_cfg, target_cfg.name,
                                                     used_deps,
                                                     include_tests=True)
-        options = {'main': target_cfg.main}
+        options = {'main': target_cfg.main,
+                   'jetpackID': target_cfg.name + '@jetpack'}
         options.update(build)
         basedir = self.make_basedir()
         xpi_name = os.path.join(basedir, "contents.xpi")
@@ -384,7 +387,8 @@ class SmallXPI(unittest.TestCase):
         build = packaging.generate_build_for_target(pkg_cfg, target_cfg.name,
                                                     used_deps,
                                                     include_tests=True)
-        options = {'main': target_cfg.main}
+        options = {'main': target_cfg.main,
+                   'jetpackID': target_cfg.name + '@jetpack'}
         options.update(build)
         basedir = self.make_basedir()
         xpi_name = os.path.join(basedir, "contents.xpi")

--- a/test/addons/private-browsing-supported/test-private-browsing.js
+++ b/test/addons/private-browsing-supported/test-private-browsing.js
@@ -15,7 +15,7 @@ const { isWindowPBSupported, isTabPBSupported } = require('sdk/private-browsing/
 const TAB_URL = 'data:text/html;charset=utf-8,TEST-TAB';
 
 exports.testIsPrivateBrowsingTrue = function(assert) {
-  assert.ok(isPrivateBrowsingSupported,
+  assert.ok(isPrivateBrowsingSupported(),
             'isPrivateBrowsingSupported property is true');
 };
 

--- a/test/test-page-mod.js
+++ b/test/test-page-mod.js
@@ -1101,7 +1101,7 @@ exports["test page-mod on private tab in global pb"] = function (test) {
       test.assertEqual(worker.tab.url,
                        privateUri,
                        "page-mod should attach");
-      test.assertEqual(isPrivateBrowsingSupported,
+      test.assertEqual(isPrivateBrowsingSupported(),
                        false,
                        "private browsing is not supported");
       test.assert(isPrivate(worker),

--- a/test/test-private-browsing.js
+++ b/test/test-private-browsing.js
@@ -72,7 +72,7 @@ exports.testIsActiveDefault = function(test) {
 };
 
 exports.testIsPrivateBrowsingFalseDefault = function(test) {
-  test.assertEqual(isPrivateBrowsingSupported, false,
+  test.assertEqual(isPrivateBrowsingSupported(), false,
   	               'isPrivateBrowsingSupported property is false by default');
 };
 

--- a/test/test-self.js
+++ b/test/test-self.js
@@ -38,7 +38,7 @@ exports.testSelf = function(test) {
   test.assertEqual(self.loadReason, testLoadReason,
                    "self.loadReason is either startup or install on test runs");
 
-  test.assertEqual(self.isPrivateBrowsingSupported, false,
+  test.assertEqual(self.isPrivateBrowsingSupported(), false,
                    'usePrivateBrowsing property is false by default');
 };
 


### PR DESCRIPTION
WIP -

This change is going add a preference to every SDK add-on allowing users to disable add-on for private browsing.
If preference is set to `false` it will make [self.isPrivateBrowsingSupported](https://github.com/mozilla/addon-sdk/blob/master/lib/sdk/self.js#L40-L41) to be `false` hiding all the private browsing windows from the high level APIs.
Switching preference will undo all the changes that add-on did to a private windows (Initially probably we could just disable and re-enable addon with new pref set. We can optimize it later).