### PR TITLE
Bug 858965 - Intermittent Jetpack tests/test-tabs.testOnLoadEventWithImage | Test output exceeded timeout (60s)

### DIFF
--- a/test/tabs/test-firefox-tabs.js
+++ b/test/tabs/test-firefox-tabs.js
@@ -13,10 +13,7 @@ const { StringBundle } = require('sdk/deprecated/app-strings');
 const tabs = require('sdk/tabs');
 const { browserWindows } = require('sdk/windows');
 
-const base64png = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYA" +
-                  "AABzenr0AAAASUlEQVRYhe3O0QkAIAwD0eyqe3Q993AQ3cBSUKpygfsNTy" +
-                  "N5ugbQpK0BAADgP0BRDWXWlwEAAAAAgPsA3rzDaAAAAHgPcGrpgAnzQ2FG" +
-                  "bWRR9AAAAABJRU5ErkJggg%3D%3D";
+const base64png = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWNgYGBgAA";
 
 // Bug 682681 - tab.title should never be empty
 exports.testBug682681_aboutURI = function(assert, done) {
@@ -864,50 +861,45 @@ exports['test unique tab ids'] = function(assert, done) {
 
 // related to Bug 671305
 exports.testOnLoadEventWithDOM = function(assert, done) {
-  openBrowserWindow(function(window, browser) {
-    let count = 0;
-    tabs.on('load', function onLoad(tab) {
-      assert.equal(tab.title, 'tab', 'tab passed in as arg, load called');
-      if (!count++) {
-        tab.reload();
+  let count = 0;
+  let title = 'testOnLoadEventWithDOM';
+
+  // open a about: url
+  tabs.open({
+    url: 'data:text/html;charset=utf-8,<title>' + title + '</title>',
+    inBackground: true,
+    onLoad: function(tab) {
+      assert.equal(tab.title, title, 'tab passed in as arg, load called');
+
+      if (++count > 1) {
+        assert.pass('onLoad event called on reload');
+        tab.close(done);
       }
       else {
-        // end of test
-        tabs.removeListener('load', onLoad);
-        assert.pass('onLoad event called on reload');
-        close(window).then(done);
+        assert.pass('first onLoad event occured');
+        tab.reload();
       }
-    });
-
-    // open a about: url
-    tabs.open({
-      url: 'data:text/html;charset=utf-8,<title>tab</title>',
-      inBackground: true
-    });
+    }
   });
 };
 
 // related to Bug 671305
 exports.testOnLoadEventWithImage = function(assert, done) {
-  openBrowserWindow(function(window, browser) {
-    let count = 0;
-    tabs.on('load', function onLoad(tab) {
-      if (!count++) {
-        tab.reload();
+  let count = 0;
+
+  tabs.open({
+    url: base64png,
+    inBackground: true,
+    onLoad: function(tab) {
+      if (++count > 1) {
+        assert.pass('onLoad event called on reload with image');
+        tab.close(done);
       }
       else {
-        // end of test
-        tabs.removeListener('load', onLoad);
-        assert.pass('onLoad event called on reload with image');
-        close(window).then(done);
+        assert.pass('first onLoad event occured');
+        tab.reload();
       }
-    });
-
-    // open a image url
-    tabs.open({
-      url: base64png,
-      inBackground: true
-    });
+    }
   });
 };
 

--- a/test/test-clipboard.js
+++ b/test/test-clipboard.js
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 "use strict";
 
 require("sdk/clipboard");


### PR DESCRIPTION
- Removing use of weird and unnecessary window opener function
- Using a smaller image
- Adding more asserts so that if the intermittent failure occurs again then we have more information for debugging
