### PR TITLE
Bug 888097 Update cfx-tool.md

### DIFF
--- a/doc/dev-guide-source/cfx-tool.md
+++ b/doc/dev-guide-source/cfx-tool.md
@@ -586,15 +586,14 @@ and this usually involves using HTTPS for the links.
 So if we run the following command:
 
 <pre>
-  cfx xpi --update-link https://example.com/addon/latest
-          --update-url https://example.com/addon/update_rdf
+  cfx xpi --update-link https://example.com/addon/latest/pluginName.xpi --update-url https://example.com/addon/update_rdf/pluginName.update.rdf
 </pre>
 
 `cfx` will create two files:
 
 * an XPI file which embeds
-`https://example.com/addon/update_rdf` as the value of `updateURL`
-* an RDF file which embeds `https://example.com/addon/latest` as the value of
+`https://example.com/addon/update_rdf/pluginName.update.rdf` as the value of `updateURL`
+* an RDF file which embeds `https://example.com/addon/latest/pluginName.xpi` as the value of
 `updateLink`.
 
 #### Supported Options ####


### PR DESCRIPTION
The documentation was not clear on how the autoupdate links are created. The name of the files are also needed in the URLs to specify for the update requests.
Also the cfx xpi -update-link commands need to be on the same line (at least on Windows).
