### PR TITLE
Fix bug 880632 - Remove the Firefox 3.6 exception in test-windows.testAc...

### DIFF
--- a/test/windows/test-firefox-windows.js
+++ b/test/windows/test-firefox-windows.js
@@ -184,12 +184,6 @@ exports.testOnOpenOnCloseListeners = function(test) {
 /*
 Disabled due to all of the Win8 PGO bustage in bug 873007.
 exports.testActiveWindow = function(test) {
-  const xulApp = require("sdk/system/xul-app");
-  if (xulApp.versionInRange(xulApp.platformVersion, "1.9.2", "1.9.2.*")) {
-    test.pass("This test is disabled on 3.6. For more information, see bug 598525");
-    return;
-  }
-
   let windows = browserWindows;
 
   // API window objects


### PR DESCRIPTION
...tiveWindow because Firefox 3.6 is nowhere close to being a supported version of Firefox
