### PR TITLE
fixes bug 910304

### DIFF
--- a/lib/sdk/addon/runner.js
+++ b/lib/sdk/addon/runner.js
@@ -112,6 +112,7 @@ function startup(reason, options) {
     }).then(function() {
       run(options);
     }).then(null, console.exception);
+    return void 0; // otherwise we raise a warning, see bug 910304
 }
 
 function run(options) {

--- a/lib/toolkit/loader.js
+++ b/lib/toolkit/loader.js
@@ -330,6 +330,7 @@ const resolveURI = iced(function resolveURI(id, mapping) {
     if (id.indexOf(path) === 0)
       return normalize(id.replace(path, uri));
   }
+  return void 0; // otherwise we raise a warning, see bug 910304
 });
 exports.resolveURI = resolveURI;
 


### PR DESCRIPTION
These functions raise warnings because they do not always return a value. The fix is to return undefined in the worst case scenario.
