### PR TITLE
Bug 952265 - Expose tab 'rename' and 'move' events.

### DIFF
--- a/doc/module-source/sdk/tabs.md
+++ b/doc/module-source/sdk/tabs.md
@@ -233,6 +233,12 @@ This is an optional property.
 @prop [onPageShow] {function}
 A callback function that will be registered for the 'pageshow' event.
 This is an optional property.
+@prop [onRename] {function}
+A callback function that will be registered for the 'rename' event.
+This is an optional property.
+@prop [onMove] {function}
+A callback function that will be registered for the 'move' event.
+This is an optional property.
 @prop [onActivate] {function}
 A callback function that will be registered for the 'activate' event.
 This is an optional property.
@@ -461,6 +467,26 @@ Listeners are passed the tab object.
 @argument {persisted}
 Listeners are passed a boolean value indicating whether or not the page
 was loaded from the [bfcache](https://developer.mozilla.org/en-US/docs/Working_with_BFCache).
+</api>
+
+<api name="rename">
+@event
+
+This event is emitted when the tab's title changes.
+
+@argument {Tab}
+Listeners are passed the tab object.
+@argument {lastTitle}
+Listeners are passed the string value of the tab's last title.
+</api>
+
+<api name="move">
+@event
+
+This event is emitted when the tab's index changes.
+
+@argument {Tab}
+Listeners are passed the tab object.
 </api>
 
 <api name="activate">

--- a/lib/sdk/tab/events.js
+++ b/lib/sdk/tab/events.js
@@ -27,7 +27,7 @@ const isFennec = require("sdk/system/xul-app").is("Fennec");
 
 // Set of tab events that this module going to aggregate and expose.
 const TYPES = ["TabOpen","TabClose","TabSelect","TabMove","TabPinned",
-               "TabUnpinned"];
+               "TabUnpinned","DOMTitleChanged"];
 
 // Utility function that given a browser `window` returns stream of above
 // defined tab events for all tabs on the given window.

--- a/lib/sdk/tabs/common.js
+++ b/lib/sdk/tabs/common.js
@@ -22,6 +22,8 @@ function Options(options) {
     onReady: { is: ["undefined", "function"] },
     onLoad: { is: ["undefined", "function"] },
     onPageShow: { is: ["undefined", "function"] },
+    onRename: { is: ["undefined", "function"] },
+    onMove: { is: ["undefined", "function"] },
     onActivate: { is: ["undefined", "function"] },
     onDeactivate: { is: ["undefined", "function"] }
   });

--- a/lib/sdk/tabs/events.js
+++ b/lib/sdk/tabs/events.js
@@ -19,7 +19,9 @@ const EVENTS = {
   activate: "TabSelect",
   deactivate: null,
   pinned: "TabPinned",
-  unpinned: "TabUnpinned"
+  unpinned: "TabUnpinned",
+  move: "TabMove",
+  rename: "DOMTitleChanged"
 }
 exports.EVENTS = EVENTS;
 

--- a/lib/sdk/tabs/tab-fennec.js
+++ b/lib/sdk/tabs/tab-fennec.js
@@ -33,9 +33,12 @@ const Tab = Class({
     // TabReady
     let onReady = tabInternals.onReady = onTabReady.bind(this);
     tab.browser.addEventListener(EVENTS.ready.dom, onReady, false);
-    
+
     let onPageShow = tabInternals.onPageShow = onTabPageShow.bind(this);
     tab.browser.addEventListener(EVENTS.pageshow.dom, onPageShow, false);
+
+    let onRename = tabInternals.onRename = onTabRename.bind(this);
+    tab.browser.addEventListener(EVENTS.rename.dom, onRename, false);
 
     // TabClose
     let onClose = tabInternals.onClose = onTabClose.bind(this);
@@ -184,9 +187,11 @@ function cleanupTab(tab) {
   if (tabInternals.tab.browser) {
     tabInternals.tab.browser.removeEventListener(EVENTS.ready.dom, tabInternals.onReady, false);
     tabInternals.tab.browser.removeEventListener(EVENTS.pageshow.dom, tabInternals.onPageShow, false);
+    tabInternals.tab.browser.removeEventListener(EVENTS.rename.dom, tabInternals.onRename, false);
   }
   tabInternals.onReady = null;
   tabInternals.onPageShow = null;
+  tabInternals.onRename = null;
   tabInternals.window.BrowserApp.deck.removeEventListener(EVENTS.close.dom, tabInternals.onClose, false);
   tabInternals.onClose = null;
   rawTabNS(tabInternals.tab).tab = null;
@@ -205,8 +210,20 @@ function onTabReady(event) {
 
 function onTabPageShow(event) {
   let win = event.target.defaultView;
-  if (win === win.top)
+  if (win === win.top) {
+    this.lastTitle = this.title;
     emit(this, 'pageshow', this, event.persisted);
+  }
+}
+
+function onTabRename(event) {
+  let win = event.target.defaultView;
+  if (win === win.top
+  && !this._browser.webProgress.isLoadingDocument
+  && this.lastTitle !== this.title) {
+    emit(this 'rename', this, this.lastTitle);
+    this.lastTitle = this.title;
+  }
 }
 
 // TabClose

--- a/lib/sdk/tabs/tab-firefox.js
+++ b/lib/sdk/tabs/tab-firefox.js
@@ -38,6 +38,7 @@ const TabTrait = Trait.compose(EventEmitter, {
     this._onReady = this._onReady.bind(this);
     this._onLoad = this._onLoad.bind(this);
     this._onPageShow = this._onPageShow.bind(this);
+    this._onRename = this._onRename.bind(this);
     this._tab = options.tab;
     // TODO: Remove this dependency
     let window = this.window = options.window || require('../windows').BrowserWindow({ window: getOwnerWindow(this._tab) });
@@ -49,7 +50,7 @@ const TabTrait = Trait.compose(EventEmitter, {
         this.on(type.name, options[type.listener]);
       }
       // window spreads this event.
-      if (!has(['ready', 'load', 'pageshow'], (type.name)))
+      if (!has(['ready', 'load', 'pageshow', 'rename'], (type.name)))
         window.tabs.on(type.name, this._onEvent.bind(this, type.name));
     }
 
@@ -58,6 +59,7 @@ const TabTrait = Trait.compose(EventEmitter, {
     this._browser.addEventListener(EVENTS.ready.dom, this._onReady, true);
     this._browser.addEventListener(EVENTS.load.dom, this._onLoad, true);
     this._browser.addEventListener(EVENTS.pageshow.dom, this._onPageShow, true);
+    this._browser.addEventListener(EVENTS.rename.dom, this._onRename, true);
 
     if (options.isPinned)
       this.pin();
@@ -82,9 +84,27 @@ const TabTrait = Trait.compose(EventEmitter, {
         browser.removeEventListener(EVENTS.ready.dom, this._onReady, true);
         browser.removeEventListener(EVENTS.load.dom, this._onLoad, true);
         browser.removeEventListener(EVENTS.pageshow.dom, this._onPageShow, true);
+        browser.removeEventListener(EVENTS.rename.dom, this._onRename, true);
       }
       this._tab = null;
       TABS.splice(TABS.indexOf(this), 1);
+    }
+  },
+
+  /**
+   * Internal listener that emits public event 'rename' when the title of this
+   * tab is changed via DOMTitleChanged
+   */
+  _onRename: function _onRename(event) {
+    if (event.target == this._contentDocument
+    // DOMTitleChanged will fire when the tab changes location,
+    // so ignore loading documents.
+    && !this._browser.webProgress.isLoadingDocument
+    // DOMTitleChanged fires even when the title is the same,
+    // so we need to compare it against the last title.
+    && this.lastTitle !== this.title) {
+      this._emit(EVENTS.rename.name, this._public, this.lastTitle);
+      this.lastTitle = this.title;
     }
   },
 
@@ -97,7 +117,7 @@ const TabTrait = Trait.compose(EventEmitter, {
     if (event.target == this._contentDocument)
       this._emit(EVENTS.ready.name, this._public);
   },
-  
+
   /**
    * Internal listener that emits public event 'load' when the page of this
    * tab is loaded, for triggering on non-HTML content, bug #671305
@@ -116,6 +136,7 @@ const TabTrait = Trait.compose(EventEmitter, {
   _onPageShow: function _onPageShow(event) {
     // IFrames events will bubble so we need to ignore those.
     if (event.target == this._contentDocument) {
+      this.lastTitle = this.title;
       this._emit(EVENTS.pageshow.name, this._public, event.persisted);
     }
   },

--- a/lib/sdk/windows/tabs-fennec.js
+++ b/lib/sdk/windows/tabs-fennec.js
@@ -132,11 +132,12 @@ function onTabOpen(event) {
   tabNS(tab).opened = true;
 
   tab.on('ready', function() emit(gTabs, 'ready', tab));
+  tab.on('rename', function() emit(gTabs, 'rename', tab));
   tab.once('close', onTabClose);
 
   tab.on('pageshow', function(_tab, persisted)
     emit(gTabs, 'pageshow', tab, persisted));
-  
+
   emit(tab, 'open', tab);
   emit(gTabs, 'open', tab);
 }

--- a/lib/sdk/windows/tabs-firefox.js
+++ b/lib/sdk/windows/tabs-firefox.js
@@ -54,12 +54,14 @@ const WindowTabTracker = Trait.compose({
     this._onTabReady = this._emitEvent.bind(this, "ready");
     this._onTabLoad = this._emitEvent.bind(this, "load");
     this._onTabPageShow = this._emitEvent.bind(this, "pageshow");
+    this._onTabRename = this._emitEvent.bind(this, "rename");
     this._onTabOpen = this._onTabEvent.bind(this, "open");
     this._onTabClose = this._onTabEvent.bind(this, "close");
     this._onTabActivate = this._onTabEvent.bind(this, "activate");
     this._onTabDeactivate = this._onTabEvent.bind(this, "deactivate");
     this._onTabPinned = this._onTabEvent.bind(this, "pinned");
     this._onTabUnpinned = this._onTabEvent.bind(this, "unpinned");
+    this._onTabMove = this._onTabEvent.bind(this, "move");
 
     for each (let tab in getTabs(this._window)) {
       // We emulate "open" events for all open tabs since gecko does not emits
@@ -78,6 +80,7 @@ const WindowTabTracker = Trait.compose({
     tabsObserver.on("deactivate", this._onTabDeactivate);
     tabsObserver.on("pinned", this._onTabPinned);
     tabsObserver.on("unpinned", this._onTabUnpinned);
+    tabsObserver.on("move", this._onTabMove);
   },
   _destroyWindowTabTracker: function _destroyWindowTabTracker() {
     // We emulate close events on all tabs, since gecko does not emits such
@@ -115,6 +118,7 @@ const WindowTabTracker = Trait.compose({
         wrappedTab.on("ready", this._onTabReady);
         wrappedTab.on("load", this._onTabLoad);
         wrappedTab.on("pageshow", this._onTabPageShow);
+        wrappedTab.on("rename", this._onTabRename);
       }
 
       this._emitEvent(type, wrappedTab);

--- a/test/tabs/test-fennec-tabs.js
+++ b/test/tabs/test-fennec-tabs.js
@@ -541,6 +541,29 @@ exports.testPerTabEvents = function(assert, done) {
   });
 };
 
+// TEST: onRename event handler
+exports.testTabsEvent_onRename = function(assert, done) {
+  tabs.open({
+    url: "data:text/html;charset=utf-8,<script>document.title='hello world';</script>",
+    onRename: function (tab) {
+      assert.equal(tab.title, 'hello world', "The tab rename event was fired properly");
+      tab.close(done);
+    }
+  });
+};
+
+// TEST: onMove event handler
+exports.testTabsEvent_onMove = function(assert, done) {
+  tabs.open({
+    url: "data:text/html;charset=utf-8,foobar",
+    onReady: function (tab) { tab.index = 0; },
+    onMove: function (tab) {
+      assert.equal(tab.index, 0, "The tab move event was fired properly");
+      tab.close(done);
+    }
+  });
+};
+
 exports.testUniqueTabIds = function(assert, done) {
   var tabs = require('sdk/tabs');
   var tabIds = {};

--- a/test/tabs/test-firefox-tabs.js
+++ b/test/tabs/test-firefox-tabs.js
@@ -927,6 +927,35 @@ exports.testFaviconGetterDeprecation = function (assert, done) {
   });
 }
 
+exports.testRename = function(assert, done) {
+  let loader = Loader(module);
+  let tabs = loader.require("sdk/tabs");
+
+  tabs.open({
+    url: "data:text/html;charset=utf-8,<script>document.title='hello world';</script>",
+    onRename: function (tab) {
+      assert.equal(tab.title, 'hello world', "The tab rename event was fired properly");
+      tab.close(done);
+      loader.unload();
+    }
+  });
+};
+
+exports.testMove = function(assert, done) {
+  let loader = Loader(module);
+  let tabs = loader.require("sdk/tabs");
+
+  tabs.open({
+    url: "data:text/html;charset=utf-8,foobar",
+    onReady: function (tab) { tab.index = 0; },
+    onMove: function (tab) {
+      assert.equal(tab.index, 0, "The tab move event was fired properly");
+      tab.close(done);
+      loader.unload();
+    }
+  });
+};
+
 /******************* helpers *********************/
 
 // Helper for getting the active window


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=952265

This commit implements a 'rename' event and exposes the 'move' event
which was previously hidden. The code for Fennec has yet to be tested.