### PR TITLE
Update panel.show()

### DIFF
--- a/lib/sdk/panel.js
+++ b/lib/sdk/panel.js
@@ -179,9 +179,6 @@ const Panel = Class({
   show: function show(options, anchor) {
     if (options instanceof Ci.nsIDOMElement) {
       [anchor, options] = [options, null];
-    }
-
-    if (anchor instanceof Ci.nsIDOMElement) {
       console.warn(
         "Passing a DOM node to Panel.show() method is an unsupported " +
         "feature that will be soon replaced. " +


### PR DESCRIPTION
Only check for misplaced anchor once.

If checking for the DOM element after reassigning variables, then anyone using an anchor will always receive a warning.
