### PR TITLE
Bug 976967 - sdk/system module issue: architecture and compiler return invalid values

### DIFF
--- a/lib/sdk/system.js
+++ b/lib/sdk/system.js
@@ -109,17 +109,21 @@ exports.pathFor = function pathFor(id) {
  */
 exports.platform = runtime.OS.toLowerCase();
 
+const [, architecture, compiler] = runtime.XPCOMABI ? 
+                                   runtime.XPCOMABI.match(/^([^-]*)-(.*)$/) :
+                                   [, null, null];
+
 /**
  * What processor architecture you're running on:
  * `'arm', 'ia32', or 'x64'`.
  */
-exports.architecture = runtime.XPCOMABI.split('_')[0];
+exports.architecture = architecture;
 
 /**
  * What compiler used for build:
  * `'msvc', 'n32', 'gcc2', 'gcc3', 'sunc', 'ibmc'...`
  */
-exports.compiler = runtime.XPCOMABI.split('_')[1];
+exports.compiler = compiler;
 
 /**
  * The application's build ID/date, for example "2004051604".

--- a/test/test-system-runtime.js
+++ b/test/test-system-runtime.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-var runtime = require("sdk/system/runtime");
+const runtime = require("sdk/system/runtime");
 
 exports["test system runtime"] = function(assert) {
   assert.equal(typeof(runtime.inSafeMode), "boolean",
@@ -14,7 +14,7 @@ exports["test system runtime"] = function(assert) {
                "runtime.processType is a number");
   assert.equal(typeof(runtime.widgetToolkit), "string",
                "runtime.widgetToolkit is string");
-  var XPCOMABI = typeof(runtime.XPCOMABI);
+  const XPCOMABI = runtime.XPCOMABI;
   assert.ok(XPCOMABI === null || typeof(XPCOMABI) === "string",
             "runtime.XPCOMABI is string or null if not supported by platform");
 };

--- a/test/test-system.js
+++ b/test/test-system.js
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+"use strict";
+
+const runtime = require("sdk/system/runtime");
+const system = require("sdk/system");
+
+exports["test system architecture and compiler"] = function(assert) {
+
+  if (system.architecture !== null) {
+    assert.equal(
+      runtime.XPCOMABI.indexOf(system.architecture), 0,
+      "system.architecture is starting substring of runtime.XPCOMABI"
+    );
+  }
+
+  if (system.compiler !== null) {
+    assert.equal(
+      runtime.XPCOMABI.indexOf(system.compiler),
+      runtime.XPCOMABI.length - system.compiler.length,
+      "system.compiler is trailing substring of runtime.XPCOMABI"
+    );
+  }
+
+  assert.ok(
+    system.architecture === null || typeof(system.architecture) === "string",
+    "system.architecture is string or null if not supported by platform"
+  );
+
+  assert.ok(
+    system.compiler === null || typeof(system.compiler) === "string",
+    "system.compiler is string or null if not supported by platform"
+  );
+};
+
+require("test").run(exports);


### PR DESCRIPTION
- fixed deliminator to dash
- handled possible null value
- fixed bug in test/test-system-runtime.js
