### PR TITLE
Bug 858399 Patch - context menu should work in panels solution

### DIFF
--- a/lib/sdk/panel/utils.js
+++ b/lib/sdk/panel/utils.js
@@ -234,6 +234,8 @@ function make(document) {
   document = document || getMostRecentBrowserWindow().document;
   let panel = document.createElementNS(XUL_NS, "panel");
   panel.setAttribute("type", "arrow");
+  // Add the context menu ability to the panel
+  panel.setAttribute("context", "contentAreaContextMenu");
 
   // Note that panel is a parent of `viewFrame` who's `docShell` will be
   // configured at creation time. If `panel` and there for `viewFrame` won't


### PR DESCRIPTION
Solution adds context attribute to the panel element with a value of
'contentAreaContextMenu' when the panel element is created during the sdk/panel/utils.js make function.
