### PR TITLE
Bug 858402:  Intermittent tests/test-xhr.testLocalXhr | Timed out

### DIFF
--- a/test/test-xhr.js
+++ b/test/test-xhr.js
@@ -1,12 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ 'use strict'
 
-var xhr = require("sdk/net/xhr");
-var timer = require("sdk/timers");
-var { Loader } = require("sdk/test/loader");
-var xulApp = require("sdk/system/xul-app");
+const xhr = require('sdk/net/xhr');
+const { Loader } = require('sdk/test/loader');
+const xulApp = require('sdk/system/xul-app');
 
+// TODO: rewrite test below
 /* Test is intentionally disabled until platform bug 707256 is fixed.
 exports.testAbortedXhr = function(test) {
   var req = new xhr.XMLHttpRequest();
@@ -16,67 +17,76 @@ exports.testAbortedXhr = function(test) {
 };
 */
 
-exports.testLocalXhr = function(test) {
+exports.testLocalXhr = function(assert, done) {
   var req = new xhr.XMLHttpRequest();
-  req.overrideMimeType("text/plain");
-  req.open("GET", module.uri);
+  let ready = false;
+
+  req.overrideMimeType('text/plain');
+  req.open('GET', module.uri);
   req.onreadystatechange = function() {
     if (req.readyState == 4 && (req.status == 0 || req.status == 200)) {
-      test.assertMatches(req.responseText,
-                         /onreadystatechange/,
-                         "XMLHttpRequest should get local files");
-      timer.setTimeout(
-        function() { test.assertEqual(xhr.getRequestCount(), 0);
-                     test.done(); },
-        0
-      );
+      ready = true;
+      assert.ok(req.responseText.match(/onreadystatechange/i),
+                'XMLHttpRequest should get local files');
     }
   };
+  req.addEventListener('load', function onload() {
+    req.removeEventListener('load', onload);
+    assert.pass('addEventListener for load event worked');
+    assert.ok(ready, 'onreadystatechange listener worked');
+    assert.equal(xhr.getRequestCount(), 0, 'request count is 0');
+    done();
+  });
   req.send(null);
-  test.assertEqual(xhr.getRequestCount(), 1);
-  test.waitUntilDone(4000);
+
+  assert.equal(xhr.getRequestCount(), 1, 'request count is 1');
 };
 
-exports.testUnload = function(test) {
+exports.testUnload = function(assert) {
   var loader = Loader(module);
-  var sbxhr = loader.require("sdk/net/xhr");
+  var sbxhr = loader.require('sdk/net/xhr');
   var req = new sbxhr.XMLHttpRequest();
-  req.overrideMimeType("text/plain");
+
+  req.overrideMimeType('text/plain');
   req.open("GET", module.uri);
   req.send(null);
-  test.assertEqual(sbxhr.getRequestCount(), 1);
+
+  assert.equal(sbxhr.getRequestCount(), 1, 'request count is 1');
   loader.unload();
-  test.assertEqual(sbxhr.getRequestCount(), 0);
+  assert.equal(sbxhr.getRequestCount(), 0, 'request count is 0');
 };
 
-exports.testResponseHeaders = function(test) {
+exports.testResponseHeaders = function(assert, done) {
   var req = new xhr.XMLHttpRequest();
-  req.overrideMimeType("text/plain");
-  req.open("GET", module.uri);
+
+  req.overrideMimeType('text/plain');
+  req.open('GET', module.uri);
   req.onreadystatechange = function() {
     if (req.readyState == 4 && (req.status == 0 || req.status == 200)) {
       var headers = req.getAllResponseHeaders();
-      if (xulApp.versionInRange(xulApp.platformVersion, "13.0a1", "*")) {
+      if (xulApp.satisfiesVersion(xulApp.platformVersion, '>=13.0a1')) {
         headers = headers.split("\r\n");
-        if(headers.length == 1) {
+        if (headers.length == 1) {
           headers = headers[0].split("\n");
         }
-        for(let i in headers) {
-          if(headers[i] && headers[i].search("Content-Type") >= 0) {
-            test.assertEqual(headers[i], "Content-Type: text/plain",
-                             "XHR's headers are valid");
+        for (let i in headers) {
+          if (headers[i] && headers[i].search('Content-Type') >= 0) {
+            assert.equal(headers[i], 'Content-Type: text/plain',
+                         'XHR\'s headers are valid');
           }
         }
       }
       else {
-        test.assert(headers === null || headers === "",
-                    "XHR's headers are empty");
+        assert.ok(headers === null || headers === '',
+                  'XHR\'s headers are empty');
       }
-      test.done();
+
+      done();
     }
   };
   req.send(null);
-  test.assertEqual(xhr.getRequestCount(), 1);
-  test.waitUntilDone(4000);
+
+  assert.equal(xhr.getRequestCount(), 1, 'request count is 1');
 }
 
+require('test').run(exports);


### PR DESCRIPTION
Added addEventListener and removeEventListener methods to sdk/net/xhr and used a load event listener to check if the request cleaned up itself, instead of using a setTimout.

Also cleaned up the test-xhr.js file to use the new test framework.

The setTimeout was either not firing soon enough or it was firing too soon.
