### PR TITLE
Fix for bug 870563 - Document panel positioning

### DIFF
--- a/doc/module-source/sdk/panel.md
+++ b/doc/module-source/sdk/panel.md
@@ -70,6 +70,13 @@ method exported by the
 
     panel.show();
 
+## Panel Positioning ##
+
+By default the panel appears in the center of the currently active browser window.
+You can position the panel by passing a `position` to the panel's
+[constructor](modules/sdk/panel.html#Panel(options)) or to
+its [`show()`](modules/sdk/panel.html#show(options)) method.
+
 ## Updating Panel Content ##
 
 You can update the panel's content simply by setting the panel's `contentURL`
@@ -425,23 +432,23 @@ Creates a panel.
     The position of the panel.
     Ignored if the panel is opened by a widget.
 
-    You can set as value an object that has one or more of the following
-    properites: `top`, `right`, `bottom` and `left`. Their values are expressed
+    This is an object that has one or more of the following
+    properties: `top`, `right`, `bottom` and `left`. Their values are expressed
     in pixels. Any other properties will be ignored.
 
-    The default alignment is centered, so for example panel can be displayed in
-    the center of the bottom corner by leaving off vertical axis:
+    The default alignment along each axis is centered: so to display a panel centred
+    along the vertical or horizontal axis, just omit that axis:
 
-        // Show the panel to the centered horizontally and aligned to the bottom
-        // of the content area
+        // Show the panel centered horizontally and
+        // aligned to the bottom of the content area
         require("sdk/panel").Panel({
           position: {
            bottom: 0
           }
         }).show();
 
-        // Show the panel to the centered vertically and aligned to the left o
-        // the content area
+        // Show the panel centered vertically and
+        // aligned to the left of the content area
         require("sdk/panel").Panel({
           position: {
             left: 0
@@ -451,11 +458,13 @@ Creates a panel.
         // Centered panel, default behavior
         require("sdk/panel").Panel({}).show();
 
-    In the same way of their CSS counterpart, setting both `top` and `bottom`,
-    or `left` and `right`, will results in calculated the `height` and `width`:
+    As with the CSS `top`, `bottom`, `left`, and `right` properties, setting
+    both `top` and `bottom` or both `left` and `right` will implicitly set the
+    panel's `height` or `width` relative to the content window:
 
-        // Show the panel centered horizontally, that is distant 40px
-        // from the top and 100px from the bottom.
+        // Show the panel centered horizontally, with:
+        // - the top edge 40px from the top of the content window
+        // - the bottom edge 100px from the bottom of the content window
         require("sdk/panel").Panel({
           position: {
             top: 40,
@@ -463,11 +472,13 @@ Creates a panel.
           }
         }).show();
 
-    Set implicitly `height` in this example, will makes the panel ignore the
-    `bottom` property, as the CSS homonym properties does:
+    If you set both `top` and `bottom`, but also set the panel's height
+    explicitly using the `height` property, then the panel will ignore
+    `bottom`, just as CSS does for its properties with the same name:
 
-        // Show the panel centered horizontally, that is distant 40px from the top
-        // and has 400px as height
+        // Show the panel centered horizontally, with:
+        // - the top edge 40px from the top of the content window
+        // - a height of 400px
         require("sdk/panel").Panel({
           position: {
             top: 40,
@@ -485,7 +496,8 @@ Creates a panel.
           height: 400
         }).show();
 
-    The same principle is applied for `width`, `left` and `right`.
+    The same principle is applied in the horizontal axis with
+    `width`, `left` and `right`.
 
   @prop [focus=true] {boolean}
     Set to `false` to prevent taking the focus away when the panel is shown.
@@ -644,8 +656,10 @@ Displays the panel.
 
 If the `options` argument is given, it will be shallow merged with the options
 provided in the constructor: the `options` passed in the `show` method takes
-the precedence.
-It's useful for temporary changes, without touching the default values.
+precedence.
+
+Passing options here is useful for making temporary changes without touching
+the default values.
 
 @param options {object}
   Showing options for the panel, with the following keys:


### PR DESCRIPTION
I didn't add anything to the tutorial, as that uses Widget, so position won't work. But I added a section in the preamble and copy-edited the detailed API reference.
