### PR TITLE
Bug 899630 - Intermittent Jetpack tests/test-tabs.testTabsEvent_onCloseWindow

### DIFF
--- a/test/tabs/test-firefox-tabs.js
+++ b/test/tabs/test-firefox-tabs.js
@@ -519,7 +519,7 @@ exports.testTabsEvent_onCloseWindow = function(test) {
     });
 
     function beginCloseWindow() {
-      closeBrowserWindow(window, function testFinished() {
+      close(window).then(function() {
         tabs.removeListener("close", listener);
 
         test.assertEqual(closeCount, 4, "Correct number of close events received");


### PR DESCRIPTION
- Using a safer method to close windows
