### PR TITLE
Bug 903115: Many context-menu tests timeout on tinderbox.

### DIFF
--- a/test/test-context-menu.js
+++ b/test/test-context-menu.js
@@ -3144,9 +3144,7 @@ exports.testSelectionInOuterFrameNoMatch = function (test) {
 // WARNING: This looks up items in popups by comparing labels, so don't give two
 // items the same label.
 function TestHelper(test) {
-  // default waitUntilDone timeout is 10s, which is too short on the win7
-  // buildslave
-  test.waitUntilDone(30*1000);
+  test.waitUntilDone();
   this.test = test;
   this.loaders = [];
   this.browserWindow = Cc["@mozilla.org/appshell/window-mediator;1"].


### PR DESCRIPTION
A long long time ago we _increased_ the context-menu test timeout to 30s, back when the global default was 10s. The global default is now 5 minutes, we should just use that.
