### PR TITLE
Bug 793413 - Use sans-serif typefaces and neutral anchor colors in panel...

### DIFF
--- a/lib/sdk/panel/utils.js
+++ b/lib/sdk/panel/utils.js
@@ -368,11 +368,16 @@ function style(panel) {
                 document.getAnonymousElementByAttribute(panel, "class",
                                                         "panel-inner-arrowcontent");
 
-    let color = window.getComputedStyle(node).getPropertyValue("color");
+    let { color, fontFamily, fontSize, fontWeight } = window.getComputedStyle(node);
 
     let style = contentDocument.createElement("style");
     style.id = "sdk-panel-style";
-    style.textContent = "body { color: " + color + "; }";
+    style.textContent = "body { " +
+      "color: " + color + ";" +
+      "font-family: " + fontFamily + ";" +
+      "font-weight: " + fontWeight + ";" +
+      "font-size: " + fontSize + ";" +
+    "}";
 
     let container = contentDocument.head ? contentDocument.head :
                     contentDocument.documentElement;


### PR DESCRIPTION
Slight change to anchor color and typeface (nothing else in Firefox has a serif font)

Currently/before: http://grab.by/w4Mg
With patch/after: http://grab.by/w4Me
