### PR TITLE
Bug 992560 - Make console.time available to content scripts

### DIFF
--- a/lib/sdk/content/content-worker.js
+++ b/lib/sdk/content/content-worker.js
@@ -107,7 +107,9 @@ const ContentWorker = Object.freeze({
       error: pipe.emit.bind(null, "console", "error"),
       debug: pipe.emit.bind(null, "console", "debug"),
       exception: pipe.emit.bind(null, "console", "exception"),
-      trace: pipe.emit.bind(null, "console", "trace")
+      trace: pipe.emit.bind(null, "console", "trace"),
+      time: pipe.emit.bind(null, "console", "time"),
+      timeEnd: pipe.emit.bind(null, "console", "timeEnd")
     });
   },
 

--- a/lib/sdk/test/loader.js
+++ b/lib/sdk/test/loader.js
@@ -62,9 +62,11 @@ exports.LoaderWithHookedConsole = function (module, callback) {
         error: hook.bind("error"),
         debug: hook.bind("debug"),
         exception: hook.bind("exception"),
+        time: hook.bind("time"),
+        timeEnd: hook.bind("timeEnd"),
         __exposedProps__: {
           log: "rw", info: "rw", warn: "rw", error: "rw", debug: "rw",
-          exception: "rw"
+          exception: "rw", time: "rw", timeEnd: "rw"
         }
       }
     }),
@@ -105,9 +107,11 @@ exports.LoaderWithFilteredConsole = function (module, callback) {
       error: hook.bind("error"),
       debug: hook.bind("debug"),
       exception: hook.bind("exception"),
+      time: hook.bind("time"),
+      timeEnd: hook.bind("timeEnd"),
       __exposedProps__: {
         log: "rw", info: "rw", warn: "rw", error: "rw", debug: "rw",
-        exception: "rw"
+        exception: "rw", time: "rw", timeEnd: "rw"
       }
     }
   });

--- a/test/test-content-worker.js
+++ b/test/test-content-worker.js
@@ -382,8 +382,8 @@ exports["test:ensure console.xxx works in cs"] = WorkerTest(
     let calls = [];
     function onMessage(type, msg) {
       assert.equal(type, msg,
-                       "console.xxx(\"xxx\"), i.e. message is equal to the " +
-                       "console method name we are calling");
+        "console.xxx(\"xxx\"), i.e. message is equal to the " +
+        "console method name we are calling");
       calls.push(msg);
     }
 
@@ -391,19 +391,23 @@ exports["test:ensure console.xxx works in cs"] = WorkerTest(
     let worker =  loader.require("sdk/content/worker").Worker({
       window: browser.contentWindow,
       contentScript: "new " + function WorkerScope() {
+        console.time("time");
         console.log("log");
         console.info("info");
         console.warn("warn");
         console.error("error");
         console.debug("debug");
         console.exception("exception");
+        console.timeEnd("timeEnd");
         self.postMessage();
       },
       onMessage: function() {
         // Ensure that console methods are called in the same execution order
+        const EXPECTED_CALLS = ["time", "log", "info", "warn", "error",
+          "debug", "exception", "timeEnd"];
         assert.equal(JSON.stringify(calls),
-                         JSON.stringify(["log", "info", "warn", "error", "debug", "exception"]),
-                         "console has been called successfully, in the expected order");
+          JSON.stringify(EXPECTED_CALLS),
+          "console methods have been called successfully, in expected order");
         done();
       }
     });


### PR DESCRIPTION
I have tested this in up-to-date nightly firefox on windows xpp.

It works fine when I build the xpi with

```
AichnerAd@Kuckuck:~/tmp/mozilla/SnapperFirefox/Snapper$ cmd /c "%HOME%/tmp/mozilla/addon-sdk/bin/activate && cfx xpi --force-mobile --no-strip-xpi --force-use-bundled-sdk -b c:/programme/nightly/firefox.exe -v" # Use --no-strip-xpi to ship  Addon-SDK in XPI file
Welcome to the Add-on SDK. For the docs, visit https://addons.mozilla.org/en-US/developers/docs/sdk/latest/
Exporting extension to snapper.xpi.
AichnerAd@Kuckuck:~/tmp/mozilla/SnapperFirefox/Snapper$
```

The browser console logs this when the content script is loaded:

`14:14:25.493 loading started at jar:file:///C:/Dokumente%20und%20Einstellungen/AichnerAd/Anwendungsdaten/Mozilla/Firefox/Profiles/xwlwa1jh.default-1385301407992/extensions/jid1-HE38Y6vsW9TpHg@jetpack.xpi!/bootstrap.js
() takes: timer started sandbox.js:297
14:14:25.495 loading started at jar:file:///C:/Dokumente%20und%20Einstellungen/AichnerAd/Anwendungsdaten/Mozilla/Firefox/Profiles/xwlwa1jh.default-1385301407992/extensions/jid1-HE38Y6vsW9TpHg@jetpack.xpi!/bootstrap.js
() takes: 2ms sandbox.js:297`

I would prefer to sort the keys in the `Object.freeze` argument lexically for readability.

Let me know if I should add that in another commit.

Hope this is deemed useful,
Adrian
