### PR TITLE
Bug 966727 - Toolbar created by sdk/ui should not be customizable

### DIFF
--- a/lib/sdk/input/customizable-ui.js
+++ b/lib/sdk/input/customizable-ui.js
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+"use strict";
+
+const { Cu } = require("chrome");
+
+// Because Firefox Holly, we still need to check if `CustomizableUI` is
+// available. Once Australis will officially land, we can safely remove it.
+// See Bug 959142
+try {
+  Cu.import("resource:///modules/CustomizableUI.jsm", {});
+}
+catch (e) {
+  throw Error("Unsupported Application: The module"  + module.id +
+              " does not support this application.");
+}
+
+const { CustomizableUI } = Cu.import('resource:///modules/CustomizableUI.jsm', {});
+const { receive } = require("../event/utils");
+const { InputPort } = require("./system");
+const { object} = require("../util/sequence");
+const { getOuterId } = require("../window/utils");
+
+const Input = function() {};
+Input.prototype = Object.create(InputPort.prototype);
+
+Input.prototype.onCustomizeStart = function (window) {
+  receive(this, object([getOuterId(window), true]));
+}
+
+Input.prototype.onCustomizeEnd = function (window) {
+  receive(this, object([getOuterId(window), null]));
+}
+
+Input.prototype.addListener = input => CustomizableUI.addListener(input);
+
+Input.prototype.removeListener = input => CustomizableUI.removeListener(input);
+
+exports.CustomizationInput = Input;

--- a/lib/sdk/input/system.js
+++ b/lib/sdk/input/system.js
@@ -48,22 +48,28 @@ InputPort.prototype.constructor = InputPort;
 // When port is started (which is when it's subgraph get's
 // first subscriber) actual observer is registered.
 InputPort.start = input => {
-  addObserver(input, input.topic, false);
+  input.addListener(input);
   // Also register add-on unload observer to end this signal
   // when that happens.
   addObserver(input, addonUnloadTopic, false);
 };
 InputPort.prototype[start] = InputPort.start;
 
+InputPort.addListener = input => addObserver(input, input.topic, false);
+InputPort.prototype.addListener = InputPort.addListener;
+
 // When port is stopped (which is when it's subgraph has no
 // no subcribers left) an actual observer unregistered.
 // Note that port stopped once it ends as well (which is when
 // add-on is unloaded).
 InputPort.stop = input => {
-  removeObserver(input, input.topic);
+  input.removeListener(input);
   removeObserver(input, addonUnloadTopic);
 };
 InputPort.prototype[stop] = InputPort.stop;
+
+InputPort.removeListener = input => removeObserver(input, input.topic);
+InputPort.prototype.removeListener = InputPort.removeListener;
 
 // `InputPort` also implements `nsIObserver` interface and
 // `nsISupportsWeakReference` interfaces as it's going to be used as such.


### PR DESCRIPTION
WIP, Unit Test is missing.

@gozala, I was trying to use the `customization` input we created in order to listen to the customization start / end once; but I wasn't able to make it working, I'm probably missing some crucial part:

``` js
  const customization = new CustomizationInput();
  const { start, stop } = customization;

  once(customization, "*", message => console.log(message));
  start(customization);

  // this is toggle the customization mode.
  gCustomizeMode.toggle();
```

But only the `start` event is emitted, no `data`.
