### PR TITLE
Bug 893276: Only write simple-storage to disk after it has been changed.

### DIFF
--- a/lib/sdk/simple-storage.js
+++ b/lib/sdk/simple-storage.js
@@ -135,14 +135,12 @@ JsonStore.prototype = {
     try {
       let str = fs.readFileSync(this.filename, "UTF-8");
 
-      // Ideally we'd log the parse error with console.error(), but logged
-      // errors cause tests to fail.  Supporting "known" errors in the test
-      // harness appears to be non-trivial.  Maybe later.
       this.root = JSON.parse(str);
-      let self = this;
       getHash(str).then(hash => this.hash = hash);
     }
     catch (err) {
+      if (err.code != "ENOENT")
+        console.error(err);
       this.root = {};
       this.hash = null;
     }
@@ -204,8 +202,12 @@ JsonStore.prototype = {
         fs.writeFile(this.filename, data, "UTF-8", err => {
           if (err) {
             console.error("Error writing simple storage file: " + this.filename);
+            return;
           }
-          else if (this.onWrite) {
+
+          this.hash = hash;
+
+          if (this.onWrite) {
             try {
               this.onWrite(this);
             }
@@ -213,7 +215,6 @@ JsonStore.prototype = {
               console.exception(e);
             }
           }
-          this.hash = hash;
         });
       });
     });


### PR DESCRIPTION
This uses an asynchronous hash function to only write when the data is changed. I've used MD5 because it's cheap to calculate and we don't care much about collisions.
