### PR TITLE
Bug 860453 - Rename lang/functional's `curry` to `partial`

### DIFF
--- a/doc/module-source/sdk/lang/functional.md
+++ b/doc/module-source/sdk/lang/functional.md
@@ -94,26 +94,26 @@ Returns the value that is returned by `callee`.
   Returns the return value of `callee`.
 </api>
 
-<api name="curry">
+<api name="partial">
 @function
-[Curries](http://en.wikipedia.org/wiki/Currying) the given function with the arguments given.
+Takes a function and bind values to one or more arguments, returning a new function of smaller arity.
 
-    let { curry } = require("sdk/lang/functional");
+    let { partial } = require("sdk/lang/functional");
     let add = function add (x, y) { return x + y; }
-    let addOne = curry(add, 1);
+    let addOne = partial(add, 1);
 
     addOne(5); // 6
     addOne(10); // 11
-    curry(add, addOne(20))(2); // 23
+    partial(add, addOne(20))(2); // 23
 
 @param fn {function}
-  Function to be curried.
+  Function on which partial application is to be performed.
 
 @param arguments... {mixed}
   Additional arguments
 
 @returns {function}
-  The curried function.
+  The partial function.
 </api>
 
 <api name="compose">

--- a/lib/sdk/console/plain-text.js
+++ b/lib/sdk/console/plain-text.js
@@ -13,7 +13,7 @@ const self = require("../self");
 const traceback = require("./traceback")
 const prefs = require("../preferences/service");
 const { merge } = require("../util/object");
-const { curry } = require("../lang/functional");
+const { partial } = require("../lang/functional");
 
 const LEVELS = {
   "all": Number.MIN_VALUE,
@@ -102,13 +102,13 @@ function PlainTextConsole(print) {
   }
 
   merge(this, {
-    log: curry(message, print, "info"),
-    info: curry(message, print, "info"),
-    warn: curry(message, print, "warn"),
-    error: curry(message, print, "error"),
-    debug: curry(message, print, "debug"),
-    exception: curry(errorMessage, print),
-    trace: curry(traceMessage, print),
+    log: partial(message, print, "info"),
+    info: partial(message, print, "info"),
+    warn: partial(message, print, "warn"),
+    error: partial(message, print, "error"),
+    debug: partial(message, print, "debug"),
+    exception: partial(errorMessage, print),
+    trace: partial(traceMessage, print),
 
     dir: function dir() {},
     group: function group() {},

--- a/lib/sdk/lang/functional.js
+++ b/lib/sdk/lang/functional.js
@@ -13,6 +13,7 @@ module.metadata = {
 };
 
 const { setTimeout } = require("../timers");
+const { deprecateFunction } = require("../util/deprecate");
 
 /**
  * Takes `lambda` function and returns a method. When returned method is
@@ -55,14 +56,15 @@ function invoke(callee, params, self) callee.apply(self, params);
 exports.invoke = invoke;
 
 /**
- * Curries a function with the arguments given.
+ * Takes a function and bind values to one or more arguments, returning a new
+ * function of smaller arity.
  *
  * @param {Function} fn
- *    The function to curry
+ *    The function to partial
  *
- * @returns The function curried
+ * @returns The new function with binded values
  */
-function curry(fn) {
+function partial(fn) {
   if (typeof fn !== "function")
     throw new TypeError(String(fn) + " is not a function");
 
@@ -70,7 +72,12 @@ function curry(fn) {
 
   return function() fn.apply(this, args.concat(Array.slice(arguments)));
 }
-exports.curry = curry;
+exports.partial = partial;
+
+exports.curry = deprecateFunction(partial,
+  'curry is deprecated, ' +
+  'please use require("sdk/lang/functional").partial instead.'
+);
 
 /**
  * Returns the composition of a list of functions, where each function consumes


### PR DESCRIPTION
Renamed 'curry' to 'partial' and added deprecation warning test for the same.
