### PR TITLE
Bug 858399 - solution adds context menu to panels

### DIFF
--- a/lib/sdk/panel.js
+++ b/lib/sdk/panel.js
@@ -73,7 +73,8 @@ let panelContract = contract(merge({
   }),
   contentStyleFile: merge(Object.create(loaderContract.rules.contentScriptFile), {
     msg: 'The `contentStyleFile` option must be a local URL or an array of URLs'
-  })
+  }),
+  contextMenu: boolean
 }, displayContract.rules, loaderContract.rules));
 
 
@@ -134,6 +135,7 @@ const Panel = Class({
       defaultHeight: 240,
       focus: true,
       position: Object.freeze({}),
+      contextMenu: false
     }, panelContract(options));
     models.set(this, model);
 
@@ -151,6 +153,9 @@ const Panel = Class({
 
     // Load panel content.
     domPanel.setURL(view, model.contentURL);
+    
+    // Allow context menu
+    domPanel.allowContextMenu(view, model.contextMenu);
 
     setupAutoHide(this);
 
@@ -188,7 +193,15 @@ const Panel = Class({
 
   /* Public API: Panel.position */
   get position() modelFor(this).position,
-
+  
+  /* Public API: Panel.contextMenu */
+  get contextMenu() modelFor(this).contextMenu,
+  set contextMenu(allow) {
+    let model = modelFor(this);
+    model.contextMenu = panelContract({ contextMenu: allow }).contextMenu;
+    domPanel.allowContextMenu(viewFor(this), model.contextMenu);
+  },
+    
   get contentURL() modelFor(this).contentURL,
   set contentURL(value) {
     let model = modelFor(this);
@@ -226,7 +239,8 @@ const Panel = Class({
       height: model.height,
       defaultWidth: model.defaultWidth,
       defaultHeight: model.defaultHeight,
-      focus: model.focus
+      focus: model.focus,
+      contextMenu: model.contextMenu
     }, displayContract(options));
 
     if (!isDisposed(this))

--- a/lib/sdk/panel/utils.js
+++ b/lib/sdk/panel/utils.js
@@ -211,7 +211,7 @@ function show(panel, options, anchor) {
   // Prevent the panel from getting focus when showing up
   // if focus is set to false
   panel.setAttribute("noautofocus", !options.focus);
-
+  
   let window = anchor && getOwnerBrowserWindow(anchor);
   let { document } = window ? window : getMostRecentBrowserWindow();
   attach(panel, document);
@@ -404,3 +404,13 @@ exports.getContentDocument = getContentDocument;
 
 function setURL(panel, url) getContentFrame(panel).setAttribute("src", url)
 exports.setURL = setURL;
+
+function allowContextMenu(panel, allow) {
+  if(allow) {
+    panel.setAttribute("context", "contentAreaContextMenu");
+  } 
+  else {
+    panel.removeAttribute("context");
+  }
+}
+exports.allowContextMenu = allowContextMenu;


### PR DESCRIPTION
Context menu only shows when contextMenu: true in panel constructor
(defaults to false).

contextMenu is now added to the panelContract, not the displayContract

Also added get contextMenu property from panel

Removed contextMenu from show() and relaced with ability to set
contextMenu property (i.e. panel.contextMenu=true)
