### PR TITLE
fix typo, replaced "use stirct" by "use strict"

### DIFF
--- a/test/test-content-worker.js
+++ b/test/test-content-worker.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-"use stirct";
+"use strict";
 
 const { Cc, Ci } = require("chrome");
 const { setTimeout } = require("sdk/timers");


### PR DESCRIPTION
fix typo, replaced "use stirct" by "use strict"
