### PR TITLE
Bug 856999: Add --no-quit option to prevent from killing firefox when running tests.

### DIFF
--- a/app-extension/bootstrap.js
+++ b/app-extension/bootstrap.js
@@ -224,6 +224,8 @@ function startup(data, reasonCode) {
       logFile: options.logFile,
       // Arguments passed as --static-args
       staticArgs: options.staticArgs,
+      // Option to prevent automatic kill of firefox during tests
+      noQuit: options.no_quit,
 
       // Arguments related to test runner.
       modules: {

--- a/lib/sdk/system.js
+++ b/lib/sdk/system.js
@@ -65,7 +65,9 @@ exports.exit = function exit(code) {
     stream.close();
   }
 
-  appStartup.quit(code ? E_ATTEMPT : E_FORCE);
+  // Bug 856999: Prevent automatic kill of Firefox when running tests
+  if (!options.noQuit)
+    appStartup.quit(code ? E_ATTEMPT : E_FORCE);
 };
 
 exports.stdout = new function() {

--- a/python-lib/cuddlefish/__init__.py
+++ b/python-lib/cuddlefish/__init__.py
@@ -192,6 +192,12 @@ parser_groups = (
                                      action="store_true",
                                      default=False,
                                      cmds=['run', 'test'])),
+        (("", "--no-quit",), dict(dest="no_quit",
+                                     help=("Prevent from killing Firefox when"
+                                           "running tests"),
+                                     action="store_true",
+                                     default=False,
+                                     cmds=['run', 'test'])),
         (("", "--no-strip-xpi",), dict(dest="no_strip_xpi",
                                     help="retain unused modules in XPI",
                                     action="store_true",
@@ -660,7 +666,7 @@ def run(arguments=sys.argv[1:], target_cfg=None, pkg_cfg=None,
     # a Mozilla application (which includes running tests).
 
     use_main = False
-    inherited_options = ['verbose', 'enable_e10s', 'parseable']
+    inherited_options = ['verbose', 'enable_e10s', 'parseable', 'no_quit']
     enforce_timeouts = False
 
     if command == "xpi":
@@ -919,6 +925,7 @@ def run(arguments=sys.argv[1:], target_cfg=None, pkg_cfg=None,
                              args=options.cmdargs,
                              extra_environment=extra_environment,
                              norun=options.no_run,
+                             noquit=options.no_quit,
                              used_files=used_files,
                              enable_mobile=options.enable_mobile,
                              mobile_app_name=options.mobile_app_name,

--- a/python-lib/cuddlefish/runner.py
+++ b/python-lib/cuddlefish/runner.py
@@ -406,7 +406,7 @@ def run_app(harness_root_dir, manifest_rdf, harness_options,
             app_type, binary=None, profiledir=None, verbose=False,
             parseable=False, enforce_timeouts=False,
             logfile=None, addons=None, args=None, extra_environment={},
-            norun=None,
+            norun=None, noquit=None,
             used_files=None, enable_mobile=False,
             mobile_app_name=None,
             env_root=None,
@@ -745,7 +745,8 @@ def run_app(harness_root_dir, manifest_rdf, harness_options,
                     raise Timeout("Test run exceeded timeout (%ds)." %
                                   RUN_TIMEOUT, test_name, parseable)
     except:
-        runner.stop()
+        if not noquit:
+            runner.stop()
         raise
     else:
         runner.wait(10)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=856999
