### PR TITLE
Bug 993520: Create a custom console for workers tagged with the inner window ID of the worker's DOM window.

### DIFF
--- a/lib/sdk/console/plain-text.js
+++ b/lib/sdk/console/plain-text.js
@@ -12,7 +12,7 @@ const { Cc, Ci, Cu, Cr } = require("chrome");
 const self = require("../self");
 const prefs = require("../preferences/service");
 const { merge } = require("../util/object");
-const { ConsoleAPI } = Cu.import("resource://gre/modules/devtools/Console.jsm");
+const { ConsoleAPI } = Cu.import("resource://gre/modules/devtools/Console.jsm", {});
 
 const DEFAULT_LOG_LEVEL = "error";
 const ADDON_LOG_LEVEL_PREF = "extensions." + self.id + ".sdk.console.logLevel";
@@ -44,12 +44,13 @@ let branch = Cc["@mozilla.org/preferences-service;1"].
 branch.addObserver(ADDON_LOG_LEVEL_PREF, logLevelObserver, true);
 branch.addObserver(SDK_LOG_LEVEL_PREF, logLevelObserver, true);
 
-function PlainTextConsole(print) {
+function PlainTextConsole(print, innerID) {
 
   let consoleOptions = {
     prefix: self.name + ": ",
     maxLogLevel: logLevel,
-    dump: print
+    dump: print,
+    innerID: innerID
   };
   let console = new ConsoleAPI(consoleOptions);
 

--- a/lib/sdk/content/sandbox.js
+++ b/lib/sdk/content/sandbox.js
@@ -19,6 +19,7 @@ const { sandbox, evaluate, load } = require('../loader/sandbox');
 const { merge } = require('../util/object');
 const { getTabForContentWindow } = require('../tabs/utils');
 const { getInnerId } = require('../window/utils');
+const { PlainTextConsole } = require('../console/plain-text');
 
 // WeakMap of sandboxes so we can access private values
 const sandboxes = new WeakMap();
@@ -197,8 +198,10 @@ const WorkerSandbox = Class({
     // script
     merge(model, result);
 
+    let console = new PlainTextConsole(null, getInnerId(window));
+
     // Handle messages send by this script:
-    setListeners(this);
+    setListeners(this, console);
 
     // Inject `addon` global into target document if document is trusted,
     // `addon` in document is equivalent to `self` in content script.
@@ -304,7 +307,7 @@ function importScripts (workerSandbox, ...urls) {
   }
 }
 
-function setListeners (workerSandbox) {
+function setListeners (workerSandbox, console) {
   let { worker } = modelFor(workerSandbox);
   // console.xxx calls
   workerSandbox.on('console', function consoleListener (kind, ...args) {

--- a/test/test-test-loader.js
+++ b/test/test-test-loader.js
@@ -48,12 +48,12 @@ exports["test LoaderWithHookedConsole"] = function (assert) {
   console.debug("5th");
   console.exception("6th");
   assert.equal(messages.length, 6, "Got all console messages");
-  assert.deepEqual(messages[0], {type: "log", msg: "1st"}, "Got log");
-  assert.deepEqual(messages[1], {type: "error", msg: "2nd"}, "Got error");
-  assert.deepEqual(messages[2], {type: "warn", msg: "3rd"}, "Got warn");
-  assert.deepEqual(messages[3], {type: "info", msg: "4th"}, "Got info");
-  assert.deepEqual(messages[4], {type: "debug", msg: "5th"}, "Got debug");
-  assert.deepEqual(messages[5], {type: "exception", msg: "6th"}, "Got exception");
+  assert.deepEqual(messages[0], {type: "log", msg: "1st", innerID: null}, "Got log");
+  assert.deepEqual(messages[1], {type: "error", msg: "2nd", innerID: null}, "Got error");
+  assert.deepEqual(messages[2], {type: "warn", msg: "3rd", innerID: null}, "Got warn");
+  assert.deepEqual(messages[3], {type: "info", msg: "4th", innerID: null}, "Got info");
+  assert.deepEqual(messages[4], {type: "debug", msg: "5th", innerID: null}, "Got debug");
+  assert.deepEqual(messages[5], {type: "exception", msg: "6th", innerID: null}, "Got exception");
   assert.equal(count, 6, "Called for all messages");
 };
 


### PR DESCRIPTION
By using a custom console like this messages from workers show up in the browser console, the text console and the webconsole for the window.
