### PR TITLE
Bug 911498 Fix circular require in page-mod/match-pattern.js

### DIFF
--- a/lib/sdk/page-mod/match-pattern.js
+++ b/lib/sdk/page-mod/match-pattern.js
@@ -2,4 +2,4 @@ let { deprecateUsage } = require("../util/deprecate");
 
 deprecateUsage("Module 'sdk/page-mod/match-pattern' is deprecated use 'sdk/util/match-pattern' instead");
 
-module.exports = require("../page-mod/match-pattern");
+module.exports = require("../util/match-pattern");


### PR DESCRIPTION
This should refer to util/match-pattern.js instead, so that
existing code using page-mod/match-pattern doesn't break.
