### PR TITLE
Bug 905516 - This mitigates problem by making intention explicit.

### DIFF
--- a/lib/method/core.js
+++ b/lib/method/core.js
@@ -99,7 +99,7 @@ function Method(hint) {
                  // in the host object's prototype chain. This avoids memory
                  // leaks that otherwise could happen when saving JS objects
                  // on host object.
-                 host[value["!" + name]] ||
+                 host[value["!" + name] || void(0)] ||
                  // Otherwise attempt to lookup implementation for builtins by
                  // a type of the value. This basically makes sure that all
                  // non primitive values will delegate to an `Object`.


### PR DESCRIPTION
Erik this is solution very similar to yours, it just makes it explicit that code intentionally passes undefined. Also while it's not a constraint to SDK, method lib performance is very much constraint for other users and this saves one lookup.
