### PR TITLE
Bug 910190 - Fix jetpack test failures in test-ui-button.js, r?zer0

### DIFF
--- a/test/test-ui-button.js
+++ b/test/test-ui-button.js
@@ -20,8 +20,8 @@ function getWidget(buttonId, window = getMostRecentBrowserWindow()) {
   const { CustomizableUI } = Cu.import('resource:///modules/CustomizableUI.jsm', {});
   const { AREA_NAVBAR } = CustomizableUI;
 
-  let widgets = CustomizableUI.getWidgetsInArea(AREA_NAVBAR).
-    filter(({id}) => id.startsWith('button--') && id.endsWith(buttonId));
+  let widgets = CustomizableUI.getWidgetIdsInArea(AREA_NAVBAR).
+    filter((id) => id.startsWith('button--') && id.endsWith(buttonId));
 
   if (widgets.length === 0)
     throw new Error('Widget with id `' + id +'` not found.');
@@ -29,7 +29,7 @@ function getWidget(buttonId, window = getMostRecentBrowserWindow()) {
   if (widgets.length > 1)
     throw new Error('Unexpected number of widgets: ' + widgets.length)
 
-  return widgets[0].forWindow(window);
+  return CustomizableUI.getWidget(widgets[0]).forWindow(window);
 };
 
 exports['test basic constructor validation'] = function(assert) {


### PR DESCRIPTION
So the reason this breaks right now is because you leave a bunch of jetpack widgets in the placements (a la currentset) for the navbar, which have already been deleted. Getting the widget objects in the area then returns a list that contains nulls. The code uses a destructuring assignment to {id}, which blows up with a cryptic error message: "  is null". Once you've got this all figured out, this makes sense, but I'll file a bug on the JS engine to provide a better exception in these cases, as this kind of sucks.

Anyhow. This is the simplest thing I could think of to avoid this problem - simply ask only for the ids, which is all you need anyway, and then get the widget for the one you care about.
