### PR TITLE
Bug 821065 - Add wildcard event listeners, remove hacks that were work a...

### DIFF
--- a/lib/sdk/event/core.js
+++ b/lib/sdk/event/core.js
@@ -93,8 +93,7 @@ function emit(target, type, message /*, ...*/) {
  * as lazy array of return values of listeners for the `emit` with the given
  * arguments.
  */
-emit.lazy = function lazy(target, type, message /*, ...*/) {
-  let args = Array.slice(arguments, 2);
+emit.lazy = function lazy(target, type, ...args) {
   let state = observers(target, type);
   let listeners = state.slice();
   let index = 0;
@@ -102,7 +101,7 @@ emit.lazy = function lazy(target, type, message /*, ...*/) {
 
   // If error event and there are no handlers then print error message
   // into a console.
-  if (count === 0 && type === 'error') console.exception(message);
+  if (count === 0 && type === 'error') console.exception(args[0]);
   while (index < count) {
     try {
       let listener = listeners[index];
@@ -117,6 +116,8 @@ emit.lazy = function lazy(target, type, message /*, ...*/) {
     }
     index = index + 1;
   }
+   // Also emit on `"*"` so that one could listen for all events.
+  if (type !== '*') emit(target, '*', type, ...args);
 }
 exports.emit = emit;
 

--- a/lib/sdk/worker/utils.js
+++ b/lib/sdk/worker/utils.js
@@ -76,9 +76,6 @@ function Worker(options) {
   ["pageshow", "pagehide", "detach", "message", "error"].forEach(function(key) {
     trait.on(key, function() {
       emit.apply(emit, [worker, key].concat(Array.slice(arguments)));
-      // Workaround lack of ability to listen on all events by emulating
-      // such ability. This will become obsolete once Bug 821065 is fixed.
-      emit.apply(emit, [worker, "*", key].concat(Array.slice(arguments)));
     });
   });
   traits.set(worker, trait);

--- a/test/test-event-core.js
+++ b/test/test-event-core.js
@@ -241,4 +241,24 @@ exports['test emit.lazy'] = function(assert) {
   assert.deepEqual(errors, [ boom ], 'errors reporetd');
 };
 
+exports['test listen to all events'] = function(assert) {
+  let actual = [];
+  let target = {};
+
+  on(target, 'foo', message => actual.push(message));
+  on(target, '*', (type, ...message) => {
+    actual.push([type].concat(message));
+  });
+ 
+  emit(target, 'foo', 'hello');
+  assert.equal(actual[0], 'hello',
+    'non-wildcard listeners still work');
+  assert.deepEqual(actual[1], ['foo', 'hello'],
+    'wildcard listener called');
+
+  emit(target, 'bar', 'goodbye');
+  assert.deepEqual(actual[2], ['bar', 'goodbye'],
+    'wildcard listener called for unbound event name');
+};
+
 require('test').run(exports);

--- a/test/test-page-worker.js
+++ b/test/test-page-worker.js
@@ -245,15 +245,14 @@ exports.testMultipleOnMessageCallbacks = function(assert, done) {
   let page = Page({
     contentScript: "self.postMessage('')",
     contentScriptWhen: "end",
-    onMessage: function() count += 1
+    onMessage: () => count += 1
   });
-  page.on('message', function() count += 2);
-  page.on('message', function() count *= 3);
-  page.on('message', function()
+  page.on('message', () => count += 2);
+  page.on('message', () => count *= 3);
+  page.on('message', () =>
     assert.equal(count, 9, "All callbacks were called, in order."));
-  page.on('message', function() done());
-
-}
+  page.on('message', done);
+};
 
 exports.testLoadContentPage = function(assert, done) {
   let page = Page({


### PR DESCRIPTION
...rounds fro this

`page-worker` was breaking with this due to the doubling of `'*'` events with the `worker/utils` work around plus this; this is now fixed
