### PR TITLE
Bug 863456: Report failures for tests that leave unexpected tabs or windows behind

### DIFF
--- a/lib/sdk/tabs/tab-firefox.js
+++ b/lib/sdk/tabs/tab-firefox.js
@@ -17,6 +17,7 @@ const viewNS = require('../core/namespace').ns();
 const { deprecateUsage } = require('../util/deprecate');
 const { getURL } = require('../url/utils');
 const { viewFor } = require('../view/core');
+const { observer } = require('./observer');
 
 // Array of the inner instances of all the wrapped tabs.
 const TABS = [];
@@ -256,8 +257,12 @@ const TabTrait = Trait.compose(EventEmitter, {
         callback();
       return;
     }
-    if (callback)
-      this.once(EVENTS.close.name, callback);
+    if (callback) {
+      if (this.window.tabs.activeTab && (this.window.tabs.activeTab.id == this.id))
+        observer.once('select', callback);
+      else
+        this.once(EVENTS.close.name, callback);
+    }
     this._window.gBrowser.removeTab(this._tab);
   },
   /**

--- a/lib/sdk/tabs/utils.js
+++ b/lib/sdk/tabs/utils.js
@@ -91,7 +91,7 @@ function getTabs(window) {
     return window.BrowserApp.tabs;
 
   // firefox - default
-  return Array.slice(getTabContainer(window).children);
+  return Array.filter(getTabContainer(window).children, function(t) !t.closing);
 }
 exports.getTabs = getTabs;
 

--- a/test/addons/page-mod-debugger-post/main.js
+++ b/test/addons/page-mod-debugger-post/main.js
@@ -6,6 +6,7 @@
 const { Cu } = require('chrome');
 const { PageMod } = require('sdk/page-mod');
 const tabs = require('sdk/tabs');
+const { closeTab } = require('sdk/tabs/utils');
 const promise = require('sdk/core/promise')
 const { getMostRecentBrowserWindow } = require('sdk/window/utils');
 const { data } = require('sdk/self');
@@ -47,6 +48,7 @@ exports.testDebugger = function(assert, done) {
           then(_ => { assert.pass('testDebuggerStatement called') }).
           then(closeConnection).
           then(_ => { assert.pass('closeConnection called') }).
+          then(_ => { tab.close() }).
           then(done).
           then(null, aError => {
             ok(false, "Got an error: " + aError.message + "\n" + aError.stack);

--- a/test/addons/page-mod-debugger-pre/main.js
+++ b/test/addons/page-mod-debugger-pre/main.js
@@ -6,6 +6,7 @@
 const { Cu } = require('chrome');
 const { PageMod } = require('sdk/page-mod');
 const tabs = require('sdk/tabs');
+const { closeTab } = require('sdk/tabs/utils');
 const promise = require('sdk/core/promise')
 const { getMostRecentBrowserWindow } = require('sdk/window/utils');
 const { data } = require('sdk/self');
@@ -54,6 +55,7 @@ exports.testDebugger = function(assert, done) {
           then(_ => { assert.pass('testDebuggerStatement called') }).
           then(closeConnection).
           then(_ => { assert.pass('closeConnection called') }).
+          then(_ => { tab.close() }).
           then(done).
           then(null, aError => {
             ok(false, "Got an error: " + aError.message + "\n" + aError.stack);

--- a/test/addons/private-browsing-supported/test-selection.js
+++ b/test/addons/private-browsing-supported/test-selection.js
@@ -87,25 +87,6 @@ function open(url, options) {
 };
 
 /**
- * Close the Active Tab
- */
-function close(window) {
-  let { promise, resolve } = defer();
-
-  if (window && typeof(window.close) === "function") {
-    closeWindow(window).then(function() resolve());
-  }
-  else {
-    // Here we assuming that the most recent browser window is the one we're
-    // doing the test, and the active tab is the one we just opened.
-    closeTab(getActiveTab(getMostRecentBrowserWindow()));
-    resolve();
-  }
-
-  return promise;
-}
-
-/**
  * Reload the window given and return a promise, that will be resolved with the
  * content window after a small delay.
  */
@@ -249,7 +230,7 @@ exports["test PWPB Selection Listener"] = function(assert, done) {
 
           assert.equal(selection.text, "fo");
 
-          close(window).
+          closeWindow(window).
             then(loader.unload).
             then(done).
             then(null, assert.fail);
@@ -279,7 +260,7 @@ exports["test PWPB Textarea OnSelect Listener"] = function(assert, done) {
         focus(window).then(function() {
           assert.equal(selection.text, "noodles");
 
-          close(window).
+          closeWindow(window).
             then(loader.unload).
             then(done).
             then(null, assert.fail);
@@ -298,7 +279,7 @@ exports["test PWPB Single DOM Selection"] = function(assert, done) {
 
   open(URL, {private: true, title: "PWPB Single DOM Selection"}).
     then(selectFirstDiv).
-    then(focus).then(function() {
+    then(focus).then(function(window) {
       assert.equal(selection.isContiguous, true,
         "selection.isContiguous with single DOM Selection works.");
 
@@ -321,7 +302,9 @@ exports["test PWPB Single DOM Selection"] = function(assert, done) {
 
       assert.equal(selectionCount, 1,
         "One iterable selection");
-    }).then(close).then(loader.unload).then(done).then(null, assert.fail);
+
+      return closeWindow(window);
+    }).then(loader.unload).then(done).then(null, assert.fail);
 }
 
 exports["test PWPB Textarea Selection"] = function(assert, done) {
@@ -331,7 +314,7 @@ exports["test PWPB Textarea Selection"] = function(assert, done) {
   open(URL, {private: true, title: "PWPB Textarea Listener"}).
     then(selectTextarea).
     then(focus).
-    then(function() {
+    then(function(window) {
 
       assert.equal(selection.isContiguous, true,
         "selection.isContiguous with Textarea Selection works.");
@@ -355,7 +338,9 @@ exports["test PWPB Textarea Selection"] = function(assert, done) {
 
       assert.equal(selectionCount, 1,
         "One iterable selection");
-    }).then(close).then(loader.unload).then(done).then(null, assert.fail);
+
+      return closeWindow(window);
+    }).then(loader.unload).then(done).then(null, assert.fail);
 };
 
 exports["test PWPB Set HTML in Multiple DOM Selection"] = function(assert, done) {
@@ -365,7 +350,7 @@ exports["test PWPB Set HTML in Multiple DOM Selection"] = function(assert, done)
   open(URL, {private: true, title: "PWPB Set HTML in Multiple DOM Selection"}).
     then(selectAllDivs).
     then(focus).
-    then(function() {
+    then(function(window) {
       let html = "<span>b<b>a</b>r</span>";
 
       let expectedText = ["bar", "and"];
@@ -393,7 +378,9 @@ exports["test PWPB Set HTML in Multiple DOM Selection"] = function(assert, done)
 
       assert.equal(selectionCount, 2,
         "Two iterable selections");
-    }).then(close).then(loader.unload).then(done).then(null, assert.fail);
+
+      return closeWindow(window);
+    }).then(loader.unload).then(done).then(null, assert.fail);
 };
 
 exports["test PWPB Set Text in Textarea Selection"] = function(assert, done) {
@@ -403,7 +390,7 @@ exports["test PWPB Set Text in Textarea Selection"] = function(assert, done) {
   open(URL, {private: true, title: "test PWPB Set Text in Textarea Selection"}).
     then(selectTextarea).
     then(focus).
-    then(function() {
+    then(function(window) {
 
       let text = "bar";
 
@@ -429,7 +416,8 @@ exports["test PWPB Set Text in Textarea Selection"] = function(assert, done) {
       assert.equal(selectionCount, 1,
         "One iterable selection");
 
-    }).then(close).then(loader.unload).then(done).then(null, assert.fail);
+      return closeWindow(window);
+    }).then(loader.unload).then(done).then(null, assert.fail);
 };
 
 // If the platform doesn't support the PBPW, we're replacing PBPW tests

--- a/test/test-clipboard.js
+++ b/test/test-clipboard.js
@@ -90,8 +90,7 @@ function comparePixelImages(imageA, imageB, callback) {
           compared = pixels;
           this.emit("draw-image", imageB);
         } else {
-          callback(compared === pixels);
-          tab.close()
+          tab.close(callback.bind(null, compared === pixels))
         }
       });
 

--- a/test/test-selection.js
+++ b/test/test-selection.js
@@ -28,7 +28,7 @@ const tabs = require("sdk/tabs");
 const { setTabURL } = require("sdk/tabs/utils");
 const { getActiveTab, getTabContentWindow, closeTab } = require("sdk/tabs/utils")
 const { getMostRecentBrowserWindow } = require("sdk/window/utils");
-const { open: openNewWindow } = require("sdk/window/helpers");
+const { open: openNewWindow, close: closeWindow } = require("sdk/window/helpers");
 const { Loader } = require("sdk/test/loader");
 const { setTimeout } = require("sdk/timers");
 const { Cu } = require("chrome");
@@ -698,13 +698,13 @@ exports["test Selection Listener"] = function(assert, done) {
 
   selection.once("select", function() {
     assert.equal(selection.text, "fo");
+    close();
+    loader.unload();
     done();
   });
 
   open(URL).then(selectContentFirstDiv).
-    then(dispatchSelectionEvent).
-    then(close).
-    then(loader.unload, assert.fail);
+    then(dispatchSelectionEvent, assert.fail);
 };
 
 exports["test Textarea OnSelect Listener"] = function(assert, done) {
@@ -713,13 +713,13 @@ exports["test Textarea OnSelect Listener"] = function(assert, done) {
 
   selection.once("select", function() {
     assert.equal(selection.text, "noodles");
+    close();
+    loader.unload();
     done();
   });
 
   open(URL).then(selectTextarea).
-    then(dispatchOnSelectEvent).
-    then(close).
-    then(loader.unload, assert.fail);
+    then(dispatchOnSelectEvent, assert.fail);
 };
 
 exports["test Selection listener removed on unload"] = function(assert, done) {
@@ -769,14 +769,14 @@ exports["test Selection Listener on existing document"] = function(assert, done)
 
     selection.once("select", function() {
       assert.equal(selection.text, "fo");
+      close();
+      loader.unload();
       done();
     });
 
     return window;
   }).then(selectContentFirstDiv).
-    then(dispatchSelectionEvent).
-    then(close).
-    then(loader.unload, assert.fail);
+    then(dispatchSelectionEvent, assert.fail);
 };
 
 
@@ -788,14 +788,14 @@ exports["test Textarea OnSelect Listener on existing document"] = function(asser
 
     selection.once("select", function() {
       assert.equal(selection.text, "noodles");
+      close();
+      loader.unload();
       done();
     });
 
     return window;
   }).then(selectTextarea).
-    then(dispatchOnSelectEvent).
-    then(close).
-    then(loader.unload, assert.fail);
+    then(dispatchOnSelectEvent, assert.fail);
 };
 
 exports["test Selection Listener on document reload"] = function(assert, done) {
@@ -804,15 +804,15 @@ exports["test Selection Listener on document reload"] = function(assert, done) {
 
   selection.once("select", function() {
     assert.equal(selection.text, "fo");
+    close();
+    loader.unload();
     done();
   });
 
   open(URL).
     then(reload).
     then(selectContentFirstDiv).
-    then(dispatchSelectionEvent).
-    then(close).
-    then(loader.unload, assert.fail);
+    then(dispatchSelectionEvent, assert.fail);
 };
 
 exports["test Textarea OnSelect Listener on document reload"] = function(assert, done) {
@@ -821,15 +821,15 @@ exports["test Textarea OnSelect Listener on document reload"] = function(assert,
 
   selection.once("select", function() {
     assert.equal(selection.text, "noodles");
+    close();
+    loader.unload();
     done();
   });
 
   open(URL).
     then(reload).
     then(selectTextarea).
-    then(dispatchOnSelectEvent).
-    then(close).
-    then(loader.unload, assert.fail);
+    then(dispatchOnSelectEvent, assert.fail);
 };
 
 exports["test Selection Listener on frame"] = function(assert, done) {
@@ -884,7 +884,7 @@ exports["test PBPW Selection Listener"] = function(assert, done) {
   open(URL, {private: true}).
     then(selectContentFirstDiv).
     then(dispatchSelectionEvent).
-    then(close).
+    then(closeWindow).
     then(loader.unload).
     then(done, assert.fail);
 };
@@ -902,7 +902,7 @@ exports["test PBPW Textarea OnSelect Listener"] = function(assert, done) {
   open(URL, {private: true}).
     then(selectTextarea).
     then(dispatchOnSelectEvent).
-    then(close).
+    then(closeWindow).
     then(loader.unload).
     then(done, assert.fail);
 };
@@ -931,7 +931,7 @@ exports["test PBPW Single DOM Selection"] = function(assert, done) {
       "No iterable selection in PBPW");
 
     return window;
-  }).then(close).then(loader.unload).then(done, assert.fail);
+  }).then(closeWindow).then(loader.unload).then(done, assert.fail);
 };
 
 exports["test PBPW Textarea Selection"] = function(assert, done) {
@@ -964,7 +964,7 @@ exports["test PBPW Textarea Selection"] = function(assert, done) {
       "No iterable selection in PBPW");
 
     return window;
-  }).then(close).then(loader.unload).then(done, assert.fail);
+  }).then(closeWindow).then(loader.unload).then(done, assert.fail);
 };
 
 // TODO: test Selection Listener on long-held connection (Bug 661884)


### PR DESCRIPTION
The important part is the unit-test code that checks for remaining windows/tabs. Tests are expected to completely close (and wait for the close to complete) before calling done. There are a lot of tests that don't do that now and fixes for them.

The tabs API in particular has a problem, the callback from tab.close calls before the next tab has been selected so lots of tabs can try to use tabs.activeTab and end up with the wrong thing. I worked around this by only calling the callback when a new tab has been selected.
