### PR TITLE
Bug 858970 - Wait for tab close before switching to next test in testWindowTabsObject_alt.

### DIFF
--- a/test/test-windows-common.js
+++ b/test/test-windows-common.js
@@ -39,7 +39,7 @@ exports.testWindowTabsObject_alt = function(test) {
       test.assertNotEqual(window.tabs.activeTab, tab, "Correct active tab");
 
       // end test
-      tab.close(test.done());
+      tab.close(test.done.bind(test));
     }
   });
 };

--- a/test/windows/test-firefox-windows.js
+++ b/test/windows/test-firefox-windows.js
@@ -356,8 +356,6 @@ exports.testWindowOpenPrivateDefault = function(test) {
     url: 'about:mozilla',
     isPrivate: true,
     onOpen: function(window) {
-      test.assertEqual();
-
       let tab = window.tabs[0];
       tab.once('ready', function() {
         test.assertEqual(tab.url, 'about:mozilla', 'opened correct tab');


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=858970
