### PR TITLE
Bug 874070 - SDK tests shouldn't check for <tab>'s load event but for browser's

### DIFF
--- a/lib/sdk/deprecated/tab-browser.js
+++ b/lib/sdk/deprecated/tab-browser.js
@@ -566,7 +566,7 @@ ModuleTabTracker.prototype = {
   _TAB_EVENTS: ["TabOpen", "TabClose", "TabSelect", "DOMContentLoaded",
                 "load", "MozAfterPaint"],
   _safeTrackTab: function safeTrackTab(tab) {
-    tab.addEventListener("load", this, false);
+    tab.linkedBrowser.addEventListener("load", this, true);
     tab.linkedBrowser.addEventListener("MozAfterPaint", this, false);
     this._tabs.push(tab);
     try {
@@ -576,7 +576,7 @@ ModuleTabTracker.prototype = {
     }
   },
   _safeUntrackTab: function safeUntrackTab(tab) {
-    tab.removeEventListener("load", this, false);
+    tab.linkedBrowser.removeEventListener("load", this, true);
     tab.linkedBrowser.removeEventListener("MozAfterPaint", this, false);
     var index = this._tabs.indexOf(tab);
     if (index == -1)
@@ -617,7 +617,11 @@ ModuleTabTracker.prototype = {
     }
   },
   _safeLoad: function safeLoad(event) {
-    let tab = event.target;
+    let win = event.currentTarget.ownerDocument.defaultView;
+    let tabIndex = win.gBrowser.getBrowserIndexForDocument(event.target);
+    if (tabIndex == -1)
+      return;
+    let tab = win.gBrowser.tabContainer.getItemAtIndex(tabIndex);
     let index = this._tabs.indexOf(tab);
     if (index == -1)
       console.error("internal error: tab not found");

--- a/test/addons/private-browsing-supported/test-selection.js
+++ b/test/addons/private-browsing-supported/test-selection.js
@@ -49,8 +49,8 @@ function open(url, options) {
 
       let tab = getActiveTab(chromeWindow);
 
-      tab.addEventListener("load", function ready(event) {
-        let { document } = getTabContentWindow(this);
+      tab.linkedBrowser.addEventListener("load", function ready(event) {
+        let { document } = getTabContentWindow(tab);
 
         if (document.readyState === "complete" && document.URL === url) {
           this.removeEventListener(event.type, ready);
@@ -60,7 +60,7 @@ function open(url, options) {
 
           resolve(document.defaultView);
         }
-      })
+      }, true);
 
       setTabURL(tab, url);
     });

--- a/test/test-selection.js
+++ b/test/test-selection.js
@@ -50,15 +50,15 @@ function open(url, options) {
 
       let tab = getActiveTab(chromeWindow);
 
-      tab.addEventListener("load", function ready(event) {
-        let { document } = getTabContentWindow(this);
+      tab.linkedBrowser.addEventListener("load", function ready(event) {
+        let { document } = getTabContentWindow(tab);
 
         if (document.readyState === "complete" && document.URL === url) {
           this.removeEventListener(event.type, ready);
 
           resolve(document.defaultView);
         }
-      })
+      }, true);
 
       setTabURL(tab, url);
     });


### PR DESCRIPTION
Per https://bugzilla.mozilla.org/show_bug.cgi?id=874070 .
