### PR TITLE
Bug 689291 test-tabs.test window focus changes active tab | Test output exceeded timeout (60s)

### DIFF
--- a/test/tabs/test-firefox-tabs.js
+++ b/test/tabs/test-firefox-tabs.js
@@ -834,18 +834,29 @@ exports.testAttachUnwrapped = function (test) {
 
 exports['test window focus changes active tab'] = function(test) {
   test.waitUntilDone();
+
+  let url1 = "data:text/html;charset=utf-8," + encodeURIComponent("test window focus changes active tab</br><h1>Window #1");
+
   let win1 = openBrowserWindow(function() {
+    test.pass("window 1 is open");
+
     let win2 = openBrowserWindow(function() {
-      tabs.on("activate", function onActivate() {
+      test.pass("window 2 is open");
+
+      tabs.on("activate", function onActivate(tab) {
         tabs.removeListener("activate", onActivate);
         test.pass("activate was called on windows focus change.");
-        closeBrowserWindow(win1, function() {
-          closeBrowserWindow(win2, function() { test.done(); });
-        });
+        test.assertEqual(tab.url, url1, 'the activated tab url is correct');
+
+        close(win2).then(function() {
+          test.pass('window 2 was closed');
+          return close(win1);
+        }).then(test.done.bind(test));
       });
+
       win1.focus();
     }, "data:text/html;charset=utf-8,test window focus changes active tab</br><h1>Window #2");
-  }, "data:text/html;charset=utf-8,test window focus changes active tab</br><h1>Window #1");
+  }, url1);
 };
 
 exports['test ready event on new window tab'] = function(test) {


### PR DESCRIPTION
- Using a safer method to close the window
- Adding some more test asserts so that we have more information if there continue to be failures
