### PR TITLE
Bug 865489 - Cannot iterate Addon SDK-List with for..of

### DIFF
--- a/lib/sdk/deprecated/list.js
+++ b/lib/sdk/deprecated/list.js
@@ -111,8 +111,15 @@ const List = Trait.resolve({ toString: null }).compose({
   __iterator__: function __iterator__(onKeys, onKeyValue) {
     let array = this._keyValueMap.slice(0),
         i = -1;
-    for each(let element in array)
+    for (let element of array)
       yield onKeyValue ? [++i, element] : onKeys ? ++i : element;
+  },
+  iterator: function iterator() {
+    let array = this._keyValueMap.slice(0);
+
+    for (let element of array)
+      yield element;
   }
+
 });
 exports.List = List;

--- a/lib/sdk/util/list.js
+++ b/lib/sdk/util/list.js
@@ -45,6 +45,13 @@ const List = Class({
                 i = -1;
     for each(let element in array)
       yield onKeyValue ? [++i, element] : onKeys ? ++i : element;
+  },
+  iterator: function iterator() {
+    let array = listNS(this).keyValueMap.slice(0),
+                i = -1;
+
+    for (let element of array)
+      yield element;
   }
 });
 exports.List = List;

--- a/test/test-deprecated-list.js
+++ b/test/test-deprecated-list.js
@@ -50,6 +50,16 @@ exports['test:test for each'] = function(test) {
   }
 };
 
+exports['test:test for of'] = function(test) {
+  let fixture = new List(3, 2, 1);
+
+  test.assertEqual(3, fixture.length, 'length is 3');
+  let i = 3;
+  for (let value of fixture) {
+    test.assertEqual(i--, value, 'value should match');
+  }
+};
+
 exports['test:test toString'] = function(test) {
   let fixture = List(3, 2, 1);
 

--- a/test/test-list.js
+++ b/test/test-list.js
@@ -21,6 +21,12 @@ exports.testList = function(test) {
     test.assertEqual(++count, 1, 'count is correct');
   }
 
+  count = 0;
+  for (let ele of list) {
+    test.assertEqual(ele, 1, 'ele is correct');
+    test.assertEqual(++count, 1, 'count is correct');
+  }
+
   removeListItem(list, 1);
   test.assertEqual(list.length, 0, 'remove worked');
 };
@@ -34,9 +40,16 @@ exports.testImplementsList = function(test) {
   });
   let list2 = List2();
   let count = 0;
+
   for each (let ele in list2) {
     test.assertEqual(ele, count++, 'ele is correct');
   }
+
+  count = 0;
+  for (let ele of list2) {
+    test.assertEqual(ele, count++, 'ele is correct');
+  }
+
   addListItem(list2, 3);
   test.assertEqual(list2.length, 4, '3 was added');
   test.assertEqual(list2[list2.length-1], 3, '3 was added');


### PR DESCRIPTION
Added `iterator` method to `List` (deprecated version too), so that our SDK list (`tabs`, `browserWindows`, etc) can be iterated with `for...of`.
