### PR TITLE
Bug 893276: Only write simple-storage to disk after it has been changed.

### DIFF
--- a/lib/sdk/simple-storage.js
+++ b/lib/sdk/simple-storage.js
@@ -9,12 +9,14 @@ module.metadata = {
 };
 
 const { Cc, Ci } = require("chrome");
-const file = require("./io/file");
+const path = require("./fs/path");
+const fs = require("./io/fs");
 const prefs = require("./preferences/service");
 const jpSelf = require("./self");
 const timer = require("./timers");
 const unload = require("./system/unload");
 const { emit, on, off } = require("./event/core");
+const { defer } = require('./core/promise');
 
 const WRITE_PERIOD_PREF = "extensions.addon-sdk.simple-storage.writePeriod";
 const WRITE_PERIOD_DEFAULT = 300000; // 5 minutes
@@ -35,6 +37,36 @@ Object.defineProperties(exports, {
   }
 });
 
+function getHash(data) {
+  let { promise, resolve } = defer();
+
+  let crypto = Cc["@mozilla.org/security/hash;1"].createInstance(Ci.nsICryptoHash);
+  crypto.init(crypto.MD5);
+
+  let listener = {
+    onStartRequest: function() { },
+
+    onDataAvailable: function(request, context, inputStream, offset, count) {
+      crypto.updateFromStream(inputStream, count);
+    },
+
+    onStopRequest: function(request, context, status) {
+      resolve(crypto.finish(false));
+    }
+  };
+
+  let converter = Cc["@mozilla.org/intl/scriptableunicodeconverter"].
+                  createInstance(Ci.nsIScriptableUnicodeConverter);
+  converter.charset = "UTF-8";
+  let stream = converter.convertToInputStream(data);
+  let pump = Cc["@mozilla.org/network/input-stream-pump;1"].
+             createInstance(Ci.nsIInputStreamPump);
+  pump.init(stream, -1, -1, 0, 0, true);
+  pump.asyncRead(listener, null);
+
+  return promise;
+}
+
 // A generic JSON store backed by a file on disk.  This should be isolated
 // enough to move to its own module if need be...
 function JsonStore(options) {
@@ -43,6 +75,7 @@ function JsonStore(options) {
   this.writePeriod = options.writePeriod;
   this.onOverQuota = options.onOverQuota;
   this.onWrite = options.onWrite;
+  this.hash = null;
 
   unload.ensure(this);
 
@@ -85,13 +118,14 @@ JsonStore.prototype = {
   purge: function JsonStore_purge() {
     try {
       // This'll throw if the file doesn't exist.
-      file.remove(this.filename);
+      fs.unlinkSync(this.filename);
+      this.hash = null;
       let parentPath = this.filename;
       do {
-        parentPath = file.dirname(parentPath);
+        parentPath = path.dirname(parentPath);
         // This'll throw if the dir isn't empty.
-        file.rmdir(parentPath);
-      } while (file.basename(parentPath) !== JETPACK_DIR_BASENAME);
+        fs.rmdirSync(parentPath);
+      } while (path.basename(parentPath) !== JETPACK_DIR_BASENAME);
     }
     catch (err) {}
   },
@@ -99,25 +133,17 @@ JsonStore.prototype = {
   // Initializes the root by reading the backing file.
   read: function JsonStore_read() {
     try {
-      let str = file.read(this.filename);
+      let str = fs.readFileSync(this.filename, "UTF-8");
 
-      // Ideally we'd log the parse error with console.error(), but logged
-      // errors cause tests to fail.  Supporting "known" errors in the test
-      // harness appears to be non-trivial.  Maybe later.
       this.root = JSON.parse(str);
+      getHash(str).then(hash => this.hash = hash);
     }
     catch (err) {
+      if (err.code != "ENOENT")
+        console.error(err);
       this.root = {};
+      this.hash = null;
     }
-  },
-
-  // If the store is under quota, writes the root to the backing file.
-  // Otherwise quota observers are notified and nothing is written.
-  write: function JsonStore_write() {
-    if (this.quotaUsage > 1)
-      this.onOverQuota(this);
-    else
-      this._write();
   },
 
   // Cleans up on unload.  If unloading because of uninstall, the store is
@@ -129,7 +155,7 @@ JsonStore.prototype = {
     if (reason === "uninstall")
       this.purge();
     else
-      this._write();
+      this.write();
   },
 
   // True if the root is an empty object.
@@ -148,31 +174,50 @@ JsonStore.prototype = {
   // Writes the root to the backing file, notifying write observers when
   // complete.  If the store is over quota or if it's empty and the store has
   // never been written, nothing is written and write observers aren't notified.
-  _write: function JsonStore__write() {
-    // Don't write if the root is uninitialized or if the store is empty and the
-    // backing file doesn't yet exist.
-    if (!this.isRootInited || (this._isEmpty && !file.exists(this.filename)))
+  write: function JsonStore_write() {
+    // Don't write if the root is uninitialized
+    if (!this.isRootInited)
       return;
 
-    // If the store is over quota, don't write.  The current under-quota state
-    // should persist.
-    if (this.quotaUsage > 1)
-      return;
+    fs.exists(this.filename, (err, exists) => {
+      // Don't write if if the store is empty and the backing file doesn't exist.
+      if (this._isEmpty && !exists)
+        return;
 
-    // Finally, write.
-    let stream = file.open(this.filename, "w");
-    try {
-      stream.writeAsync(JSON.stringify(this.root), function writeAsync(err) {
-        if (err)
-          console.error("Error writing simple storage file: " + this.filename);
-        else if (this.onWrite)
-          this.onWrite(this);
-      }.bind(this));
-    }
-    catch (err) {
-      // writeAsync closes the stream after it's done, so only close on error.
-      stream.close();
-    }
+      let data = JSON.stringify(this.root);
+
+      // If the store is over quota, don't write.  The current under-quota state
+      // should persist.
+      if ((this.quota > 0) && (data.length > this.quota)) {
+        this.onOverQuota(this);
+        return;
+      }
+
+      // Hash the data to compare it to any previously written data
+      getHash(data).then(hash => {
+        if (hash == this.hash)
+          return;
+
+        // Finally, write.
+        fs.writeFile(this.filename, data, "UTF-8", err => {
+          if (err) {
+            console.error("Error writing simple storage file: " + this.filename);
+            return;
+          }
+
+          this.hash = hash;
+
+          if (this.onWrite) {
+            try {
+              this.onWrite(this);
+            }
+            catch (e) {
+              console.exception(e);
+            }
+          }
+        });
+      });
+    });
   }
 };
 
@@ -191,7 +236,8 @@ let manager = ({
     storeFile.append(JETPACK_DIR_BASENAME);
     storeFile.append(jpSelf.id);
     storeFile.append("simple-storage");
-    file.mkpath(storeFile.path);
+    if (!fs.existsSync(storeFile.path))
+      fs.mkdirSync(storeFile.path, 0o755);
     storeFile.append("store.json");
     return storeFile.path;
   },

--- a/test/test-simple-storage.js
+++ b/test/test-simple-storage.js
@@ -6,10 +6,11 @@ const file = require("sdk/io/file");
 const prefs = require("sdk/preferences/service");
 
 const QUOTA_PREF = "extensions.addon-sdk.simple-storage.quota";
+const WRITE_PERIOD_PREF = "extensions.addon-sdk.simple-storage.writePeriod";
 
 let {Cc,Ci} = require("chrome");
 
-const { Loader } = require("sdk/test/loader");
+const { Loader, LoaderWithHookedConsole } = require("sdk/test/loader");
 const { id } = require("sdk/self");
 
 let storeFile = Cc["@mozilla.org/file/directory_service;1"].
@@ -33,12 +34,13 @@ exports.testSetGet = function (assert, done) {
     // Load the module again and make sure the value stuck.
     loader = Loader(module);
     ss = loader.require("sdk/simple-storage");
-    manager(loader).jsonStore.onWrite = function (storage) {
-      file.remove(storeFilename);
-      done();
-    };
     assert.equal(ss.storage.foo, val, "Value should persist");
+    manager(loader).jsonStore.onWrite = function (storage) {
+      assert.fail("Nothing should be written since `storage` was not changed.");
+    };
     loader.unload();
+    file.remove(storeFilename);
+    done();
   };
   let val = "foo";
   ss.storage.foo = val;
@@ -108,7 +110,7 @@ exports.testMalformed = function (assert) {
   let stream = file.open(storeFilename, "w");
   stream.write("i'm not json");
   stream.close();
-  let loader = Loader(module);
+  let { loader, messages } = LoaderWithHookedConsole(module);
   let ss = loader.require("sdk/simple-storage");
   let empty = true;
   for (let key in ss.storage) {
@@ -116,6 +118,12 @@ exports.testMalformed = function (assert) {
     break;
   }
   assert.ok(empty, "Malformed storage should cause root to be empty");
+
+  assert.equal(messages.length, 1, "Should have seen an console message");
+  assert.equal(messages[0].type, "error", "Should be an error");
+  assert.equal(String(messages[0].msg), "SyntaxError: JSON.parse: unexpected character",
+               "Should be a syntax error");
+
   loader.unload();
 };
 
@@ -141,10 +149,11 @@ exports.testQuotaExceededHandle = function (assert, done) {
       assert.equal(ss.storage.x, 4, "x value should be correct");
       assert.equal(ss.storage.y, 5, "y value should be correct");
       manager(loader).jsonStore.onWrite = function (storage) {
-        prefs.reset(QUOTA_PREF);
-        done();
+        assert.fail("Nothing should be written since `storage` was not changed.");
       };
       loader.unload();
+      prefs.reset(QUOTA_PREF);
+      done();
     };
     loader.unload();
   });
@@ -178,6 +187,9 @@ exports.testQuotaExceededNoHandle = function (assert, done) {
       assert.equal(ss.storage, val,
                        "Over-quota value should not have been written, " +
                        "old value should have persisted: " + ss.storage);
+      manager(loader).jsonStore.onWrite = function (storage) {
+        assert.fail("Nothing should be written since `storage` was not changed.");
+      };
       loader.unload();
       prefs.reset(QUOTA_PREF);
       done();
@@ -232,6 +244,167 @@ exports.testUninstall = function (assert, done) {
   loader.unload();
 };
 
+exports.testChangeInnerArray = function(assert, done) {
+  prefs.set(WRITE_PERIOD_PREF, 10);
+
+  let expected = {
+    x: [5, 7],
+    y: [7, 28],
+    z: [6, 2]
+  };
+
+  // Load the module, set a value.
+  let loader = Loader(module);
+  let ss = loader.require("sdk/simple-storage");
+  manager(loader).jsonStore.onWrite = function (storage) {
+    assert.ok(file.exists(storeFilename), "Store file should exist");
+
+    // Load the module again and check the result
+    loader = Loader(module);
+    ss = loader.require("sdk/simple-storage");
+    assert.equal(JSON.stringify(ss.storage),
+                 JSON.stringify(expected), "Should see the expected object");
+
+    // Add a property
+    ss.storage.x.push(["bar"]);
+    expected.x.push(["bar"]);
+    manager(loader).jsonStore.onWrite = function (storage) {
+      assert.equal(JSON.stringify(ss.storage),
+                   JSON.stringify(expected), "Should see the expected object");
+
+      // Modify a property
+      ss.storage.y[0] = 42;
+      expected.y[0] = 42;
+      manager(loader).jsonStore.onWrite = function (storage) {
+        assert.equal(JSON.stringify(ss.storage),
+                     JSON.stringify(expected), "Should see the expected object");
+
+        // Delete a property
+        delete ss.storage.z[1];
+        delete expected.z[1];
+        manager(loader).jsonStore.onWrite = function (storage) {
+          assert.equal(JSON.stringify(ss.storage),
+                       JSON.stringify(expected), "Should see the expected object");
+
+          // Modify the new inner-object
+          ss.storage.x[2][0] = "baz";
+          expected.x[2][0] = "baz";
+          manager(loader).jsonStore.onWrite = function (storage) {
+            assert.equal(JSON.stringify(ss.storage),
+                         JSON.stringify(expected), "Should see the expected object");
+
+            manager(loader).jsonStore.onWrite = function (storage) {
+              assert.fail("Nothing should be written since `storage` was not changed.");
+            };
+            loader.unload();
+
+            // Load the module again and check the result
+            loader = Loader(module);
+            ss = loader.require("sdk/simple-storage");
+            assert.equal(JSON.stringify(ss.storage),
+                         JSON.stringify(expected), "Should see the expected object");
+            loader.unload();
+            file.remove(storeFilename);
+            prefs.reset(WRITE_PERIOD_PREF);
+            done();
+          };
+        };
+      };
+    };
+  };
+
+  ss.storage = expected;
+  assert.equal(JSON.stringify(ss.storage),
+               JSON.stringify(expected), "Should see the expected object");
+
+  loader.unload();
+};
+
+exports.testChangeInnerObject = function(assert, done) {
+  prefs.set(WRITE_PERIOD_PREF, 10);
+
+  let expected = {
+    x: {
+      a: 5,
+      b: 7
+    },
+    y: {
+      c: 7,
+      d: 28
+    },
+    z: {
+      e: 6,
+      f: 2
+    }
+  };
+
+  // Load the module, set a value.
+  let loader = Loader(module);
+  let ss = loader.require("sdk/simple-storage");
+  manager(loader).jsonStore.onWrite = function (storage) {
+    assert.ok(file.exists(storeFilename), "Store file should exist");
+
+    // Load the module again and check the result
+    loader = Loader(module);
+    ss = loader.require("sdk/simple-storage");
+    assert.equal(JSON.stringify(ss.storage),
+                 JSON.stringify(expected), "Should see the expected object");
+
+    // Add a property
+    ss.storage.x.g = {foo: "bar"};
+    expected.x.g = {foo: "bar"};
+    manager(loader).jsonStore.onWrite = function (storage) {
+      assert.equal(JSON.stringify(ss.storage),
+                   JSON.stringify(expected), "Should see the expected object");
+
+      // Modify a property
+      ss.storage.y.c = 42;
+      expected.y.c = 42;
+      manager(loader).jsonStore.onWrite = function (storage) {
+        assert.equal(JSON.stringify(ss.storage),
+                     JSON.stringify(expected), "Should see the expected object");
+
+        // Delete a property
+        delete ss.storage.z.f;
+        delete expected.z.f;
+        manager(loader).jsonStore.onWrite = function (storage) {
+          assert.equal(JSON.stringify(ss.storage),
+                       JSON.stringify(expected), "Should see the expected object");
+
+          // Modify the new inner-object
+          ss.storage.x.g.foo = "baz";
+          expected.x.g.foo = "baz";
+          manager(loader).jsonStore.onWrite = function (storage) {
+            assert.equal(JSON.stringify(ss.storage),
+                         JSON.stringify(expected), "Should see the expected object");
+
+            manager(loader).jsonStore.onWrite = function (storage) {
+              assert.fail("Nothing should be written since `storage` was not changed.");
+            };
+            loader.unload();
+
+            // Load the module again and check the result
+            loader = Loader(module);
+            ss = loader.require("sdk/simple-storage");
+            assert.equal(JSON.stringify(ss.storage),
+                         JSON.stringify(expected), "Should see the expected object");
+            loader.unload();
+            file.remove(storeFilename);
+            prefs.reset(WRITE_PERIOD_PREF);
+            done();
+          };
+        };
+      };
+    };
+  };
+
+  ss.storage = expected;
+  assert.equal(JSON.stringify(ss.storage),
+               JSON.stringify(expected), "Should see the expected object");
+
+  loader.unload();
+};
+
 exports.testSetNoSetRead = function (assert, done) {
   // Load the module, set a value.
   let loader = Loader(module);
@@ -250,12 +423,13 @@ exports.testSetNoSetRead = function (assert, done) {
     // Load the module a third time and make sure the value stuck.
     loader = Loader(module);
     ss = loader.require("sdk/simple-storage");
-    manager(loader).jsonStore.onWrite = function (storage) {
-      file.remove(storeFilename);
-      done();
-    };
     assert.equal(ss.storage.foo, val, "Value should persist");
+    manager(loader).jsonStore.onWrite = function (storage) {
+      assert.fail("Nothing should be written since `storage` was not changed.");
+    };
     loader.unload();
+    file.remove(storeFilename);
+    done();
   };
   let val = "foo";
   ss.storage.foo = val;
@@ -276,12 +450,13 @@ function setGetRoot(assert, done, val, compare) {
     // Load the module again and make sure the value stuck.
     loader = Loader(module);
     ss = loader.require("sdk/simple-storage");
-    manager(loader).jsonStore.onWrite = function () {
-      file.remove(storeFilename);
-      done();
-    };
     assert.ok(compare(ss.storage, val), "Value should persist");
+    manager(loader).jsonStore.onWrite = function (storage) {
+      assert.fail("Nothing should be written since `storage` was not changed.");
+    };
     loader.unload();
+    file.remove(storeFilename);
+    done();
   };
   ss.storage = val;
   assert.ok(compare(ss.storage, val), "Value read should be value set");


### PR DESCRIPTION
This wraps any object or array in storage in a proxy that notifies the storage manager whenever a property changes. It uses DeferredTask to trigger a write to disk 5 minutes after the last change. I added some tests to verify inner-object and array manipulations, are there any other kinds of manipulations we need to test, I want to make sure we have the proxy handler notifying for everything.
