### PR TITLE
Loader documentation: it actually lives in gre/modules/commonjs/

### DIFF
--- a/doc/module-source/toolkit/loader.md
+++ b/doc/module-source/toolkit/loader.md
@@ -11,7 +11,7 @@ can be loaded in several ways:
 [system principals][]:
 
     <pre class="brush: html">
-        &lt;script type='application/javascript' src='resource://gre/modules/toolkit/loader.js'&gt;&lt;/script&gt;
+        &lt;script type='application/javascript' src='resource://gre/modules/commonjs/toolkit/loader.js'&gt;&lt;/script&gt;
     </pre>
 
     This will expose a single `loader` object containing all of the
@@ -19,7 +19,7 @@ can be loaded in several ways:
 
 2. It can be loaded as a [JavaScript code module][]:
 
-        let { Loader, Require, unload } = Components.utils.import('resource://gre/modules/toolkit/loader.js');
+        let { Loader, Require, unload } = Components.utils.import('resource://gre/modules/commonjs/toolkit/loader.js');
 
 3. It can be required as a CommonJS module from a module loaded in
 the loader itself:
@@ -136,7 +136,7 @@ This feature may be used in a few different ways:
    but is then exposed as a pseudo-module to avoid the overhead of subsequent
    loads:
 
-        let loaderModule = Cu.import('resource://gre/modules/toolkit/loader.js');
+        let loaderModule = Cu.import('resource://gre/modules/commonjs/toolkit/loader.js');
         let loader = loaderModule.Loader({
           modules: {
             // Overlay `toolkit/loader` so that `require('toolkit/loader')`


### PR DESCRIPTION
resource://gre/modules/toolkit/loader.js does not actually exist; resource://gre/modules/commonjs/toolkit/loader.js does, though, and is used by all the in-tree code.
