### PR TITLE
Bug 885233 - Use python2 when available in activation script

### DIFF
--- a/bin/activate
+++ b/bin/activate
@@ -88,11 +88,11 @@ pyexe=python
 # If there is `python2` command available in the system use it and make
 # sure bin/cfx uses it too.
 
-if [ -n "$(command -v python2)"] ; then
+if [ -n "$(command -v python2)" ] ; then
     pyexe='python2'
     DIR=`realpath $(dirname ${BASH_SOURCE[0]})`
     if [ -z "$(grep 'python2' $DIR/cfx)" ] ; then
-        sed -ri '1 s/([^!]|^)python(\s|$)/\1python2\2/g'
+        sed -ri '1 s/([^!]|^)python(\s|$)/\1python2\2/g' "$DIR/cfx"
     fi
 fi
 


### PR DESCRIPTION
The following pull requests fixes the bug [885233](https://bugzilla.mozilla.org/show_bug.cgi?id=885233).

The general procedure is as follows:

If there is a `python2` executable present in the system the activation script will use it and change every occurrence of `python` on lines like `#!/usr/bin/env python`.

This approach has been used for long for the Arch Linux's PKGBUILD which can be found in the AUR (https://aur.archlinux.org/packages/ad/addon-sdk/PKGBUILD)

Please note that running `source bin/activate` takes a bit longer to run for the first time (around 3 seconds on my machine) but then uses the python2 executable without any delay.
