### PR TITLE
Bug 699450 - Exceptions are thrown when you use page-mod and tab.close()

### DIFF
--- a/lib/sdk/tabs/tab-firefox.js
+++ b/lib/sdk/tabs/tab-firefox.js
@@ -125,7 +125,7 @@ const TabTrait = Trait.compose(EventEmitter, {
    * listeners.
    */
   _onEvent: function _onEvent(type, tab) {
-    if (tab == this._public)
+    if (viewNS(tab).tab == this._tab)
       this._emit(type, tab);
   },
   /**

--- a/lib/sdk/tabs/utils.js
+++ b/lib/sdk/tabs/utils.js
@@ -131,19 +131,23 @@ function isTabOpen(tab) {
 exports.isTabOpen = isTabOpen;
 
 function closeTab(tab) {
-   // Bug 699450: the tab may already have been detached
-  if (!tab.parentNode)
-    return;
-
   let gBrowser = getTabBrowserForTab(tab);
   // normal case?
-  if (gBrowser)
+  if (gBrowser) {
+    // Bug 699450: the tab may already have been detached
+    if (!tab.parentNode)
+      return;
     return gBrowser.removeTab(tab);
+  }
 
   let window = getWindowHoldingTab(tab);
   // fennec?
-  if (window && window.BrowserApp)
+  if (window && window.BrowserApp) {
+    // Bug 699450: the tab may already have been detached
+    if (!tab.browser)
+      return;
     return window.BrowserApp.closeTab(tab);
+  }
   return null;
 }
 exports.closeTab = closeTab;
@@ -207,17 +211,18 @@ exports.getAllTabContentWindows = getAllTabContentWindows;
 
 // gets the tab containing the provided window
 function getTabForContentWindow(window) {
-  // Bug 699450: The tab may already have been detached so that following XPCOM
-  // trick is going to throw if we try using it.
-  if (!window.parent)
-    return null;
-
   // Retrieve the topmost frame container. It can be either <xul:browser>,
   // <xul:iframe/> or <html:iframe/>. But in our case, it should be xul:browser.
-  let browser = window.QueryInterface(Ci.nsIInterfaceRequestor)
-                   .getInterface(Ci.nsIWebNavigation)
-                   .QueryInterface(Ci.nsIDocShell)
-                   .chromeEventHandler;
+  let browser;
+  try {
+    browser = window.QueryInterface(Ci.nsIInterfaceRequestor)
+                    .getInterface(Ci.nsIWebNavigation)
+                    .QueryInterface(Ci.nsIDocShell)
+                    .chromeEventHandler;
+  } catch(e) {
+    // Bug 699450: The tab may already have been detached so that `window` is
+    // in a almost destroyed state and can't be queryinterfaced anymore.
+  }
 
   // Is null for toplevel documents
   if (!browser) {

--- a/test/tabs/test-firefox-tabs.js
+++ b/test/tabs/test-firefox-tabs.js
@@ -287,8 +287,11 @@ exports.testTabClose = function(test) {
     tabs.on('ready', function onReady(tab) {
       tabs.removeListener('ready', onReady);
       test.assertEqual(tabs.activeTab.url, tab.url, "tab is now the active tab");
+      let secondOnCloseCalled = false;
       tab.close(function() {
         closeBrowserWindow(window, function() {
+          test.assert(secondOnCloseCalled,
+            "The immediate second call to tab.close gots its callback fired");
           test.assertNotEqual(tabs.activeTab.url, url, "tab is no longer the active tab");
           test.done()
         });
@@ -296,10 +299,12 @@ exports.testTabClose = function(test) {
 
       // Bug 699450: Multiple calls to tab should not throw
       try {
-        tab.close();
+        tab.close(function () {
+          secondOnCloseCalled = true;
+        });
       }
       catch(e) {
-        test.fail("second call to tab.closed thrown an exception: " + e);
+        test.fail("second call to tab.close() thrown an exception: " + e);
       }
       test.assertNotEqual(tabs.activeTab.url, url, "tab is no longer the active tab");
     });


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=699450
