### PR TITLE
Bug 865391 - Intermittent Jetpack TEST-UNEXPECTED-FAIL | unknown | Test ...

### DIFF
--- a/python-lib/cuddlefish/runner.py
+++ b/python-lib/cuddlefish/runner.py
@@ -35,7 +35,7 @@ RUN_TIMEOUT = 1.5 * 60 * 60 # 1.5 Hour
 # Maximum time we'll wait for tests to emit output, in seconds.
 # The purpose of this timeout is to recover from hangs.  It should be longer
 # than the amount of time any test takes to report results.
-OUTPUT_TIMEOUT = 60 # one minute
+OUTPUT_TIMEOUT = 60 * 5 # five minutes
 
 def follow_file(filename):
     """


### PR DESCRIPTION
...output exceeded timeout (60s)

Increased the timeout from 1 minute to 5 minutes - hoping it would be enough

It seems that the failure happens before any test is actually running – that's why the "unknown" part in the error message –, so basically it seems that from when runner.py is executed, to the accessing at the log file for the first time, on try server, sometimes, a minute is passed.

I have no past experience on try server, but gabor said that it could be that it hangs for minutes. It could be also because some sync I/O operation, I don't know. There is no actually test to fix or disable here, so my blind shot is just increase the output's timeout and see if it's actually depends by slowness of try server machine or not.
