### PR TITLE
Only emit to non-null _contentWorker

### DIFF
--- a/lib/sdk/content/worker.js
+++ b/lib/sdk/content/worker.js
@@ -535,7 +535,7 @@ const Worker = EventEmitter.compose({
   },
 
   _pageShow: function _pageShow() {
-    this._contentWorker.emitSync("pageshow");
+    if(this._contentWorker != null) this._contentWorker.emitSync("pageshow");
     this._emit("pageshow");
     this._frozen = false;
   },


### PR DESCRIPTION
This prevents logging exception data that can easily be avoided. Some of our users notice these and complain about them cluttering their consoles.