### PR TITLE
Bug 964489 - add getTabForId to tabs/utils

### DIFF
--- a/lib/sdk/tabs/utils.js
+++ b/lib/sdk/tabs/utils.js
@@ -182,6 +182,11 @@ function getTabId(tab) {
 }
 exports.getTabId = getTabId;
 
+function getTabForId(id) {
+  return getTabs().find(tab => getTabId(tab) === id) || null;
+}
+exports.getTabForId = getTabForId;
+
 function getTabTitle(tab) {
   return getBrowserForTab(tab).contentDocument.title || tab.label || "";
 }
@@ -264,7 +269,7 @@ function getTabForWindow(window) {
         return tab;
     }
   }
-  return null; 
+  return null;
 }
 
 function getTabURL(tab) {


### PR DESCRIPTION
Notice that even if fennec has its implementation of `getTabForId`, in `BrowserApp` object, is not worthy to use it because the implementation does exactly the same thing – iterate all over the tabs, compare the id, returns a tab if it find it with that id.
So, because there is no advantages to use the fennec's one, with this code we do not need to "branch" the implementation from Firefox and Fennec, and keep the code simpler.

The test case is not added because [Bug 807426](https://bugzilla.mozilla.org/show_bug.cgi?id=807426), all the tabs utils tests are missing and they will be added once the new implementation is done. 
