### PR TITLE
Bug 812417: Listen for domwindowclosed instead of unload when closing a toplevel window.

### DIFF
--- a/lib/sdk/window/helpers.js
+++ b/lib/sdk/window/helpers.js
@@ -4,6 +4,7 @@
 'use strict';
 
 const { defer } = require('../core/promise');
+const events = require('../system/events');
 const { open: openWindow, onFocus } = require('./utils');
 
 function open(uri, options) {
@@ -12,11 +13,18 @@ function open(uri, options) {
 exports.open = open;
 
 function close(window) {
-  // unload event could happen so fast that it is not resolved
-  // if we listen to unload after calling close()
-  let p = promise(window, 'unload');
+  // We shouldn't wait for unload, as it is dispatched
+  // before the window is actually closed.
+  // `domwindowclosed` is a better match.
+  let deferred = defer();
+  events.on("domwindowclosed", function onclose({subject}) {
+    if (subject == window) {
+      events.off("domwindowclosed", onclose);
+      deferred.resolve(window);
+    }
+  }, true);
   window.close();
-  return p;
+  return deferred.promise;
 }
 exports.close = close;
 

--- a/test/test-window-utils2.js
+++ b/test/test-window-utils2.js
@@ -61,7 +61,10 @@ exports.testBackgroundify = function(assert, done) {
             'backgroundifyied window is in the list of windows');
 
   // Wait for the window unload before ending test
-  close(window).then(done);
+  // backgroundified windows doesn't dispatch domwindowclosed event
+  // so that we have to manually wait for unload event
+  window.onunload = done;
+  window.close();
 };
 
 exports.testIsBrowser = function(assert) {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=812417
