### PR TITLE
Bug 901744 more asserts for tests/test-window-events.test browser events

### DIFF
--- a/test/test-window-events.js
+++ b/test/test-window-events.js
@@ -21,8 +21,19 @@ exports["test browser events"] = function(assert, done) {
 
   on(events, "data", function handler(e) {
     actual.push(e);
-    if (e.type === "load") window.close();
-    if (e.type === "close") {
+
+    if (e.type === "open") {
+      assert.pass("window open has occured");
+    }
+    else if (e.type === "DOMContentLoaded") {
+      assert.pass("window DOMContentLoaded has occured");
+    }
+    else if (e.type === "load") {
+      assert.pass("window load has occured");
+      window.close();
+    }
+    else if (e.type === "close") {
+      // confirm the ordering of events
       let [ open, ready, load, close ] = actual;
       assert.equal(open.type, "open")
       assert.equal(open.target, window, "window is open")


### PR DESCRIPTION
This should give us some more information about where window-events is hanging, if it happens again.
