### PR TITLE
Bug 882910 - toolbarbutton's icon doesn't have a max height

### DIFF
--- a/lib/sdk/ui/button/view.js
+++ b/lib/sdk/ui/button/view.js
@@ -142,6 +142,7 @@ function create(options) {
       node.setAttribute('label', label);
       node.setAttribute('tooltiptext', label);
       node.setAttribute('image', image);
+      node.setAttribute('sdk-button', 'true');
 
       views.set(id, {
         area: this.currentArea,


### PR DESCRIPTION
- Added `sdk-button` attribute to buttons created by SDK, in order to apply the style properly
