### PR TITLE
Bug 924500: Use outer-window-destroyed to detect when a window has been completely closed.

### DIFF
--- a/lib/sdk/window/helpers.js
+++ b/lib/sdk/window/helpers.js
@@ -5,9 +5,9 @@
 
 const { defer } = require('../core/promise');
 const events = require('../system/events');
-const { setImmediate } = require('../timers');
 const { open: openWindow, onFocus, getToplevelWindow,
-        isInteractive } = require('./utils');
+        isInteractive, getOuterId } = require('./utils');
+const { Ci } = require("chrome");
 
 function open(uri, options) {
   return promise(openWindow.apply(null, arguments), 'load');
@@ -15,19 +15,14 @@ function open(uri, options) {
 exports.open = open;
 
 function close(window) {
-  // We shouldn't wait for unload, as it is dispatched
-  // before the window is actually closed. 'domwindowclosed' isn't great either,
-  // because it's fired midway through window teardown (see bug 874502
-  // comment 15). We could go with xul-window-destroyed, but _that_ doesn't
-  // provide us with a subject by which to disambiguate notifications. So we
-  // end up just doing the dumb thing and round-tripping through the event loop
-  // with setImmediate.
   let deferred = defer();
   let toplevelWindow = getToplevelWindow(window);
-  events.on("domwindowclosed", function onclose({subject}) {
-    if (subject == toplevelWindow) {
-      events.off("domwindowclosed", onclose);
-      setImmediate(function() deferred.resolve(window));
+  let outerId = getOuterId(toplevelWindow);
+  events.on("outer-window-destroyed", function onclose({subject}) {
+    let id = subject.QueryInterface(Ci.nsISupportsPRUint64).data;
+    if (id == outerId) {
+      events.off("outer-window-destroyed", onclose);
+      deferred.resolve();
     }
   }, true);
   window.close();


### PR DESCRIPTION
Rather than using the setImmediate hack added by bug 874502 wait for the window to close completely. A minor API change here, we can't resolve the promise with the window because it is now dead and any attempt to use it throws an exception. All tests seem to pass with this change though.
