### PR TITLE
Bug 886329 - drop-down list in Jetpack add-on breaks entire UI in Aurora (23.0a2)

### DIFF
--- a/lib/sdk/panel/utils.js
+++ b/lib/sdk/panel/utils.js
@@ -236,7 +236,12 @@ function make(document) {
   let viewFrame = createFrame(panel, frameOptions);
   setupPanelFrame(viewFrame);
 
-  function onDisplayChange({type}) {
+  function onDisplayChange({type, target}) {
+    // Events from child element like <select /> may propagate (dropdowns are
+    // popups too), in which case frame loader shouldn't be swapped.
+    // See Bug 886329
+    if (target !== this) return;
+
     try { swapFrameLoaders(backgroundFrame, viewFrame); }
     catch(error) { console.exception(error); }
     events.emit(type, { subject: panel });

--- a/lib/sdk/window/helpers.js
+++ b/lib/sdk/window/helpers.js
@@ -5,7 +5,8 @@
 
 const { defer } = require('../core/promise');
 const events = require('../system/events');
-const { open: openWindow, onFocus, getToplevelWindow } = require('./utils');
+const { open: openWindow, onFocus, getToplevelWindow,
+        isInteractive } = require('./utils');
 
 function open(uri, options) {
   return promise(openWindow.apply(null, arguments), 'load');
@@ -35,6 +36,18 @@ function focus(window) {
   return p;
 }
 exports.focus = focus;
+
+function ready(window) {
+  let { promise: result, resolve } = defer();
+
+  if (isInteractive(window))
+    resolve(window);
+  else
+    resolve(promise(window, 'DOMContentLoaded'));
+
+  return result;
+}
+exports.ready = ready;
 
 function promise(target, evt, capture) {
   let deferred = defer();


### PR DESCRIPTION
- Ignored `popupshowing` events are not emitted by panel
- Added unit test
- Added `ready` helper function
