### PR TITLE
Bug 880524 - Ignore *-document-global-created causing oranges

### DIFF
--- a/test/test-content-events.js
+++ b/test/test-content-events.js
@@ -42,9 +42,10 @@ exports["test multiple tabs"] = function(assert, done) {
   let { on, off } = loader.require("sdk/event/core");
   let actual = [];
   on(events, "data", function({type, target, timeStamp}) {
-    // ignore about:blank pages and content-document-global-created
+    // ignore about:blank pages and *-document-global-created
     // events that are not very consistent.
     if (target.URL !== "about:blank" &&
+        type !== "chrome-document-global-created" &&
         type !== "content-document-global-created")
       actual.push(type + " -> " + target.URL)
   });
@@ -83,9 +84,10 @@ exports["test nested frames"] = function(assert, done) {
   let { on, off } = loader.require("sdk/event/core");
   let actual = [];
   on(events, "data", function({type, target, timeStamp}) {
-    // ignore about:blank pages and content-document-global-created
+    // ignore about:blank pages and *-global-created
     // events that are not very consistent.
     if (target.URL !== "about:blank" &&
+       type !== "chrome-document-global-created" &&
        type !== "content-document-global-created")
       actual.push(type + " -> " + target.URL)
   });


### PR DESCRIPTION
Ok so unlike #1025 this should actually fix the oranges. If read everything correctly now original fix did not actually did anything since I filtered "content-document-global-created" but Bug 880524 is caused by inconsistent `chrome-document-global-created` events. There for we still oranges since `chrome-document-global-created` seems to be present when they shouldn't: https://tbpl.mozilla.org/php/getParsedLog.php?id=24015116&tree=Jetpack#error0

This change put's back `content-document-global-created` events as they did not cause issues and remove `chrome-document-global-created`.

@erikvold could you please take a look and verify that I'm not missing something again ?
