### PR TITLE
Bug 865057: wait for one window to close before closing the next

### DIFF
--- a/test/windows/test-firefox-windows.js
+++ b/test/windows/test-firefox-windows.js
@@ -310,14 +310,15 @@ exports.testTrackWindows = function(test) {
           openWindow()
         }
         else {
-          let count = windows.length;
-          for each (let win in windows) {
-            win.close(function() {
-              if (--count == 0) {
-                test.done();
-              }
+          (function closeWindows(windows) {
+            if (!windows.length)
+              return test.done();
+
+            return windows.pop().close(function() {
+              test.pass('window was closed');
+              closeWindows(windows);
             });
-          }
+          })(windows)
         }
       },
 


### PR DESCRIPTION
Also providing more information about test-windows:testTrackWindows
