### PR TITLE
Bug 863946: mozrunner: support FreeBSD

### DIFF
--- a/python-lib/mozrunner/__init__.py
+++ b/python-lib/mozrunner/__init__.py
@@ -406,7 +406,8 @@ class Runner(object):
     def find_binary(self):
         """Finds the binary for self.names if one was not provided."""
         binary = None
-        if sys.platform in ('linux2', 'sunos5', 'solaris'):
+        if sys.platform in ('linux2', 'sunos5', 'solaris') \
+                or sys.platform.startswith('freebsd'):
             for name in reversed(self.names):
                 binary = findInPath(name)
         elif os.name == 'nt' or sys.platform == 'cygwin':
@@ -578,7 +579,8 @@ class FirefoxRunner(Runner):
     def names(self):
         if sys.platform == 'darwin':
             return ['firefox', 'nightly', 'shiretoko']
-        if (sys.platform == 'linux2') or (sys.platform in ('sunos5', 'solaris')):
+        if sys.platform in ('linux2', 'sunos5', 'solaris') \
+                or sys.platform.startswith('freebsd'):
             return ['firefox', 'mozilla-firefox', 'iceweasel']
         if os.name == 'nt' or sys.platform == 'cygwin':
             return ['firefox']

--- a/python-lib/mozrunner/killableprocess.py
+++ b/python-lib/mozrunner/killableprocess.py
@@ -257,7 +257,8 @@ class Popen(subprocess.Popen):
                 self.kill(group)
 
         else:
-            if (sys.platform == 'linux2') or (sys.platform in ('sunos5', 'solaris')):
+            if sys.platform in ('linux2', 'sunos5', 'solaris') \
+                    or sys.platform.startswith('freebsd'):
                 def group_wait(timeout):
                     try:
                         os.waitpid(self.pid, 0)


### PR DESCRIPTION
Running `cfx test` fails on FreeBSD because it can't find the
application binary.  Specifying the application binary results in no
activity or output.

Recognise FreeBSD in `sys.platform` and look for the "firefox"
binary on FreeBSD.
