### PR TITLE
Bug 946813 - Part 2: Expose invisibleToDebugger via the loader.

### DIFF
--- a/lib/toolkit/loader.js
+++ b/lib/toolkit/loader.js
@@ -200,6 +200,8 @@ const Sandbox = iced(function Sandbox(options) {
                           options.wantGlobalProperties : [],
     sandboxPrototype: 'prototype' in options ? options.prototype : {},
     sameGroupAs: 'sandbox' in options ? options.sandbox : null,
+    invisibleToDebugger: 'invisibleToDebugger' in options ?
+                         options.invisibleToDebugger : false,
     metadata: 'metadata' in options ? options.metadata : {}
   };
 
@@ -270,6 +272,7 @@ const load = iced(function load(loader, module) {
     prototype: create(globals, descriptors),
     wantXrays: false,
     wantGlobalProperties: module.id == "sdk/indexed-db" ? ["indexedDB"] : [],
+    invisibleToDebugger: loader.invisibleToDebugger,
     metadata: {
       addonID: loader.id,
       URI: module.uri
@@ -527,6 +530,9 @@ const Loader = iced(function Loader(options) {
     resolve: { enumerable: false, value: resolve },
     // ID of the addon, if provided.
     id: { enumerable: false, value: options.id },
+    // Whether the modules loaded should be ignored by the debugger
+    invisibleToDebugger: { enumerable: false,
+                           value: options.invisibleToDebugger || false },
     load: { enumerable: false, value: options.load || load },
     // Main (entry point) module, it can be set only once, since loader
     // instance can have only one main module.

--- a/test/test-loader.js
+++ b/test/test-loader.js
@@ -218,4 +218,36 @@ exports['test require .json, .json.js'] = function (assert) {
     'js modules are cached whether access via .json.js or .json');
 };
 
+exports['test invisibleToDebugger: false'] = function (assert) {
+  let uri = root + '/fixtures/loader/cycles/';
+  let loader = Loader({ paths: { '': uri } });
+  main(loader, 'main');
+
+  let dbg = new Debugger();
+  let sandbox = loader.sandboxes[uri + 'main.js'];
+
+  try {
+    dbg.addDebuggee(sandbox);
+    assert.ok(true, 'debugger added visible value');
+  } catch(e) {
+    assert.fail('debugger could not add visible value');
+  }
+};
+
+exports['test invisibleToDebugger: true'] = function (assert) {
+  let uri = root + '/fixtures/loader/cycles/';
+  let loader = Loader({ paths: { '': uri }, invisibleToDebugger: true });
+  main(loader, 'main');
+
+  let dbg = new Debugger();
+  let sandbox = loader.sandboxes[uri + 'main.js'];
+
+  try {
+    dbg.addDebuggee(sandbox);
+    assert.fail('debugger added invisible value');
+  } catch(e) {
+    assert.ok(true, 'debugger did not add invisible value');
+  }
+};
+
 require('test').run(exports);


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=946813

In part 1 of bug 946813, I exposed a new sandbox option "invisibleToDebugger" which marks the sandbox's compartment as invisible for debugging purposes, which eventually will help me resolve issues with having two debugging servers active at the same time. Since we load the server via the add-on SDK loader, I need to expose the ability to set this flag on all the sandboxes one loader creates.
