### PR TITLE
Bug 898229 - Add support for getting a list of globals for an addon.

### DIFF
--- a/lib/toolkit/loader.js
+++ b/lib/toolkit/loader.js
@@ -233,6 +233,10 @@ const load = iced(function load(loader, module) {
     wantXrays: false
   });
 
+  let subject = { sandbox: sandbox, module: module };
+  subject.wrappedJSObject = subject;
+  notifyObservers(subject, 'sdk:loader:new-sandbox', null);
+
   try {
     evaluate(sandbox, module.uri);
   } catch (error) {
@@ -379,6 +383,15 @@ const unload = iced(function unload(loader, reason) {
   notifyObservers(subject, 'sdk:loader:destroy', reason);
 });
 exports.unload = unload;
+
+const getSandboxes = iced(function getSandboxes(loader) {
+  let sandboxes = {};
+  for(let name of Object.keys(loader.sandboxes)) {
+    sandboxes[name] = loader.sandboxes[name];
+  }
+  return sandboxes;
+});
+exports.getSandboxes = getSandboxes;
 
 // Function makes new loader that can be used to load CommonJS modules
 // described by a given `options.manifest`. Loader takes following options:

--- a/test/test-loader.js
+++ b/test/test-loader.js
@@ -4,7 +4,12 @@
 
 'use strict';
 
-let { Loader, main, unload, parseStack } = require('toolkit/loader');
+let { Loader, main, unload, parseStack, getSandboxes } =
+  require('toolkit/loader');
+
+const { Cc, Ci, Cu } = require("chrome");
+const { notifyObservers, addObserver } =
+  Cc['@mozilla.org/observer-service;1'].getService(Ci.nsIObserverService);
 
 let root = module.uri.substr(0, module.uri.lastIndexOf('/'))
 
@@ -139,6 +144,45 @@ exports['test early errors in module'] = function(assert) {
   } finally {
     unload(loader);
   }
+}
+
+exports['test getSandboxes'] = function(assert) {
+  let uri = root + '/fixtures/loader/cycles/';
+  let loader = Loader({ paths: { '': uri } });
+  let program = main(loader, 'main');
+  
+  let sandboxes = getSandboxes(loader);
+  assert.ok(Object.keys(sandboxes).every(function(uri) {
+    return uri.contains('cycles/main.js') ||
+      uri.contains('cycles/a.js') ||
+      uri.contains('cycles/b.js') ||
+      uri.contains('cycles/c.js');
+  }), "getSandboxes reports all, and only, modules from the addon");
+
+  unload(loader);
+}
+
+exports['test new sandbox notification'] = function(assert) {
+  let uri = root + '/fixtures/loader/sandbox-notification/';
+  let loader = Loader({ paths: { '': uri } });
+  let program = main(loader, 'main');
+  let loadedModules = [];
+
+  addObserver(function(eventData) {
+    let module = eventData.wrappedJSObject.module;
+    loadedModules.push(module.uri);
+  }, 'sdk:loader:new-sandbox', false);
+
+  // This notification is handled in main.js inside the fixture.
+  notifyObservers(null, 'test:test-loader:new-sandbox-notification:go-ahead',
+    null);
+
+  // This also ensures that the notification is issued before a module is
+  // evaluated.
+  assert.ok(loadedModules[0].contains('sandbox-notification/a.js'),
+    'modue a.js should be loaded');
+  assert.ok(loadedModules[1].contains('sandbox-notification/b.js'),
+    'modue b.js should be loaded');
 }
 
 require('test').run(exports);


### PR DESCRIPTION
This pull request both adds a function to retrieve a list of sandboxes loaded by a module, and also enables dynamic notifications for newly loaded modules.
