### PR TITLE
Bug 993029: Tag the SDK console with the add-on ID.

### DIFF
--- a/lib/sdk/console/plain-text.js
+++ b/lib/sdk/console/plain-text.js
@@ -50,7 +50,8 @@ function PlainTextConsole(print, innerID) {
     prefix: self.name + ": ",
     maxLogLevel: logLevel,
     dump: print,
-    innerID: innerID
+    innerID: innerID,
+    consoleID: "addon/" + self.id
   };
   let console = new ConsoleAPI(consoleOptions);
 

--- a/lib/toolkit/loader.js
+++ b/lib/toolkit/loader.js
@@ -40,7 +40,7 @@ const { notifyObservers } = Cc['@mozilla.org/observer-service;1'].
                         getService(Ci.nsIObserverService);
 const { NetUtil } = Cu.import("resource://gre/modules/NetUtil.jsm", {});
 const { Reflect } = Cu.import("resource://gre/modules/reflect.jsm", {});
-const { console } = Cu.import("resource://gre/modules/devtools/Console.jsm");
+const { ConsoleAPI } = Cu.import("resource://gre/modules/devtools/Console.jsm");
 const { join: pathJoin, normalize, dirname } = Cu.import("resource://gre/modules/osfile/ospath_unix.jsm");
 
 // Define some shortcuts.
@@ -688,6 +688,10 @@ exports.unload = unload;
 //   If `resolve` does not returns `uri` string exception will be thrown by
 //   an associated `require` call.
 const Loader = iced(function Loader(options) {
+  let console = new ConsoleAPI({
+    consoleID: options.id ? "addon/" + options.id : ""
+  });
+
   let {
     modules, globals, resolve, paths, rootURI, manifest, requireMap, isNative
   } = override({


### PR DESCRIPTION
Makes sure all our consoles show up in the add-on console.
