### PR TITLE
Bug 746124 - Fix windows specific issues in FS module.

### DIFF
--- a/lib/sdk/io/fs.js
+++ b/lib/sdk/io/fs.js
@@ -144,6 +144,8 @@ const ReadStream = Class({
 
     let { flags, mode, position, length } = this;
     let fd = isString(path) ? openSync(path, flags, mode) : path;
+    this.fd = fd;
+
     let input = nsIFileInputStream(fd);
     // Setting a stream position, unless it"s `-1` which means current position.
     if (position >= 0)
@@ -164,6 +166,10 @@ const ReadStream = Class({
       input: binaryInputStream, pump: pump
     });
     this.read();
+  },
+  destroy: function() {
+    closeSync(this.fd);
+    InputStream.prototype.destroy.call(this);
   }
 });
 exports.ReadStream = ReadStream;
@@ -192,6 +198,8 @@ const WriteStream = Class({
     // If pass was passed we create a file descriptor out of it. Otherwise
     // we just use given file descriptor.
     let fd = isString(path) ? openSync(path, flags, mode) : path;
+    this.fd = fd;
+
     let output = nsIFileOutputStream(fd);
     // Setting a stream position, unless it"s `-1` which means current position.
     if (position >= 0)
@@ -214,6 +222,10 @@ const WriteStream = Class({
       output: binaryOutputStream,
       asyncOutputStream: asyncOutputStream
     });
+  },
+  destroy: function() {
+    closeSync(this.fd);
+    OutputStream.prototype.destroy.call(this);
   }
 });
 exports.WriteStream = WriteStream;
@@ -570,7 +582,9 @@ function readdirSync(path) {
   }
   catch (error) {
     // Adjust exception thorw to match ones thrown by node.
-    if (error.name === "NS_ERROR_FILE_TARGET_DOES_NOT_EXIST") {
+    if (error.name === "NS_ERROR_FILE_TARGET_DOES_NOT_EXIST" ||
+        error.name === "NS_ERROR_FILE_NOT_FOUND")
+    {
       let { fileName, lineNumber } = error;
       error = FSError("readdir", "ENOENT", 34, path, fileName, lineNumber);
     }
@@ -824,8 +838,8 @@ function writeFile(path, content, encoding, callback) {
       writeStream.destroy();
     });
     writeStream.write(content, function onDrain() {
-      callback(null);
       writeStream.destroy();
+      callback(null);
     });
   } catch (error) {
     callback(error);

--- a/test/test-fs.js
+++ b/test/test-fs.js
@@ -48,7 +48,7 @@ exports["test readir"] = function(assert, end) {
   async = true;
 };
 
-exports["test readir error"] = function(assert, end) {
+exports["test readdir error"] = function(assert, end) {
   var async = false;
   var path = profilePath + "-does-not-exists";
   fs.readdir(path, function(error, entries) {
@@ -445,7 +445,7 @@ exports["test fs.writeFile"] = function(assert, end) {
 
   var async = false;
   fs.writeFile(path, content, function(error) {
-    assert.ok(async, "fs write is sync");
+    assert.ok(async, "fs write is async");
     assert.ok(!error, "error is falsy");
     assert.ok(fs.existsSync(path), "file was created");
     assert.equal(fs.readFileSync(path).toString(),


### PR DESCRIPTION
It looks like on windows there were few issues:
1. Error thrown when reading non existing directory is not `NS_ERROR_FILE_TARGET_DOES_NOT_EXIST` but `NS_ERROR_FILE_NOT_FOUND` instead.
2. On unix closing `nsIBinaryInputStream` / `nsIBinaryOutputStream` closes associated `nsIFileInputStream` / `nsIFileOutputStream`, while on windows they need to be closed manually.

With this fixes all tests pass on my virtual windows and OSX.
