### PR TITLE
Bug 922308: Add ability to load JSMs via loader

### DIFF
--- a/app-extension/bootstrap.js
+++ b/app-extension/bootstrap.js
@@ -112,6 +112,7 @@ function startup(data, reasonCode) {
       // Relative modules resolve to add-on package lib
       './': prefixURI + name + '/lib/',
       './tests/': prefixURI + name + '/tests/',
+      'modules/': 'resource://gre/modules/',
       '': 'resource://gre/modules/commonjs/'
     };
 

--- a/lib/toolkit/loader.js
+++ b/lib/toolkit/loader.js
@@ -327,8 +327,8 @@ exports.load = load;
 function isRelative(id) { return id[0] === '.'; }
 // Utility function to normalize module `uri`s so they have `.js` extension.
 function normalize(uri) {
-  return isJSURI(uri) ? uri :
-         isJSONURI(uri) ? uri :
+  return (isJSURI(uri) || isJSONURI(uri) || isJSMURI(uri)) ?
+         uri :
          uri + '.js';
 }
 // Utility function to join paths. In common case `base` is a
@@ -354,6 +354,8 @@ const resolveURI = iced(function resolveURI(id, mapping) {
   let count = mapping.length, index = 0;
   while (index < count) {
     let [ path, uri ] = mapping[index ++];
+    if (isResourcePath(id))
+      return normalize(id);
     if (id.indexOf(path) === 0)
       return normalize(id.replace(path, uri));
   }
@@ -373,8 +375,8 @@ const Require = iced(function Require(loader, requirer) {
       throw Error('you must provide a module name when calling require() from '
                   + requirer.id, requirer.uri);
 
-    // Resolve `id` to its requirer if it's relative.
-    let requirement = requirer ? resolve(id, requirer.id) : id;
+    // Resolve `id` to its requirer if it's relative or a 'main' module
+    let requirement = needsResolved(id) ? resolve(id, requirer.id) : id;
 
     // Resolves `uri` of module using loaders resolve function.
     let uri = resolveURI(requirement, mapping);
@@ -384,22 +386,22 @@ const Require = iced(function Require(loader, requirer) {
                   requirer.id + ' located at ' + requirer.uri, requirer.uri);
 
     let module = null;
+    let importedModule = null;
+
     // If module is already cached by loader then just use it.
     if (uri in modules) {
       module = modules[uri];
     }
+    else if (isJSMURI(uri)) {
+      importedModule = Cu.import(uri, {});
+    }
     else if (isJSONURI(uri)) {
-      let data;
-
       // First attempt to load and parse json uri
       // ex: `test.json`
       // If that doesn't exist, check for `test.json.js`
       // for node parity
       try {
-        data = JSON.parse(readURI(uri));
-        module = modules[uri] = Module(requirement, uri);
-        module.exports = data;
-        freeze(module);
+        importedModule = JSON.parse(readURI(uri));
       }
       catch (err) {
         // If error thrown from JSON parsing, throw that, do not
@@ -409,12 +411,20 @@ const Require = iced(function Require(loader, requirer) {
         uri = uri + '.js';
       }
     }
-    // If not yet cached, load and cache it.
-    // We also freeze module to prevent it from further changes
-    // at runtime.
+
     if (!(uri in modules)) {
+      // If not yet cached, load and cache it.
       module = modules[uri] = Module(requirement, uri);
-      freeze(load(loader, module));
+
+      if (isJSURI(uri)) {
+        importedModule = load(loader, module);
+      }
+      else {
+        module.exports = importedModule;
+      }
+      // We also freeze module to prevent it from further changes
+      // at runtime.
+      freeze(module);
     }
 
     return module.exports;
@@ -545,6 +555,9 @@ exports.Loader = Loader;
 
 let isJSONURI = uri => uri.substr(-5) === '.json';
 let isJSURI = uri => uri.substr(-3) === '.js';
+let isJSMURI = uri => uri.substr(-4) === '.jsm';
+let isResourcePath = uri => uri.substr(0, 11) === 'resource://';
+let needsResolved = uri => isRelative(uri) || uri === 'main';
 
 });
 

--- a/python-lib/cuddlefish/manifest.py
+++ b/python-lib/cuddlefish/manifest.py
@@ -393,9 +393,15 @@ class ManifestBuilder:
         # traversal of the module graph
 
         for reqname in sorted(requires.keys()):
+
+            # If a resource:// URI or uses `modules/` alias (which maps to
+            # resource://gre/module/), just ignore and let loader load directly
+            # without bundling or verifying existence
+            if reqname.startswith("modules/") or reqname.startswith("resource://"):
+                continue
             # If requirement is chrome or a pseudo-module (starts with @) make
             # path a requirement name.
-            if reqname == "chrome" or reqname.startswith("@"):
+            elif reqname == "chrome" or reqname.startswith("@"):
                 me.add_requirement(reqname, reqname)
             else:
                 # when two modules require() the same name, do they get a
@@ -606,13 +612,17 @@ class ManifestBuilder:
         filename = os.sep.join(name.split("/"))
         # normalize filename, make sure that we do not add .js if it already has
         # it.
-        if not filename.endswith(".js") and not filename.endswith(".json"):
+        if (not filename.endswith(".js") and
+            not filename.endswith(".json") and
+            not filename.endswith(".jsm")):
           filename += ".js"
 
         if filename.endswith(".js"):
           basename = filename[:-3]
         if filename.endswith(".json"):
           basename = filename[:-5]
+        if filename.endswith(".jsm"):
+          basename = filename[:-4]
 
         pkg = self.pkg_cfg.packages[pkgname]
         if isinstance(sections, basestring):

--- a/test/addons/loader/Test.jsm
+++ b/test/addons/loader/Test.jsm
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+this.EXPORTED_SYMBOLS = ["Test"];
+
+this.Test = {
+  square: function (x) { return x * x; }
+};

--- a/test/addons/loader/main.js
+++ b/test/addons/loader/main.js
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict'
+
+const { defer: async } = require('sdk/lang/functional');
+const { Test } = require('./Test.jsm');
+const { console: devtoolsConsole } = require('resource://gre/modules/devtools/Console.jsm');
+const { Promise } = require('modules/Promise.jsm');
+const { TouchEventHandler } = require('resource://gre/modules/devtools/touch-events');
+
+exports['test alias for loading JSM in addon'] = function (assert, done) {
+  let { promise, resolve } = Promise.defer();
+  async(() => resolve(5))();
+  promise.then(val => {
+    assert.equal(val, 5, 'aliased JSM correctly loaded in addon');
+  }).then(done, done);
+};
+
+exports['test relative loading JSM in addon'] = function (assert) {
+  assert.equal(Test.square(5), 25, 'relative JSM correctly loaded in addon');
+};
+
+exports['test resource:// JSM loading in addon'] = function (assert) {
+  assert.ok(devtoolsConsole.log, 'resource:// JSM correctly loaded in addon');
+};
+
+exports['test resource:// JS loading in addon'] = function (assert) {
+  assert.ok(TouchEventHandler,
+    'resource:// JS correctly loaded in addon without .js suffix');
+};
+
+require('sdk/test/runner').runTestsFromModule(module);

--- a/test/addons/loader/package.json
+++ b/test/addons/loader/package.json
@@ -1,0 +1,3 @@
+{
+  "id": "test-loader"
+}

--- a/test/fixtures/loader/Test.jsm
+++ b/test/fixtures/loader/Test.jsm
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+this.EXPORTED_SYMBOLS = ["Test"];
+
+this.Test = {
+  square: function (x) { return x * x; }
+};


### PR DESCRIPTION
Adds ability to load JSM files, via relative or absolute (resource) paths, and js files via resource paths:

```
require('./File.jsm');
require('resource://gre/modules/File.jsm');
require('resource://gre/modules/commonjs/sdk/file.js');
```
