### PR TITLE
920346 - Setting PYTHONPATH to original value even if original was blank.

### DIFF
--- a/bin/activate
+++ b/bin/activate
@@ -25,11 +25,9 @@ deactivate () {
         unset _OLD_VIRTUAL_PS1
     fi
 
-    if [ -n "$_OLD_PYTHONPATH" ] ; then
-        PYTHONPATH="$_OLD_PYTHONPATH"
-        export PYTHONPATH
-        unset _OLD_PYTHONPATH
-    fi
+    PYTHONPATH="$_OLD_PYTHONPATH"
+    export PYTHONPATH
+    unset _OLD_PYTHONPATH
 
     unset CUDDLEFISH_ROOT
 


### PR DESCRIPTION
At first glance, the bat scripts shouldn't have this issue, but I have not verified that. 

https://bugzilla.mozilla.org/show_bug.cgi?id=920346
