### PR TITLE
Bug 892193 - Make strip-sdk a default.

### DIFF
--- a/python-lib/cuddlefish/__init__.py
+++ b/python-lib/cuddlefish/__init__.py
@@ -172,7 +172,7 @@ parser_groups = (
         (("", "--strip-sdk",), dict(dest="bundle_sdk",
                                     help=("Do not ship SDK modules in the xpi"),
                                     action="store_false",
-                                    default=True,
+                                    default=False,
                                     cmds=['run', 'test', 'testex', 'testpkgs',
                                           'testall', 'xpi'])),
         (("", "--force-use-bundled-sdk",), dict(dest="force_use_bundled_sdk",
@@ -564,7 +564,7 @@ def initializer(env_root, args, out=sys.stdout, err=sys.stderr):
         print >>out, 'Do "cfx test" to test it and "cfx run" to try it.  Have fun!'
     else:
         print >>out, '\nYour sample add-on is now ready in the \'' + args[1] +  '\' directory.'
-        print >>out, 'Change to that directory, then do "cfx test" to test it, \nand "cfx run" to try it.  Have fun!' 
+        print >>out, 'Change to that directory, then do "cfx test" to test it, \nand "cfx run" to try it.  Have fun!'
     return {"result":0, "jid":jid}
 
 def buildJID(target_cfg):
@@ -593,7 +593,7 @@ def run(arguments=sys.argv[1:], target_cfg=None, pkg_cfg=None,
     (options, args) = parse_args(**parser_kwargs)
 
     config_args = get_config_args(options.config, env_root);
-    
+
     # reparse configs with arguments from local.json
     if config_args:
         parser_kwargs['arguments'] += config_args

--- a/python-lib/cuddlefish/tests/test_linker.py
+++ b/python-lib/cuddlefish/tests/test_linker.py
@@ -188,16 +188,13 @@ class Contents(unittest.TestCase):
                 self.failUnlessEqual(e.args[0], 0)
             zf = zipfile.ZipFile("seven.xpi", "r")
             names = zf.namelist()
-            # the first problem found in bug 664840 was that cuddlefish.js
-            # (the loader) was stripped out on windows, due to a /-vs-\ bug
-            self.assertIn("resources/addon-sdk/lib/sdk/loader/cuddlefish.js", names)
-            # the second problem found in bug 664840 was that an addon
+            # problem found in bug 664840 was that an addon
             # without an explicit tests/ directory would copy all files from
             # the package into a bogus JID-PKGNAME-tests/ directory, so check
             # for that
             testfiles = [fn for fn in names if "seven/tests" in fn]
             self.failUnlessEqual([], testfiles)
-            # the third problem was that data files were being stripped from
+            # another problem was that data files were being stripped from
             # the XPI. Note that data/ is only supposed to be included if a
             # module that actually gets used does a require("self") .
             self.assertIn("resources/seven/data/text.data",


### PR DESCRIPTION
Make --strip-sdk a default
