### PR TITLE
Bug 887675 bind the xul window to the hideChromeForLocation function

### DIFF
--- a/lib/sdk/addon-page.js
+++ b/lib/sdk/addon-page.js
@@ -62,7 +62,7 @@ function untrackTab(window, tab) {
   let { hideChromeForLocation } = windows(window);
 
   if (hideChromeForLocation) {
-    window.XULBrowserWindow.hideChromeForLocation = hideChromeForLocation;
+    window.XULBrowserWindow.hideChromeForLocation = hideChromeForLocation.bind(window.XULBrowserWindow);
     windows(window).hideChromeForLocation = null;
   }
 


### PR DESCRIPTION
In order to avoid a "can't access dead object" TypeError we need to bind the hideChromeForLocation back to the XULBrowserWindow object.

I've been struggling to write a test for this but can't come up with anything to ensure that this function is applied correctly.  Help wanted.
