### PR TITLE
Bug 980468 - Ensure that content script syntax errors can be caught.

### DIFF
--- a/lib/sdk/page-mod.js
+++ b/lib/sdk/page-mod.js
@@ -201,6 +201,10 @@ function createWorker (mod, window) {
     contentScript: mod.contentScript,
     contentScriptFile: mod.contentScriptFile,
     contentScriptOptions: mod.contentScriptOptions,
+    // Bug 980468: Syntax errors from scripts can happen before the worker
+    // can set up an error handler. They are per-mod rather than per-worker
+    // so are best handled at the mod level.
+    onError: (e) => emit(mod, 'error', e)
   });
   workers.set(mod, worker);
   pipe(worker, mod);

--- a/test/test-page-mod.js
+++ b/test/test-page-mod.js
@@ -1531,4 +1531,32 @@ exports.testDetachOnUnload = function(assert, done) {
   })
 }
 
+exports.testSyntaxErrorInContentScript = function(assert, done) {
+  const url = "data:text/html;charset=utf-8,testSyntaxErrorInContentScript";
+  let hitError = null;
+  let attached = false;
+
+  testPageMod(assert, done, url, [{
+      include: url,
+      contentScript: 'console.log(23',
+
+      onAttach: function() {
+        attached = true;
+      },
+
+      onError: function(e) {
+        hitError = e;
+      }
+    }],
+
+    function(win, done) {
+      assert.ok(attached, "The worker was attached.");
+      assert.notStrictEqual(hitError, null, "The syntax error was reported.");
+      if (hitError)
+        assert.equal(hitError.name, "SyntaxError", "The error thrown should be a SyntaxError");
+      done();
+    }
+  );
+};
+
 require('sdk/test').run(exports);


### PR DESCRIPTION
Fix for https://bugzilla.mozilla.org/show_bug.cgi?id=980468
