### PR TITLE
Bug 937982 Add support for a DELETE request method

### DIFF
--- a/lib/sdk/request.js
+++ b/lib/sdk/request.js
@@ -130,6 +130,10 @@ const Request = Class({
     request(this).contentType = validateSingleOption('contentType', value);
   },
   get response() { return request(this).response; },
+  delete: function() {
+    runRequest('DELETE', this);
+    return this;
+  },
   get: function() {
     runRequest('GET', this);
     return this;

--- a/test/test-request.js
+++ b/test/test-request.js
@@ -210,6 +210,27 @@ exports.testInvalidJSON = function (assert, done) {
   });
 };
 
+exports.testDelete = function (assert, done) {
+  let srv = startServerAsync(port, basePath);
+
+  srv.registerPathHandler("/test-delete",
+      function handle(request, response) {
+    response.setHeader("Content-Type", "text/plain", false);
+  });
+
+  Request({
+    url: "http://localhost:" + port + "/test-delete",
+    onComplete: function (response) {
+      // We cannot access the METHOD of the request to verify it's set
+      // correctly.
+      assert.equal(response.text, "");
+      assert.equal(response.statusText, "OK");
+      assert.equal(response.headers["Content-Type"], "text/plain");
+      srv.stop(done);
+    }
+  }).delete();
+};
+
 exports.testHead = function (assert, done) {
   let srv = startServerAsync(port, basePath);
 


### PR DESCRIPTION
I needed to make a DELETE api call and added support for the method. I attempted to write a test, but I don't see a method of getting at the Request METHOD from the test. I duped the HEAD test case and just verified that it's callable.

I'm having a hard time running the tests to verify my test is valid. 

./bin/cfx testcf works well and I get all passed tests. 
./bin/cfx testall fails with the below error even in trunk without my changes.

JavaScript strict warning: chrome://browser/content/urlbarBindings.xml, line 672: reference to undefined property this._value
JavaScript error: chrome://browser/content/urlbarBindings.xml, line 654: aUrl is undefined
^CTraceback (most recent call last):
  File "./bin/cfx", line 33, in <module>
    cuddlefish.run()
  File "/home/rharding/src/firefox-sdk/addon-sdk/python-lib/cuddlefish/__init__.py", line 621, in run
    test_all(env_root, defaults=options.**dict**)
  File "/home/rharding/src/firefox-sdk/addon-sdk/python-lib/cuddlefish/**init**.py", line 393, in test_all
    test_all_testaddons(env_root, defaults)
  File "/home/rharding/src/firefox-sdk/addon-sdk/python-lib/cuddlefish/**init**.py", line 440, in test_all_testaddons
    env_root=env_root)
  File "/home/rharding/src/firefox-sdk/addon-sdk/python-lib/cuddlefish/**init**.py", line 945, in run
    pkgdir=options.pkgdir)
  File "/home/rharding/src/firefox-sdk/addon-sdk/python-lib/cuddlefish/runner.py", line 719, in run_app
    time.sleep(0.05)
KeyboardInterrupt
