### PR TITLE
Bug 812417: Listen for domwindowclosed instead of unload when closing a toplevel window.

### DIFF
--- a/doc/module-source/sdk/window/utils.md
+++ b/doc/module-source/sdk/window/utils.md
@@ -79,6 +79,22 @@ to support private browsing, refer to the
   @returns {nsIBaseWindow}
 </api>
 
+<api name="getToplevelWindow">
+  @function
+  Returns the toplevel
+  [`nsIDOMWindow`](https://developer.mozilla.org/en-US/docs/XPCOM_Interface_Reference/nsIDOMWindow)
+  for the given child [`nsIDOMWindow`](https://developer.mozilla.org/en/nsIDOMWindow):
+
+      var { Ci } = require('chrome');
+      var utils = require('sdk/window/utils');
+      var browserWindow = utils.getMostRecentBrowserWindow();
+      var window = browserWindow.content; // `window` object for the current webpage
+      utils.getToplevelWindw(window) == browserWindow // => true
+
+  @param window {nsIDOMWindow}
+  @returns {nsIDOMWindow}
+</api>
+
 <api name="getWindowDocShell">
   @function
   Returns the

--- a/lib/sdk/window/utils.js
+++ b/lib/sdk/window/utils.js
@@ -113,6 +113,19 @@ function getBaseWindow(window) {
 }
 exports.getBaseWindow = getBaseWindow;
 
+/**
+ * Returns the `nsIDOMWindow` toplevel window for any child/inner window
+ */
+function getToplevelWindow(window) {
+  return window.QueryInterface(Ci.nsIInterfaceRequestor)
+               .getInterface(Ci.nsIWebNavigation)
+               .QueryInterface(Ci.nsIDocShellTreeItem)
+               .rootTreeItem
+               .QueryInterface(Ci.nsIInterfaceRequestor)
+               .getInterface(Ci.nsIDOMWindow);
+}
+exports.getToplevelWindow = getToplevelWindow;
+
 function getWindowDocShell(window) window.gBrowser.docShell;
 exports.getWindowDocShell = getWindowDocShell;
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=812417
