### PR TITLE
Bug 858399 - solution adds context menu to panels

### DIFF
--- a/lib/sdk/panel.js
+++ b/lib/sdk/panel.js
@@ -59,7 +59,8 @@ let displayContract = contract({
   width: number,
   height: number,
   focus: boolean,
-  position: position
+  position: position,
+  contextMenu: boolean
 });
 
 let panelContract = contract(merge({}, displayContract.rules, loaderContract.rules));
@@ -120,6 +121,7 @@ const Panel = Class({
       defaultHeight: 240,
       focus: true,
       position: Object.freeze({}),
+      contextMenu: false
     }, panelContract(options));
     models.set(this, model);
 
@@ -167,6 +169,9 @@ const Panel = Class({
 
   /* Public API: Panel.position */
   get position() modelFor(this).position,
+  
+  /* Public API: Panel.contextMenu */
+  get contextMenu() modelFor(this).contextMenu,
 
   get contentURL() modelFor(this).contentURL,
   set contentURL(value) {
@@ -205,7 +210,8 @@ const Panel = Class({
       height: model.height,
       defaultWidth: model.defaultWidth,
       defaultHeight: model.defaultHeight,
-      focus: model.focus
+      focus: model.focus,
+      contextMenu: model.contextMenu
     }, displayContract(options));
 
     if (!isDisposed(this))

--- a/lib/sdk/panel/utils.js
+++ b/lib/sdk/panel/utils.js
@@ -210,6 +210,14 @@ function show(panel, options, anchor) {
   // if focus is set to false
   panel.setAttribute("noautofocus", !options.focus);
 
+  // Prevent the panel from showing the context menu
+  // if contextMenu is set to false
+  if(options.contextMenu) {
+    panel.setAttribute("context", "contentAreaContextMenu");
+  } else {
+    panel.removeAttribute("context");
+  }
+
   let window = anchor && getOwnerBrowserWindow(anchor);
   let { document } = window ? window : getMostRecentBrowserWindow();
   attach(panel, document);


### PR DESCRIPTION
Context menu only shows when contextMenu: true in panel constructor (defaults to false)

Also added get contextMenu property from panel

Also added ability to temporarily change contextMenu property setting in
the panel show(options) function

EXAMPLE USAGE:

``` js
var { ToggleButton } = require('sdk/ui/button/toggle');
var panels = require("sdk/panel");

var button = ToggleButton({
  id: "my-button",
  label: "my button",
  icon: {
    "16": "./icon-16.png",
    "32": "./icon-32.png",
    "64": "./icon-64.png"
  },
  onChange: handleChange
});

var panel = panels.Panel({
  contentURL: "https://news.ycombinator.com",
  width: 500,
  height: 600,
  onHide: handleHide,
  contextMenu: true   //initial contextMenu setting, defaults to false
});

function handleChange(state) {
  if (state.checked) {
    panel.show({
      position: button,
      contextMenu: false  //override contextMenu constructor setting temporarily
    });
  }
}

function handleHide() {
  console.log("panel.contextMenu:"+panel.contextMenu);  //read the current contextMenu setting
  button.state('window', {checked: false});
}
```
