### PR TITLE
Bug 1026796 - Allow tags, annotation, and frecency sorting

### DIFF
--- a/lib/sdk/places/utils.js
+++ b/lib/sdk/places/utils.js
@@ -213,7 +213,10 @@ const SORT_MAP = {
   // keywords currently unsupported
   // keyword: 9,
   dateAdded: 11, // bookmarks only
-  lastModified: 13 // bookmarks only
+  lastModified: 13, // bookmarks only
+  tags: 17,
+  annotation: 19,
+  frecency: 21
 };
 
 function createQueryOptions (type, options) {


### PR DESCRIPTION
Not tested but appears to match values at https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsINavHistoryQueryOptions#Sorting_methods 

(I'm currently only interested in frecency (for applying the awesomebar approach to my `file://` browser overlay add-on), but thought all of these ought to be included).