### PR TITLE
Bug 881047 Use Promise.jsm as promise implementation and remove

### DIFF
--- a/lib/sdk/core/promise.js
+++ b/lib/sdk/core/promise.js
@@ -1,243 +1,29 @@
-;(function(id, factory) { // Module boilerplate :(
-  if (typeof(define) === 'function') { // RequireJS
-    define(factory);
-  } else if (typeof(require) === 'function') { // CommonJS
-    factory.call(this, require, exports, module);
-  } else if (String(this).indexOf('BackstagePass') >= 0) { // JSM
-    this[factory.name] = {};
-    try {
-      this.console = this['Components'].utils
-          .import('resource://gre/modules/devtools/Console.jsm', {}).console;
-    }
-    catch (ex) {
-      // Avoid failures on different toolkit configurations.
-    }
-    factory(function require(uri) {
-      var imports = {};
-      this['Components'].utils.import(uri, imports);
-      return imports;
-    }, this[factory.name], { uri: __URI__, id: id });
-    this.EXPORTED_SYMBOLS = [factory.name];
-  } else if (~String(this).indexOf('Sandbox')) { // Sandbox
-    factory(function require(uri) {}, this, { id: id });
-  } else {  // Browser or alike
-    var globals = this;
-    factory(function require(id) {
-      return globals[id];
-    }, (globals[id] = {}), { uri: document.location.href + '#' + id, id: id });
-  }
-}).call(this, 'promise/core', function Promise(require, exports, module) {
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 
 'use strict';
 
+/*
+ * Uses `Promise.jsm` as a core implementation, with additional sugar
+ * from previous implementation, with inspiration from `Q` and `when`
+ *
+ * https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Promise.jsm
+ * https://github.com/cujojs/when
+ * https://github.com/kriskowal/q
+ */
+const PROMISE_URI = 'resource://gre/modules/Promise.jsm';
+
+getEnvironment.call(this, function ({ require, exports, module, Cu }) {
+
+const { defer, resolve, all, reject, race } = Cu.import(PROMISE_URI, {}).Promise;
+
 module.metadata = {
-  "stability": "unstable"
+  'stability': 'unstable'
 };
 
-/**
- * Internal utility: Wraps given `value` into simplified promise, successfully
- * fulfilled to a given `value`. Note the result is not a complete promise
- * implementation, as its method `then` does not returns anything.
- */
-function fulfilled(value) {
-  return { then: function then(fulfill) { fulfill(value); } };
-}
-
-/**
- * Internal utility: Wraps given input into simplified promise, pre-rejected
- * with a given `reason`. Note the result is not a complete promise
- * implementation, as its method `then` does not returns anything.
- */
-function rejected(reason) {
-  return { then: function then(fulfill, reject) { reject(reason); } };
-}
-
-/**
- * Internal utility: Returns `true` if given `value` is a promise. Value is
- * assumed to be a promise if it implements method `then`.
- */
-function isPromise(value) {
-  return value && typeof(value.then) === 'function';
-}
-
-/**
- * Creates deferred object containing fresh promise & methods to either resolve
- * or reject it. The result is an object with the following properties:
- * - `promise` Eventual value representation implementing CommonJS [Promises/A]
- *   (http://wiki.commonjs.org/wiki/Promises/A) API.
- * - `resolve` Single shot function that resolves enclosed `promise` with a
- *   given `value`.
- * - `reject` Single shot function that rejects enclosed `promise` with a given
- *   `reason`.
- *
- * An optional `prototype` argument is used as a prototype of the returned
- * `promise` allowing one to implement additional API. If prototype is not
- * passed then it falls back to `Object.prototype`.
- *
- *  ## Example
- *
- *  function fetchURI(uri, type) {
- *    var deferred = defer();
- *    var request = new XMLHttpRequest();
- *    request.open("GET", uri, true);
- *    request.responseType = type;
- *    request.onload = function onload() {
- *      deferred.resolve(request.response);
- *    }
- *    request.onerror = function(event) {
- *     deferred.reject(event);
- *    }
- *    request.send();
- *
- *    return deferred.promise;
- *  }
- */
-function defer(prototype) {
-  // Define FIFO queue of observer pairs. Once promise is resolved & all queued
-  // observers are forwarded to `result` and variable is set to `null`.
-  var observers = [];
-
-  // Promise `result`, which will be assigned a resolution value once promise
-  // is resolved. Note that result will always be assigned promise (or alike)
-  // object to take care of propagation through promise chains. If result is
-  // `null` promise is not resolved yet.
-  var result = null;
-
-  prototype = (prototype || prototype === null) ? prototype : Object.prototype;
-
-  // Create an object implementing promise API.
-  var promise = Object.create(prototype, {
-    then: { value: function then(onFulfill, onError) {
-      var deferred = defer(prototype);
-
-      function resolve(value) {
-        // If `onFulfill` handler is provided resolve `deferred.promise` with
-        // result of invoking it with a resolution value. If handler is not
-        // provided propagate value through.
-        try {
-          deferred.resolve(onFulfill ? onFulfill(value) : value);
-        }
-        // `onFulfill` may throw exception in which case resulting promise
-        // is rejected with thrown exception.
-        catch(error) {
-          if (exports._reportErrors && typeof(console) === 'object')
-            console.error(error);
-          // Note: Following is equivalent of `deferred.reject(error)`,
-          // we use this shortcut to reduce a stack.
-          deferred.resolve(rejected(error));
-        }
-      }
-
-      function reject(reason) {
-        try {
-          if (onError) deferred.resolve(onError(reason));
-          else deferred.resolve(rejected(reason));
-        }
-        catch(error) {
-          if (exports._reportErrors && typeof(console) === 'object')
-            console.error(error);
-          deferred.resolve(rejected(error));
-        }
-      }
-
-      // If enclosed promise (`this.promise`) observers queue is still alive
-      // enqueue a new observer pair into it. Note that this does not
-      // necessary means that promise is pending, it may already be resolved,
-      // but we still have to queue observers to guarantee an order of
-      // propagation.
-      if (observers) {
-        observers.push({ resolve: resolve, reject: reject });
-      }
-      // Otherwise just forward observer pair right to a `result` promise.
-      else {
-        result.then(resolve, reject);
-      }
-
-      return deferred.promise;
-    }}
-  })
-
-  var deferred = {
-    promise: promise,
-    /**
-     * Resolves associated `promise` to a given `value`, unless it's already
-     * resolved or rejected. Note that resolved promise is not necessary a
-     * successfully fulfilled. Promise may be resolved with a promise `value`
-     * in which case `value` promise's fulfillment / rejection will propagate
-     * up to a promise resolved with `value`.
-     */
-    resolve: function resolve(value) {
-      if (!result) {
-        // Store resolution `value` in a `result` as a promise, so that all
-        // the subsequent handlers can be simply forwarded to it. Since
-        // `result` will be a promise all the value / error propagation will
-        // be uniformly taken care of.
-        result = isPromise(value) ? value : fulfilled(value);
-
-        // Forward already registered observers to a `result` promise in the
-        // order they were registered. Note that we intentionally dequeue
-        // observer at a time until queue is exhausted. This makes sure that
-        // handlers registered as side effect of observer forwarding are
-        // queued instead of being invoked immediately, guaranteeing FIFO
-        // order.
-        while (observers.length) {
-          var observer = observers.shift();
-          result.then(observer.resolve, observer.reject);
-        }
-
-        // Once `observers` queue is exhausted we `null`-ify it, so that
-        // new handlers are forwarded straight to the `result`.
-        observers = null;
-      }
-    },
-    /**
-     * Rejects associated `promise` with a given `reason`, unless it's already
-     * resolved / rejected. This is just a (better performing) convenience
-     * shortcut for `deferred.resolve(reject(reason))`.
-     */
-    reject: function reject(reason) {
-      // Note that if promise is resolved that does not necessary means that it
-      // is successfully fulfilled. Resolution value may be a promise in which
-      // case its result propagates. In other words if promise `a` is resolved
-      // with promise `b`, `a` is either fulfilled or rejected depending
-      // on weather `b` is fulfilled or rejected. Here `deferred.promise` is
-      // resolved with a promise pre-rejected with a given `reason`, there for
-      // `deferred.promise` is rejected with a given `reason`. This may feel
-      // little awkward first, but doing it this way greatly simplifies
-      // propagation through promise chains.
-      deferred.resolve(rejected(reason));
-    }
-  };
-
-  return deferred;
-}
-exports.defer = defer;
-
-/**
- * Returns a promise resolved to a given `value`. Optionally a second
- * `prototype` argument may be provided to be used as a prototype for the
- * returned promise.
- */
-function resolve(value, prototype) {
-  var deferred = defer(prototype);
-  deferred.resolve(value);
-  return deferred.promise;
-}
-exports.resolve = resolve;
-
-/**
- * Returns a promise rejected with a given `reason`. Optionally a second
- * `prototype` argument may be provided to be used as a prototype for the
- * returned promise.
- */
-function reject(reason, prototype) {
-  var deferred = defer(prototype);
-  deferred.reject(reason);
-  return deferred.promise;
-}
-exports.reject = reject;
-
-var promised = (function() {
+let promised = (function() {
   // Note: Define shortcuts and utility functions here in order to avoid
   // slower property accesses and unnecessary closure creations on each
   // call of this popular function.
@@ -247,15 +33,14 @@ var promised = (function() {
 
   // Utility function that does following:
   // execute([ f, self, args...]) => f.apply(self, args)
-  function execute(args) { return call.apply(call, args) }
+  function execute (args) call.apply(call, args)
 
   // Utility function that takes promise of `a` array and maybe promise `b`
   // as arguments and returns promise for `a.concat(b)`.
   function promisedConcat(promises, unknown) {
-    return promises.then(function(values) {
-      return resolve(unknown).then(function(value) {
-        return values.concat([ value ]);
-      });
+    return promises.then(function (values) {
+      return resolve(unknown)
+        .then(function (value) values.concat([value]));
     });
   }
 
@@ -280,11 +65,53 @@ var promised = (function() {
         // finally map that to promise of `f.apply(this, args...)`
         then(execute);
     };
-  }
+  };
 })();
-exports.promised = promised;
 
-var all = promised(Array);
+exports.promised = promised;
 exports.all = all;
+exports.defer = defer;
+exports.resolve = resolve;
+exports.reject = reject;
+exports.race = race;
+exports.Promise = Promise;
 
 });
+
+function getEnvironment (callback) {
+  let Cu, _exports, _module, _require;
+
+  // CommonJS / SDK
+  if (typeof(require) === 'function') {
+    Cu = require('chrome').Cu;
+    _exports = exports;
+    _module = module;
+    _require = require;
+  }
+  // JSM
+  else if (String(this).indexOf('BackstagePass') >= 0) {
+    Cu = this['Components'].utils;
+    _exports = this.Promise = {};
+    _module = { uri: __URI__, id: 'promise/core' };
+    _require = uri => {
+      let imports = {};
+      Cu.import(uri, imports);
+      return imports;
+    };
+    this.EXPORTED_SYMBOLS = ['Promise'];
+  // mozIJSSubScriptLoader.loadSubscript
+  } else if (~String(this).indexOf('Sandbox')) {
+    Cu = this['Components'].utils;
+    _exports = this;
+    _module = { id: 'promise/core' };
+    _require = uri => {};
+  }
+
+  callback({
+    Cu: Cu,
+    exports: _exports,
+    module: _module,
+    require: _require
+  });
+}
+

--- a/lib/sdk/net/url.js
+++ b/lib/sdk/net/url.js
@@ -15,27 +15,24 @@ const { merge } = require("../util/object");
 const { NetUtil } = Cu.import("resource://gre/modules/NetUtil.jsm", {});
 
 /**
- * Open a channel synchronously for the URI given, with an optional charset, and
- * returns a resolved promise if succeed; rejected promise otherwise.
+ * Reads a URI and returns a promise.
+ *
+ * @param uri {string} The URI to read
+ * @param [options] {object} This parameter can have any or all of the following
+ * fields: `charset`. By default the `charset` is set to 'UTF-8'.
+ *
+ * @returns {promise}  The promise that will be resolved with the content of the
+ *          URL given.
+ *
+ * @example
+ *  let promise = readURI('resource://gre/modules/NetUtil.jsm', {
+ *    charset: 'US-ASCII'
+ *  });
  */
-function readSync(uri, charset) {
-  let { promise, resolve, reject } = defer();
+function readURI(uri, options) {
+  options = options || {};
+  let charset = options.charset || 'UTF-8';
 
-  try {
-    resolve(readURISync(uri, charset));
-  }
-  catch (e) {
-    reject("Failed to read: '" + uri + "' (Error Code: " + e.result + ")");
-  }
-
-  return promise;
-}
-
-/**
- * Open a channel synchronously for the URI given, with an optional charset, and
- * returns a promise.
- */
-function readAsync(uri, charset) {
   let channel = NetUtil.newChannel(uri, charset, null);
 
   let { promise, resolve, reject } = defer();
@@ -57,34 +54,6 @@ function readAsync(uri, charset) {
   }
 
   return promise;
-}
-
-/**
- * Reads a URI and returns a promise. If the `sync` option is set to `true`, the
- * promise will be resolved synchronously.
- *
- * @param uri {string} The URI to read
- * @param [options] {object} This parameter can have any or all of the following
- * fields: `sync`, `charset`. By default the `charset` is set to 'UTF-8'.
- *
- * @returns {promise}  The promise that will be resolved with the content of the
- *          URL given.
-  *
- * @example
- *  let promise = readURI('resource://gre/modules/NetUtil.jsm', {
- *    sync: true,
- *    charset: 'US-ASCII'
- });
- */
-function readURI(uri, options) {
-  options = merge({
-    charset: "UTF-8",
-    sync: false
-  }, options);
-
-  return options.sync
-    ? readSync(uri, options.charset)
-    : readAsync(uri, options.charset);
 }
 
 exports.readURI = readURI;

--- a/lib/sdk/places/utils.js
+++ b/lib/sdk/places/utils.js
@@ -49,8 +49,9 @@ exports.TreeNode = TreeNode;
 
 /*
  * Descends down from `node` applying `fn` to each in order.
- * Can be asynchronous if `fn` returns a promise. `fn` is passed 
- * one argument, the current node, `curr`
+ * `fn` can return values or promises -- if promise returned,
+ * children are not processed until resolved. `fn` is passed 
+ * one argument, the current node, `curr`.
  */
 function walk (curr, fn) {
   return promised(fn)(curr).then(val => {

--- a/test/addons/places/tests/test-places-favicon.js
+++ b/test/addons/places/tests/test-places-favicon.js
@@ -147,13 +147,13 @@ exports.testTabsGetFaviconPromiseFailure = function (assert, done) {
 exports.testRejects = function (assert, done) {
   getFavicon({})
     .then(invalidResolve(assert), validReject(assert, 'Object'))
-  .then(getFavicon(null))
+  .then(() => getFavicon(null))
     .then(invalidResolve(assert), validReject(assert, 'null'))
-  .then(getFavicon(undefined))
+  .then(() => getFavicon(undefined))
     .then(invalidResolve(assert), validReject(assert, 'undefined'))
-  .then(getFavicon([]))
+  .then(() => getFavicon([]))
     .then(invalidResolve(assert), validReject(assert, 'Array'))
-    .then(done);
+    .catch(assert.fail).then(done);
 };
 
 function invalidResolve (assert) {

--- a/test/addons/places/tests/test-places-utils.js
+++ b/test/addons/places/tests/test-places-utils.js
@@ -31,26 +31,25 @@ exports['test construct tree'] = function (assert) {
   assert.equal(tree.get(4).get(2), null, 'node.get descends from itself fails if not descendant');
 };
 
-exports['test walk'] = function (assert) {
+exports['test walk'] = function (assert, done) {
   let resultsAll = [];
+  let resultsNode = [];
   let tree = TreeNode(1);
   tree.add([2, 3, 4]);
   tree.get(2).add([2.1, 2.2]);
 
   tree.walk(function (node) {
     resultsAll.push(node.value);
-  });
-
-  [1, 2, 2.1, 2.2, 3, 4].forEach(function (num) {
-    assert.ok(~resultsAll.indexOf(num), 'function applied to each node from root');
-  });
-
-  let resultsNode = [];
-  tree.get(2).walk(function (node) resultsNode.push(node.value));
-
-  [2, 2.1, 2.2].forEach(function (num) {
-    assert.ok(~resultsNode.indexOf(num), 'function applied to each node from node');
-  });
+  }).then(() => {
+    [1, 2, 2.1, 2.2, 3, 4].forEach(num => {
+      assert.ok(~resultsAll.indexOf(num), 'function applied to each node from root');
+    });
+    return tree.get(2).walk(node => resultsNode.push(node.value));
+  }).then(() => {
+    [2, 2.1, 2.2].forEach(function (num) {
+      assert.ok(~resultsNode.indexOf(num), 'function applied to each node from node');
+    });
+  }).catch(assert.fail).then(done);
 };
 
 exports['test async walk'] = function (assert, done) {

--- a/test/test-net-url.js
+++ b/test/test-net-url.js
@@ -29,18 +29,6 @@ exports["test async readURI"] = function(assert, done) {
   assert.equal(content, "", "The URL content is not load yet");
 }
 
-exports["test sync readURI"] = function(assert) {
-  let content = "";
-
-  readURI(data.url("test-net-url.txt"), { sync: true }).then(function(data) {
-    content = data;
-  }, function() {
-    assert.fail("should not reject");
-  })
-
-  assert.equal(content, utf8text, "The URL content is loaded properly");
-}
-
 exports["test readURISync"] = function(assert) {
   let content = readURISync(data.url("test-net-url.txt"));
 
@@ -62,21 +50,6 @@ exports["test async readURI with ISO-8859-1 charset"] = function(assert, done) {
   assert.equal(content, "", "The URL content is not load yet");
 }
 
-exports["test sync readURI with ISO-8859-1 charset"] = function(assert) {
-  let content = "";
-
-  readURI(data.url("test-net-url.txt"), {
-    sync: true,
-    charset: "ISO-8859-1"
-  }).then(function(data) {
-    content = data;
-  }, function() {
-    assert.fail("should not reject");
-  })
-
-  assert.equal(content, latin1text, "The URL content is loaded properly");
-}
-
 exports["test readURISync with ISO-8859-1 charset"] = function(assert) {
   let content = readURISync(data.url("test-net-url.txt"), "ISO-8859-1");
 
@@ -90,14 +63,6 @@ exports["test async readURI with not existing file"] = function(assert, done) {
   }, function(reason) {
     assert.ok(reason.indexOf("Failed to read:") === 0);
     done();
-  })
-}
-
-exports["test sync readURI with not existing file"] = function(assert) {
-  readURI(data.url("test-net-url-fake.txt"), { sync: true }).then(function(data) {
-    assert.fail("should not resolve");
-  }, function(reason) {
-    assert.ok(reason.indexOf("Failed to read:") === 0);
   })
 }
 
@@ -122,18 +87,6 @@ exports["test async readURI with data URI"] = function(assert, done) {
   assert.equal(content, "", "The URL content is not load yet");
 }
 
-exports["test sync readURI with data URI"] = function(assert) {
-  let content = "";
-
-  readURI(dataURIutf8, { sync: true }).then(function(data) {
-    content = data;
-  }, function() {
-    assert.fail("should not reject");
-  })
-
-  assert.equal(content, utf8text, "The URL content is loaded properly");
-}
-
 exports["test readURISync with data URI"] = function(assert) {
   let content = readURISync(dataURIutf8);
 
@@ -153,21 +106,6 @@ exports["test async readURI with data URI and ISO-8859-1 charset"] = function(as
   })
 
   assert.equal(content, "", "The URL content is not load yet");
-}
-
-exports["test sync readURI with data URI and ISO-8859-1 charset"] = function(assert) {
-  let content = "";
-
-  readURI(dataURIlatin1, {
-    sync: true,
-    charset: "ISO-8859-1"
-  }).then(function(data) {
-    content = unescape(data);
-  }, function() {
-    assert.fail("should not reject");
-  })
-
-  assert.equal(content, latin1text, "The URL content is loaded properly");
 }
 
 exports["test readURISync with data URI and ISO-8859-1 charset"] = function(assert) {
@@ -195,18 +133,6 @@ exports["test async readURI with chrome URI"] = function(assert, done) {
   })
 
   assert.equal(content, "", "The URL content is not load yet");
-}
-
-exports["test sync readURI with chrome URI"] = function(assert) {
-  let content = "";
-
-  readURI(chromeURI, { sync: true }).then(function(data) {
-    content = data;
-  }, function() {
-    assert.fail("should not reject");
-  })
-
-  assert.equal(content, readURISync(chromeURI), "The URL content is loaded properly");
 }
 
 require("test").run(exports)

--- a/test/test-panel.js
+++ b/test/test-panel.js
@@ -901,7 +901,7 @@ exports['test passing DOM node as first argument'] = function (assert, done) {
 
   let widgetNode = document.getElementById(widgetId);
 
-  all(warned.promise, shown.promise).
+  all([warned.promise, shown.promise]).
     then(loader.unload).
     then(done, assert.fail)
 

--- a/test/test-ui-frame.js
+++ b/test/test-ui-frame.js
@@ -9,6 +9,7 @@ module.metadata = {
   }
 };
 
+const { Cu } = require("chrome");
 const { Frame } = require("sdk/ui/frame");
 const { Toolbar } = require("sdk/ui/toolbar");
 const { Loader } = require("sdk/test/loader");
@@ -16,15 +17,29 @@ const { identify } = require("sdk/ui/id");
 const { setTimeout } = require("sdk/timers");
 const { getMostRecentBrowserWindow, open } = require("sdk/window/utils");
 const { ready, loaded, close } = require("sdk/window/helpers");
-const { defer } = require("sdk/core/promise");
+const { defer, all } = require("sdk/core/promise");
 const { send } = require("sdk/event/utils");
 const { object } = require("sdk/util/sequence");
 const { OutputPort } = require("sdk/output/system");
+const { Task } = Cu.import("resource://gre/modules/Task.jsm", {});
 const output = new OutputPort({ id: "toolbar-change" });
 
-const wait = (toolbar, event) => {
+const wait = (toolbar, event, times) => {
   let { promise, resolve } = defer();
-  toolbar.once(event, resolve);
+  if (times) {
+    let resolveArray = [];
+    let counter = 0;
+    toolbar.on(event, function onEvent (e) {
+      resolveArray.push(e);
+      if (++counter === times) {
+        toolbar.off(event, onEvent);
+        resolve(resolveArray);
+      }
+    });
+  }
+  else {
+    toolbar.once(event, resolve);
+  }
   return promise;
 };
 
@@ -36,7 +51,9 @@ const stateEventsFor = frame =>
 const isAttached = ({id}, window=getMostRecentBrowserWindow()) =>
   !!window.document.getElementById(id);
 
-exports["test frame API"] = function*(assert) {
+// Use `Task.spawn` instead of `Task.async` because the returned function does not contain
+// a length for the test harness to determine whether the test should be executed
+exports["test frame API"] = function* (assert) {
   const url = "data:text/html,frame-api";
   assert.throws(() => new Frame(),
                 /The `options.url`/,
@@ -86,8 +103,7 @@ exports["test frame API"] = function*(assert) {
   f3.destroy();
 };
 
-
-exports["test frame in toolbar"] = function*(assert) {
+exports["test frame in toolbar"] = function* (assert) {
   const assertEvent = (event, type) => {
     assert.ok(event, "`" + type + "` event was dispatched");
     assert.equal(event.type, type, "event.type is: " + type);
@@ -116,7 +132,6 @@ exports["test frame in toolbar"] = function*(assert) {
   const [a2, r2, l2] = stateEventsFor(f1);
   const w2 = open();
 
-
   assertEvent((yield a2), "attach");
   assert.ok(isAttached(f1, w2), "frame is in the window#2");
   assertEvent((yield r2), "ready");
@@ -126,7 +141,6 @@ exports["test frame in toolbar"] = function*(assert) {
 
   const d1 = wait(f1, "detach");
   yield close(w2);
-
   assertEvent((yield d1), "detach");
   assert.pass("frame detached when window is closed");
 
@@ -138,7 +152,7 @@ exports["test frame in toolbar"] = function*(assert) {
 };
 
 
-exports["test host to content messaging"] = function*(assert) {
+exports["test host to content messaging"] = function* (assert) {
   const url = "data:text/html,<script>new " + function() {
     window.addEventListener("message", (event) => {
       if (event.data === "ping!")
@@ -159,7 +173,7 @@ exports["test host to content messaging"] = function*(assert) {
 };
 
 
-exports["test content to host messaging"] = function*(assert) {
+exports["test content to host messaging"] = function* (assert) {
   const url = "data:text/html,<script>new " + function() {
     window.addEventListener("message", (event) => {
       if (event.data === "pong!")
@@ -182,10 +196,11 @@ exports["test content to host messaging"] = function*(assert) {
 
   t1.destroy();
   yield wait(t1, "detach");
+
 };
 
 
-exports["test direct messaging"] = function*(assert) {
+exports["test direct messaging"] = function* (assert) {
   const url = "data:text/html,<script>new " + function() {
     var n = 0;
     window.addEventListener("message", (event) => {
@@ -208,31 +223,30 @@ exports["test direct messaging"] = function*(assert) {
   yield wait(f1, "ready");
   assert.pass("document loaded in window#2");
 
+  let messages = wait(f1, "message", 2);
   f1.postMessage("inc", f1.origin);
   f1.postMessage("print", f1.origin);
 
-  const e1 = yield wait(f1, "message");
+  const [e1, e2] = yield messages;
   assert.deepEqual(e1.data, {n: 1}, "received message from window#1");
-
-  const e2 = yield wait(f1, "message");
   assert.deepEqual(e2.data, {n: 1}, "received message from window#2");
 
+  let message = wait(f1, "message");
   e1.source.postMessage("inc", e1.origin);
-
   e1.source.postMessage("print", e1.origin);
-
-  const e3 = yield wait(f1, "message");
+  const e3 = yield message;
   assert.deepEqual(e3.data, {n: 2}, "state changed in window#1");
 
+  let message = wait(f1, "message");
   e2.source.postMessage("print", e2.origin);
-  const e4 = yield wait(f1, "message");
-
+  yield message;
   assert.deepEqual(e2.data, {n:1}, "window#2 didn't received inc message");
 
   yield close(w2);
   t1.destroy();
 
   yield wait(t1, "detach");
+
 };
 
 require("sdk/test").run(exports);


### PR DESCRIPTION
prototype inheritence promise functions. Remove net/url#readURI sync
options. Promise.all now only accepts promises, not spreads.
