### PR TITLE
bug 865281 - add minimal documentation of the tab.id property.

### DIFF
--- a/doc/module-source/sdk/tabs.md
+++ b/doc/module-source/sdk/tabs.md
@@ -192,6 +192,11 @@ registration.
 Tabs emit all the events described in the Events section. Listeners are
 passed the `Tab` object that triggered the event.
 
+<api name="id">
+@property {string}
+The unique id for the tab. This property is read-only.
+</api>
+
 <api name="title">
 @property {string}
 The title of the tab (usually the title of the page currently loaded in the tab)


### PR DESCRIPTION
Added the minimum amount of docs - basically admitting to the existence of tab.id. Sorry I didn't do this when I made the original change.
