### PR TITLE
Bug 907450 - Anchored Panels

### DIFF
--- a/lib/sdk/panel.js
+++ b/lib/sdk/panel.js
@@ -13,7 +13,6 @@ module.metadata = {
 };
 
 const { Ci } = require("chrome");
-const { validateOptions: valid } = require('./deprecated/api-utils');
 const { setTimeout } = require('./timers');
 const { isPrivateBrowsingSupported } = require('./self');
 const { isWindowPBSupported } = require('./private-browsing/utils');
@@ -31,11 +30,14 @@ const { events } = require("./panel/events");
 const systemEvents = require("./system/events");
 const { filter, pipe, stripListeners } = require("./event/utils");
 const { getNodeView, getActiveView } = require("./view/core");
-const { isNil, isObject } = require("./lang/type");
+const { isNil, isObject, isNumber } = require("./lang/type");
 const { getAttachEventType } = require("./content/utils");
+const { number, boolean, object } = require('./deprecated/api-utils');
 
-let number = { is: ['number', 'undefined', 'null'] };
-let boolean = { is: ['boolean', 'undefined', 'null'] };
+let isRect = ({top, right, bottom, left}) => [top, right, bottom, left].
+  some(value => isNumber(value) && !isNaN(value));
+
+let isSDKObj = obj => obj instanceof Class;
 
 let rectContract = contract({
   top: number,
@@ -44,16 +46,20 @@ let rectContract = contract({
   left: number
 });
 
-let rect = {
-  is: ['object', 'undefined', 'null'],
-  map: function(v) isNil(v) || !isObject(v) ? v : rectContract(v)
+let position = {
+  is: object,
+  map: v => (isNil(v) || isSDKObj(v) || !isObject(v)) ? v : rectContract(v),
+  ok: v => isNil(v) || isSDKObj(v) || (isObject(v) && isRect(v)),
+  msg: 'The option "position" must be a SDK object registered as anchor; ' +
+        'or an object with one or more of the following keys set to numeric ' +
+        'values: top, right, bottom, left.'
 }
 
 let displayContract = contract({
   width: number,
   height: number,
   focus: boolean,
-  position: rect
+  position: position
 });
 
 let panelContract = contract(merge({}, displayContract.rules, loaderContract.rules));
@@ -176,7 +182,7 @@ const Panel = Class({
   get isShowing() !isDisposed(this) && domPanel.isOpen(viewFor(this)),
 
   /* Public API: Panel.show */
-  show: function show(options, anchor) {
+  show: function show(options={}, anchor) {
     if (options instanceof Ci.nsIDOMElement) {
       [anchor, options] = [options, null];
     }
@@ -191,7 +197,7 @@ const Panel = Class({
 
     let model = modelFor(this);
     let view = viewFor(this);
-    let anchorView = getNodeView(anchor);
+    let anchorView = getNodeView(anchor || options.position);
 
     options = merge({
       position: model.position,
@@ -239,24 +245,25 @@ exports.Panel = Panel;
 getActiveView.define(Panel, viewFor);
 
 // Filter panel events to only panels that are create by this module.
-let panelEvents = filter(events, function({target}) panelFor(target));
+let panelEvents = filter(events, ({target}) => panelFor(target));
 
 // Panel events emitted after panel has being shown.
-let shows = filter(panelEvents, function({type}) type === "popupshown");
+let shows = filter(panelEvents, ({type}) => type === "popupshown");
 
 // Panel events emitted after panel became hidden.
-let hides = filter(panelEvents, function({type}) type === "popuphidden");
+let hides = filter(panelEvents, ({type}) => type === "popuphidden");
 
 // Panel events emitted after content inside panel is ready. For different
 // panels ready may mean different state based on `contentScriptWhen` attribute.
 // Weather given event represents readyness is detected by `getAttachEventType`
 // helper function.
-let ready = filter(panelEvents, function({type, target})
+let ready = filter(panelEvents, ({type, target}) =>
   getAttachEventType(modelFor(panelFor(target))) === type);
 
 // Forward panel show / hide events to panel's own event listeners.
-on(shows, "data", function({target}) emit(panelFor(target), "show"));
-on(hides, "data", function({target}) emit(panelFor(target), "hide"));
+on(shows, "data", ({target}) => emit(panelFor(target), "show"));
+
+on(hides, "data", ({target}) => emit(panelFor(target), "hide"));
 
 on(ready, "data", function({target}) {
   let worker = workerFor(panelFor(target));

--- a/lib/sdk/ui/button/action.js
+++ b/lib/sdk/ui/button/action.js
@@ -26,6 +26,7 @@ const { merge } = require('../../util/object');
 const { Disposable } = require('../../core/disposable');
 const { on, off, emit, setListeners } = require('../../event/core');
 const { EventTarget } = require('../../event/target');
+const { getNodeView } = require('../../view/core');
 
 const view = require('./view');
 const { buttonContract, stateContract } = require('./contract');
@@ -88,6 +89,10 @@ const ActionButton = Class({
 exports.ActionButton = ActionButton;
 
 identify.define(ActionButton, ({id}) => toWidgetId(id));
+
+getNodeView.define(ActionButton, button =>
+  view.nodeFor(toWidgetId(button.id))
+);
 
 let actionButtonStateEvents = events.filter(stateEvents,
   e => e.target instanceof ActionButton);

--- a/lib/sdk/ui/button/toggle.js
+++ b/lib/sdk/ui/button/toggle.js
@@ -26,6 +26,7 @@ const { merge } = require('../../util/object');
 const { Disposable } = require('../../core/disposable');
 const { on, off, emit, setListeners } = require('../../event/core');
 const { EventTarget } = require('../../event/target');
+const { getNodeView } = require('../../view/core');
 
 const view = require('./view');
 const { toggleButtonContract, toggleStateContract } = require('./contract');
@@ -89,6 +90,10 @@ const ToggleButton = Class({
 exports.ToggleButton = ToggleButton;
 
 identify.define(ToggleButton, ({id}) => toWidgetId(id));
+
+getNodeView.define(ToggleButton, button =>
+  view.nodeFor(toWidgetId(button.id))
+);
 
 let toggleButtonStateEvents = events.filter(stateEvents,
   e => e.target instanceof ToggleButton);

--- a/lib/sdk/ui/button/view.js
+++ b/lib/sdk/ui/button/view.js
@@ -108,6 +108,11 @@ function getImage(icon, isInToolbar, pixelRatio) {
   return image;
 }
 
+function nodeFor(id, window=getMostRecentBrowserWindow()) {
+  return customizedWindows.has(window) ? null : getNode(id, window);
+};
+exports.nodeFor = nodeFor;
+
 function create(options) {
   let { id, label, icon, type } = options;
 
@@ -183,7 +188,7 @@ function setIcon(id, window, icon) {
 exports.setIcon = setIcon;
 
 function setLabel(id, window, label) {
-  let node = customizedWindows.has(window) ? null : getNode(id, window);
+  let node = nodeFor(id, window);
 
   if (node) {
     node.setAttribute('label', label);
@@ -193,7 +198,7 @@ function setLabel(id, window, label) {
 exports.setLabel = setLabel;
 
 function setDisabled(id, window, disabled) {
-  let node = customizedWindows.has(window) ? null : getNode(id, window);
+  let node = nodeFor(id, window);
 
   if (node)
     node.disabled = disabled;
@@ -201,7 +206,7 @@ function setDisabled(id, window, disabled) {
 exports.setDisabled = setDisabled;
 
 function setChecked(id, window, checked) {
-  let node = customizedWindows.has(window) ? null : getNode(id, window);
+  let node = nodeFor(id, window);
 
   if (node)
     node.checked = checked;
@@ -209,8 +214,7 @@ function setChecked(id, window, checked) {
 exports.setChecked = setChecked;
 
 function click(id) {
-  let window = getMostRecentBrowserWindow();
-  let node = customizedWindows.has(window) ? null : getNode(id, window);
+  let node = nodeFor(id);
 
   if (node)
     node.click();

--- a/lib/sdk/ui/state.js
+++ b/lib/sdk/ui/state.js
@@ -19,7 +19,7 @@ const { events: browserEvents } = require('../browser/events');
 const { events: tabEvents } = require('../tab/events');
 const { events: stateEvents } = require('./state/events');
 
-const { windows, isInteractive, getMostRecentBrowserWindow } = require('../window/utils');
+const { windows, isInteractive, getFocusedBrowser } = require('../window/utils');
 const { getActiveTab, getOwnerWindow } = require('../tabs/utils');
 
 const { ignoreWindow } = require('../private-browsing/utils');
@@ -47,7 +47,7 @@ const isActiveTab = thing => isTab(thing) && thing === getActiveTab(getOwnerWind
 const isEnumerable = window => !ignoreWindow(window);
 const browsers = _ =>
   windows('navigator:browser', { includePrivate: true }).filter(isInteractive);
-const getMostRecentTab = _ => getActiveTab(getMostRecentBrowserWindow());
+const getMostRecentTab = _ => getActiveTab(getFocusedBrowser());
 
 function getStateFor(component, target) {
   if (!isRegistered(component))
@@ -172,7 +172,7 @@ exports.properties = properties;
 function state(contract) {
   return {
     state: function state(target, state) {
-      let nativeTarget = target === 'window' ? getMostRecentBrowserWindow()
+      let nativeTarget = target === 'window' ? getFocusedBrowser()
                           : target === 'tab' ? getMostRecentTab()
                           : viewFor(target);
 

--- a/lib/sdk/widget.js
+++ b/lib/sdk/widget.js
@@ -444,28 +444,10 @@ const WidgetViewTrait = LightTrait.compose(EventEmitterTrait, LightTrait({
     // Special case for click events: if the widget doesn't have a click
     // handler, but it does have a panel, display the panel.
     if ("click" == type && !this._listeners("click").length && this.panel) {
-      // In Australis, widgets may be positioned in an overflow panel or the
-      // menu panel.
-      // In such cases clicking this widget will hide the overflow/menu panel,
-      // and the widget's panel will show instead.
-
-      let anchor = domNode;
-      let { CustomizableUI, window } = domNode.ownerDocument.defaultView;
-
-      if (CustomizableUI) {
-        ({anchor}) = CustomizableUI.getWidget(domNode.id).forWindow(window);
-
-        // if `anchor` is not the `domNode` itself, it means the widget is
-        // positioned in a panel, therefore we have to hide it before show
-        // the widget's panel in the same anchor
-        if (anchor !== domNode)
-          CustomizableUI.hidePanelForNode(domNode);
-      }
-
       // This kind of ugly workaround, instead we should implement
       // `getNodeView` for the `Widget` class itself, but that's kind of
       // hard without cleaning things up.
-      this.panel.show(null, getNodeView.implement({}, () => anchor));
+      this.panel.show(null, getNodeView.implement({}, () => domNode));
     }
   },
 

--- a/lib/sdk/window/utils.js
+++ b/lib/sdk/window/utils.js
@@ -19,6 +19,8 @@ const WM = Cc['@mozilla.org/appshell/window-mediator;1'].
            getService(Ci.nsIWindowMediator);
 const io = Cc['@mozilla.org/network/io-service;1'].
            getService(Ci.nsIIOService);
+const FM = Cc["@mozilla.org/focus-manager;1"].
+              getService(Ci.nsIFocusManager);
 
 const XUL_NS = 'http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul';
 
@@ -355,6 +357,18 @@ function getFocusedWindow() {
   return window ? window.document.commandDispatcher.focusedWindow : null;
 }
 exports.getFocusedWindow = getFocusedWindow;
+
+/**
+ * Returns the focused browser window if any, or the most recent one.
+ * Opening new window, updates most recent window, but focus window
+ * changes later; so most recent window and focused window are not always
+ * the same.
+ */
+function getFocusedBrowser() {
+  let window = FM.activeWindow;
+  return isBrowser(window) ? window : getMostRecentBrowserWindow()
+}
+exports.getFocusedBrowser = getFocusedBrowser;
 
 /**
  * Returns the focused element in the most recent focused window

--- a/test/test-ui-toggle-button.js
+++ b/test/test-ui-toggle-button.js
@@ -1020,6 +1020,44 @@ exports['test button click do not messing up states'] = function(assert) {
   loader.unload();
 }
 
+exports['test buttons can have anchored panels'] = function(assert, done) {
+  let loader = Loader(module);
+  let { ToggleButton } = loader.require('sdk/ui');
+  let { Panel } = loader.require('sdk/panel');
+  let { identify } = loader.require('sdk/ui/id');
+  let { getActiveView } = loader.require('sdk/view/core');
+
+  let button = ToggleButton({
+    id: 'my-button-22',
+    label: 'my button',
+    icon: './icon.png',
+    onChange: ({checked}) => checked && panel.show({position: button})
+  });
+
+  let panel = Panel();
+
+  panel.once('show', () => {
+    let { document } = getMostRecentBrowserWindow();
+    let buttonNode = document.getElementById(identify(button));
+    let panelNode = getActiveView(panel);
+
+    assert.ok(button.state('window').checked,
+      'button is checked');
+
+    assert.equal(panelNode.getAttribute('type'), 'arrow',
+      'the panel is a arrow type');
+
+    assert.strictEqual(buttonNode, panelNode.anchorNode,
+      'the panel is anchored properly to the button');
+
+    loader.unload();
+
+    done();
+  });
+
+  button.click();
+}
+
 // If the module doesn't support the app we're being run in, require() will
 // throw.  In that case, remove all tests above from exports, and add one dummy
 // test that passes.


### PR DESCRIPTION
Depends by [pull 1376](https://github.com/mozilla/addon-sdk/pull/1376).

This patch allows SDK objects like `ActionButton`, `ToggleButton` and `Widget`, to be specified as Panel's `position` value.
Therefore with a code like that is possible have a `ToggleButton` turned in a "panel button":

``` js
const { ToggleButton } = require('sdk/ui');
const { Panel } = require('sdk/panel');

let button = ToggleButton({
  icon: './addon.png',
  label: 'my button',
  id: 'mybutton',
  onChange: ({checked}) => checked && panel.show({position: button})
});

let panel = Panel({
  contentURL: data.url('panel.html'),
  onHide: () => button.state('window', {checked: false})
});
```

So developers can start to migrate from deprecated Widgets to new UI components.

They could easily create their own `PanelButton` as follows:

``` js
const { ToggleButton } = require('sdk/ui');
const { Panel } = require('sdk/panel');

const { Class } = require('sdk/core/heritage');
const { data } = require('sdk/self');

const panels = new Map();

const PanelButton = Class({
  extends: ToggleButton,
  setup: function setup(options) {
    ToggleButton.prototype.setup.call(this, options);

    let panel = Panel({
      contentURL: data.url(options.url),
      onHide: () => this.state('window', {checked: false})
    });

    this.on('change', ({checked}) => checked && panel.show({position: this}));

    panels.set(this, panel);
  },

  dispose: function dispose() {
    ToggleButton.prototype.dispose.call(this);
    panels.get(this).dispose();
    panels.delete(this);
  }
});

let button = PanelButton({
  icon: './addon.png',
  label: 'my button',
  id: 'mybutton',
  url: './foo.htm'
});
```

Ideally we'll provide in the close future a sugar syntax, probably not a class but a more generic function:

``` js
const { ToggleButton, link } = require('sdk/ui');
const { Panel } = require('sdk/panel');

let button = ToggleButton({
  icon: './addon.png',
  label: 'my button',
  id: 'mybutton'
});

let panel = Panel({
  contentURL: data.url('panel.html')
});

// `link` takes UI components, "linking" them together.
// It could takes also `MenuItem`, `Sidebar`, `Toolbar`, etc.
link(button, panel);
```
