### PR TITLE
Bug 887677 abstract out the addon-page url check

### DIFF
--- a/lib/sdk/addon-page.js
+++ b/lib/sdk/addon-page.js
@@ -37,12 +37,7 @@ WindowTracker({
     // Augmenting the behavior of `hideChromeForLocation` method, as
     // suggested by https://developer.mozilla.org/en-US/docs/Hiding_browser_chrome
     XULBrowserWindow.hideChromeForLocation = function(url) {
-      if (url.indexOf(addonURL) === 0) {
-        let rest = url.substr(addonURL.length);
-        return rest.length === 0 || ['#','?'].indexOf(rest.charAt(0)) > -1
-      }
-
-      return hideChromeForLocation.call(this, url);
+      return isAddonURL(url) || hideChromeForLocation.call(this, url);
     }
   },
 
@@ -52,8 +47,16 @@ WindowTracker({
   }
 });
 
+function isAddonURL(url) {
+  if (url.indexOf(addonURL) === 0) {
+    let rest = url.substr(addonURL.length);
+    return ((rest.length === 0) || (['#','?'].indexOf(rest.charAt(0)) > -1));
+  }
+  return false;
+}
+
 function tabFilter(tab) {
-  return getURI(tab) === addonURL;
+  return isAddonURL(getURI(tab));
 }
 
 function untrackTab(window, tab) {

--- a/test/test-addon-page.js
+++ b/test/test-addon-page.js
@@ -55,6 +55,7 @@ exports['test that add-on page has no chrome'] = function(assert, done) {
     closeTab(tab);
     assert.ok(isChromeVisible(window), 'chrome is visible again');
     loader.unload();
+    assert.ok(!isTabOpen(tab), 'add-on page tab is closed on unload');
     done();
   });
 };
@@ -79,6 +80,7 @@ exports['test that add-on page with hash has no chrome'] = function(assert, done
     closeTab(tab);
     assert.ok(isChromeVisible(window), 'chrome is visible again');
     loader.unload();
+    assert.ok(!isTabOpen(tab), 'add-on page tab is closed on unload');
     done();
   });
 };
@@ -103,6 +105,7 @@ exports['test that add-on page with querystring has no chrome'] = function(asser
     closeTab(tab);
     assert.ok(isChromeVisible(window), 'chrome is visible again');
     loader.unload();
+    assert.ok(!isTabOpen(tab), 'add-on page tab is closed on unload');
     done();
   });
 };
@@ -127,6 +130,7 @@ exports['test that add-on page with hash and querystring has no chrome'] = funct
     closeTab(tab);
     assert.ok(isChromeVisible(window), 'chrome is visible again');
     loader.unload();
+    assert.ok(!isTabOpen(tab), 'add-on page tab is closed on unload');
     done();
   });
 };
@@ -148,21 +152,6 @@ exports['test that malformed uri is not an addon-page'] = function(assert, done)
     closeTab(tab);
     loader.unload();
     done();
-  });
-};
-
-exports['test that add-on pages are closed on unload'] = function(assert, done) {
-  let { loader } = LoaderWithHookedConsole(module);
-  loader.require('sdk/addon-page');
-
-  tabs.open({
-    url: uri,
-    onReady: function listener(tab) {
-      loader.unload();
-      assert.ok(!isTabOpen(tab), 'add-on page tabs are closed on unload');
-
-      done();
-    }
   });
 };
 


### PR DESCRIPTION
I know this module is deprecated but since I'm still using it I figure I'll offer up my fixes.  I've got another one coming.

This change takes the addon-page url test that's used for hiding the chrome and brings it out into a separate function such that an addon-page which was opened by this addon will also be closed on unload.  In the tests I just removed the final test that only looked at pure addon urls and did a `isTabOpen()` check after each unload of the different urls this supports.
