### PR TITLE
Bug 891224 - sidebar tests fail: check for getAttribute("checked")=='false' rather than empty string

### DIFF
--- a/test/addons/private-browsing-supported/sidebar/utils.js
+++ b/test/addons/private-browsing-supported/sidebar/utils.js
@@ -78,3 +78,10 @@ function getWidget(buttonId, window = getMostRecentBrowserWindow()) {
   return widgets[0].forWindow(window);
 };
 exports.getWidget = getWidget;
+
+// OSX and Windows exhibit different behaviors when 'checked' is false,
+// so compare against the consistent 'true'. See bug 894809.
+function isChecked(node) {
+  return node.getAttribute('checked') === 'true';
+};
+exports.isChecked = isChecked;

--- a/test/addons/private-browsing-supported/test-sidebar.js
+++ b/test/addons/private-browsing-supported/test-sidebar.js
@@ -21,7 +21,7 @@ const { URL } = require('sdk/url');
 
 const { BLANK_IMG, BUILTIN_SIDEBAR_MENUITEMS, isSidebarShowing,
         getSidebarMenuitems, getExtraSidebarMenuitems, makeID, simulateCommand,
-        simulateClick, getWidget } = require('./sidebar/utils');
+        simulateClick, getWidget, isChecked } = require('./sidebar/utils');
 
 exports.testSideBarIsInNewPrivateWindows = function(assert, done) {
   const { Sidebar } = require('sdk/ui/sidebar');
@@ -140,7 +140,7 @@ exports.testDestroyEdgeCaseBugWithPrivateWindow = function(assert, done) {
           let sidebarMI = getSidebarMenuitems();
           for each (let mi in sidebarMI) {
             assert.ok(BUILTIN_SIDEBAR_MENUITEMS.indexOf(mi.getAttribute('id')) >= 0, 'the menuitem is for a built-in sidebar')
-            assert.equal(mi.getAttribute('checked'), 'false', 'no sidebar menuitem is checked');
+            assert.ok(!isChecked(mi), 'no sidebar menuitem is checked');
           }
           assert.ok(!window.document.getElementById(makeID(testName)), 'sidebar id DNE');
           assert.equal(isSidebarShowing(window), false, 'the sidebar is not showing');
@@ -172,8 +172,7 @@ exports.testShowInPrivateWindow = function(assert, done) {
 
   assert.equal(sidebar1.url, url, 'url getter works');
   assert.equal(isShowing(sidebar1), false, 'the sidebar is not showing');
-  assert.equal(window1.document.getElementById(menuitemID).getAttribute('checked'),
-               'false',
+  assert.ok(!isChecked(window1.document.getElementById(menuitemID)),
                'the menuitem is not checked');
   assert.equal(isSidebarShowing(window1), false, 'the new window sidebar is not showing');
 

--- a/test/sidebar/utils.js
+++ b/test/sidebar/utils.js
@@ -84,3 +84,10 @@ function getWidget(buttonId, window = getMostRecentBrowserWindow()) {
   return widgets[0].forWindow(window);
 };
 exports.getWidget = getWidget;
+
+// OSX and Windows exhibit different behaviors when 'checked' is false,
+// so compare against the consistent 'true'. See bug 894809.
+function isChecked(node) {
+  return node.getAttribute('checked') === 'true';
+};
+exports.isChecked = isChecked;

--- a/test/test-ui-sidebar-private-browsing.js
+++ b/test/test-ui-sidebar-private-browsing.js
@@ -21,7 +21,7 @@ const { URL } = require('sdk/url');
 
 const { BLANK_IMG, BUILTIN_SIDEBAR_MENUITEMS, isSidebarShowing,
         getSidebarMenuitems, getExtraSidebarMenuitems, makeID, simulateCommand,
-        simulateClick, getWidget } = require('./sidebar/utils');
+        simulateClick, getWidget, isChecked } = require('./sidebar/utils');
 
 exports.testSideBarIsNotInNewPrivateWindows = function(assert, done) {
   const { Sidebar } = require('sdk/ui/sidebar');
@@ -132,7 +132,7 @@ exports.testDestroyEdgeCaseBugWithPrivateWindow = function(assert, done) {
           let sidebarMI = getSidebarMenuitems();
           for each (let mi in sidebarMI) {
             assert.ok(BUILTIN_SIDEBAR_MENUITEMS.indexOf(mi.getAttribute('id')) >= 0, 'the menuitem is for a built-in sidebar')
-            assert.equal(mi.getAttribute('checked'), 'false', 'no sidebar menuitem is checked');
+            assert.ok(!isChecked(mi), 'no sidebar menuitem is checked');
           }
           assert.ok(!window.document.getElementById(makeID(testName)), 'sidebar id DNE');
           assert.equal(isSidebarShowing(window), false, 'the sidebar is not showing');
@@ -164,8 +164,7 @@ exports.testShowInPrivateWindow = function(assert, done) {
 
   assert.equal(sidebar1.url, url, 'url getter works');
   assert.equal(isShowing(sidebar1), false, 'the sidebar is not showing');
-  assert.equal(document.getElementById(makeID(sidebar1.id)).getAttribute('checked'),
-               'false',
+  assert.ok(!isChecked(document.getElementById(makeID(sidebar1.id))),
                'the menuitem is not checked');
   assert.equal(isSidebarShowing(window), false, 'the new window sidebar is not showing');
 


### PR DESCRIPTION
Uniform the sidebar testcases for `getAttribute('checked')` where in some platform returns `false` and in others an empty string (in case of `false` the attribute is just removed).
See: https://bugzilla.mozilla.org/show_bug.cgi?id=894809
