### PR TITLE
Bug 877413: Add an addPath to toolkit/loader.

### DIFF
--- a/lib/toolkit/loader.js
+++ b/lib/toolkit/loader.js
@@ -380,6 +380,22 @@ const unload = iced(function unload(loader, reason) {
 });
 exports.unload = unload;
 
+// Adds a path mapping to an existing loader.  addPath(`loader`, `path`, `uri`)
+// is equivalent to including paths: { `path`: `uri` } during loader creation.
+const addPath = iced(function addPath(loader, path, uri) {
+  let mapping = loader.mapping;
+  let i;
+  for (i = 0; i < mapping.length; i++) {
+    let mapPath = mapping[i][0];
+    if (mapPath === path)
+      throw new Error("Path '" + path + "'  already exists");
+    if (mapPath.length < path.length)
+      break;
+  }
+  mapping.splice(i, 0, [path, uri]);
+});
+exports.addPath = addPath;
+
 // Function makes new loader that can be used to load CommonJS modules
 // described by a given `options.manifest`. Loader takes following options:
 // - `globals`: Optional map of globals, that all module scopes will inherit

--- a/test/fixtures/loader/simple/main.js
+++ b/test/fixtures/loader/simple/main.js
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+exports.a = 42;
+exports.main = exports;


### PR DESCRIPTION
We want the devtools server loader to load all extensions to the server in its own loader, for a few reasons:

a) We want to be able to identify all globals associated with the loader so we can avoid debugging ourselves during chrome debugging.
b) We want to be able to load multiple copies of the server so that we can debug the debugging server.

So we want tests and extensions to be able to add URIs that can be loaded.  A few options that would be acceptable are:

a) require("resource://fully/qualified/url");
b) defineModule(loader, "extensionpath/module", "resource://extensionuri/module.js"); require("extensionpath/module");
c) addPath(loader, "extensionpath/", "resource://extensionuri/"); require("extensionpath/module");

c) seems the simplest, so this pull request that does that.
