### PR TITLE
Bug 877578 Corrected implementation of validateOptions from api-utils

### DIFF
--- a/lib/sdk/deprecated/api-utils.js
+++ b/lib/sdk/deprecated/api-utils.js
@@ -84,9 +84,9 @@ exports.publicConstructor = function publicConstructor(privateCtor) {
 exports.validateOptions = function validateOptions(options, requirements) {
   options = options || {};
   let validatedOptions = {};
-  let mapThrew = false;
 
   for (let key in requirements) {
+    let mapThrew = false;
     let req = requirements[key];
     let [optsVal, keyInOpts] = (key in options) ?
                                [options[key], true] :

--- a/test/test-api-utils.js
+++ b/test/test-api-utils.js
@@ -175,6 +175,18 @@ exports.testValidateMapWithMissingKey = function (test) {
   assertObjsEqual(test, val, { });
 };
 
+exports.testValidateMapWithMissingKeyAndThrown = function (test) {
+  let val = apiUtils.validateOptions({}, {
+    bar: {
+      map: function(v) { throw "bar" }
+    },
+    baz: {
+      map: function(v) "foo"
+    }
+  });
+  assertObjsEqual(test, val, { baz: "foo" });
+};
+
 exports.testAddIterator = function testAddIterator(test) {
   let obj = {};
   let keys = ["foo", "bar", "baz"];


### PR DESCRIPTION
Previously, once `mapThrew` was set to true, it was never restored to `false`, causing keys to be missing on subsequent keys.

Attached bugfix and test.
(I didn't bother to create a bugreport on bugzilla, because it's a trivial bug fixed by moving one line)
