### PR TITLE
Bug 888094 Added documentation for sdk/self, property uri

### DIFF
--- a/doc/module-source/sdk/self.md
+++ b/doc/module-source/sdk/self.md
@@ -13,6 +13,13 @@ Note that the `self` module is completely different from the global `self`
 object accessible to content scripts, which is used by a content script to
 [communicate with the add-on code](dev-guide/guides/content-scripts/using-port.html).
 
+<api name="uri">
+@property {string}
+This property represents an add-on associated unique URI string.
+This URI can be used for APIs which require a valid URI string, such as the
+[passwords](modules/sdk/passwords.html) module.
+</api>
+
 <api name="id">
 @property {string}
 This property is a printable string that is unique for each add-on. It comes


### PR DESCRIPTION
I saw a reference to self's uri property in the documentation for [sdk/passwords](https://addons.mozilla.org/en-US/developers/docs/sdk/1.14/modules/sdk/passwords.html#search(options\)), but it was not mentioned at [sdk/self](https://addons.mozilla.org/en-US/developers/docs/sdk/1.14/modules/sdk/self.html).

I've updated the documentation after looking at the source code of sdk/self.js

(For the record, this is the example I'm referring to, taken from [sdk/passwords](https://addons.mozilla.org/en-US/developers/docs/sdk/1.14/modules/sdk/passwords.html#search%28options%29%29)

```
function show_my_addon_passwords() {
  require("sdk/passwords").search({
   url: require("sdk/self").uri,
```
