### PR TITLE
bug 1026844 - Allow sourcing activate from outside addon-sdk directory

### DIFF
--- a/bin/activate
+++ b/bin/activate
@@ -44,7 +44,7 @@ deactivate nondestructive
 _OLD_PYTHONPATH="$PYTHONPATH"
 _OLD_VIRTUAL_PATH="$PATH"
 
-VIRTUAL_ENV="`pwd`"
+VIRTUAL_ENV="$(cd "$(dirname "${BASH_SOURCE:-$0}")"; cd ..; pwd)"
 
 if [ "x$OSTYPE" = "xmsys" ] ; then
   CUDDLEFISH_ROOT="`pwd -W | sed s,/,\\\\\\\\,g`"
@@ -57,8 +57,6 @@ else
   PYTHONPATH="$VIRTUAL_ENV/python-lib:$PYTHONPATH"
   PATH="$VIRTUAL_ENV/bin:$PATH"
 fi
-
-VIRTUAL_ENV="`pwd`"
 
 export CUDDLEFISH_ROOT
 export PYTHONPATH

--- a/bin/activate.fish
+++ b/bin/activate.fish
@@ -45,7 +45,7 @@ set -gx _OLD_PYTHONPATH $PYTHONPATH
 set -gx _OLD_VIRTUAL_PATH $PATH
 set -gx _OLD_FISH_PROMPT_OVERRIDE "true"
 
-set VIRTUAL_ENV (pwd)
+set VIRTUAL_ENV (dirname (dirname (status -f)))
 
 set -gx CUDDLEFISH_ROOT $VIRTUAL_ENV
 set -gx PYTHONPATH "$VIRTUAL_ENV/python-lib" $PYTHONPATH


### PR DESCRIPTION
It is possible for bash/zsh/fish to source activate outside addon-sdk directory.
I have not investigated about PowerShell, though.
