### PR TITLE
Bug 809362 Fix test-tab tests on Fennec

### DIFF
--- a/lib/sdk/tabs/tab-fennec.js
+++ b/lib/sdk/tabs/tab-fennec.js
@@ -54,7 +54,9 @@ const Tab = Class({
    * Changing this property will loads page under under the specified location.
    * @type {String}
    */
-  get url() getTabURL(tabNS(this).tab),
+  get url() {
+    return tabNS(this).closed ? undefined : getTabURL(tabNS(this).tab);
+  },
   set url(url) setTabURL(tabNS(this).tab, url),
 
   /**
@@ -95,6 +97,8 @@ const Tab = Class({
    * @type {Number}
    */
   get index() {
+    if (tabNS(this).closed) return undefined;
+
     let tabs = tabNS(this).window.BrowserApp.tabs;
     let tab = tabNS(this).tab;
     for (var i = tabs.length; i >= 0; i--) {
@@ -151,8 +155,11 @@ const Tab = Class({
    * Close the tab
    */
   close: function close(callback) {
-    if (callback)
-      this.once(EVENTS.close.name, callback);
+    let tab = this;
+    this.once(EVENTS.close.name, function () {
+      tabNS(tab).closed = true;
+      if (callback) callback();
+    });
 
     closeTab(tabNS(this).tab);
   },

--- a/test/test-tab.js
+++ b/test/test-tab.js
@@ -6,6 +6,7 @@
 const tabs = require("sdk/tabs"); // From addon-kit
 const windowUtils = require("sdk/deprecated/window-utils");
 const { getTabForWindow } = require('sdk/tabs/helpers');
+const app = require("sdk/system/xul-app");
 
 // The primary test tab
 var primaryTab;
@@ -122,24 +123,17 @@ exports["test behavior on close"] = function(assert, done) {
                      "After being closed, tab attributes are undefined (url)");
         assert.equal(tab.index, undefined,
                      "After being closed, tab attributes are undefined (index)");
-        // Ensure that we can call destroy multiple times without throwing
-        tab.destroy();
-        tab.destroy();
+        if (app.is("Firefox")) {
+          // Ensure that we can call destroy multiple times without throwing;
+          // Fennec doesn't use this internal utility
+          tab.destroy();
+          tab.destroy();
+        }
 
         done();
       });
     }
   });
 };
-
-if (require("sdk/system/xul-app").is("Fennec")) {
-  module.exports = {
-    "test Unsupported Test": function UnsupportedTest (assert) {
-        assert.pass(
-          "Skipping this test until Fennec support is implemented." +
-          "See Bug 809362");
-    }
-  }
-}
 
 require("test").run(exports);


### PR DESCRIPTION
make properties undefined after closing tab, don't use internal utilities in test where not supported (`destroy`)
