### PR TITLE
Bug 994280 - It would be nice to have ability to add badge over button

### DIFF
--- a/lib/sdk/ui/button/action.js
+++ b/lib/sdk/ui/button/action.js
@@ -108,4 +108,5 @@ on(actionButtonStateEvents, 'data', ({target, window, state}) => {
   view.setIcon(id, window, state.icon);
   view.setLabel(id, window, state.label);
   view.setDisabled(id, window, state.disabled);
+  view.setBadge(id, window, state.badge, state.badgeColor);
 });

--- a/lib/sdk/ui/button/contract.js
+++ b/lib/sdk/ui/button/contract.js
@@ -6,14 +6,13 @@
 const { contract } = require('../../util/contract');
 const { isLocalURL } = require('../../url');
 const { isNil, isObject, isString } = require('../../lang/type');
-const { required, either, string, boolean, object } = require('../../deprecated/api-utils');
+const { required, either, string, boolean, object, number } = require('../../deprecated/api-utils');
 const { merge } = require('../../util/object');
 const { freeze } = Object;
 
-function isIconSet(icons) {
-  return Object.keys(icons).
-    every(size => String(size >>> 0) === size && isLocalURL(icons[size]))
-}
+const isIconSet = (icons) =>
+  Object.keys(icons).
+    every(size => String(size >>> 0) === size && isLocalURL(icons[size]));
 
 let iconSet = {
   is: either(object, string),
@@ -36,10 +35,22 @@ let label = {
   msg: 'The option "label" must be a non empty string'
 }
 
+let badge = {
+  is: either(string, number),
+  msg: 'The option "badge" must be a string or a number'
+}
+
+let badgeColor = {
+  is: string,
+  msg: 'The option "badgeColor" must be a string'
+}
+
 let stateContract = contract({
   label: label,
   icon: iconSet,
-  disabled: boolean
+  disabled: boolean,
+  badge: badge,
+  badgeColor: badgeColor
 });
 
 exports.stateContract = stateContract;

--- a/lib/sdk/ui/button/toggle.js
+++ b/lib/sdk/ui/button/toggle.js
@@ -100,6 +100,7 @@ on(toggleButtonStateEvents, 'data', ({target, window, state}) => {
   view.setLabel(id, window, state.label);
   view.setDisabled(id, window, state.disabled);
   view.setChecked(id, window, state.checked);
+  view.setBadge(id, window, state.badge, state.badgeColor);
 });
 
 on(clickEvents, 'data', ({target: id, window, checked }) => {

--- a/lib/sdk/ui/button/view.js
+++ b/lib/sdk/ui/button/view.js
@@ -15,7 +15,7 @@ const { on, off, emit } = require('../../event/core');
 
 const { data } = require('sdk/self');
 
-const { isObject } = require('../../lang/type');
+const { isObject, isNil } = require('../../lang/type');
 
 const { getMostRecentBrowserWindow } = require('../../window/utils');
 const { ignoreWindow } = require('../../private-browsing/utils');
@@ -114,7 +114,7 @@ function nodeFor(id, window=getMostRecentBrowserWindow()) {
 exports.nodeFor = nodeFor;
 
 function create(options) {
-  let { id, label, icon, type } = options;
+  let { id, label, icon, type, badge } = options;
 
   if (views.has(id))
     throw new Error('The ID "' + id + '" seems already used.');
@@ -137,7 +137,7 @@ function create(options) {
         node.style.display = 'none';
 
       node.setAttribute('id', this.id);
-      node.setAttribute('class', 'toolbarbutton-1 chromeclass-toolbar-additional');
+      node.setAttribute('class', 'toolbarbutton-1 chromeclass-toolbar-additional badged-button');
       node.setAttribute('type', type);
       node.setAttribute('label', label);
       node.setAttribute('tooltiptext', label);
@@ -212,6 +212,27 @@ function setChecked(id, window, checked) {
     node.checked = checked;
 }
 exports.setChecked = setChecked;
+
+function setBadge(id, window, badge, color) {
+  let node = nodeFor(id, window);
+
+  if (node) {
+    // `Array.from` is needed to handle unicode symbol properly:
+    // '𝐀𝐁'.length is 4 where Array.from('𝐀𝐁').length is 2
+    let text = isNil(badge)
+                  ? ''
+                  : Array.from(String(badge)).slice(0, 4).join('');
+
+    node.setAttribute('badge', text);
+
+    let badgeNode = node.ownerDocument.getAnonymousElementByAttribute(node,
+                                        'class', 'toolbarbutton-badge');
+
+    if (badgeNode)
+      badgeNode.style.backgroundColor = isNil(color) ? '' : color;
+  }
+}
+exports.setBadge = setBadge;
 
 function click(id) {
   let node = nodeFor(id);


### PR DESCRIPTION
- Added badge support for both `ActionButton` and `ToggleButton`
- Unit Test needs to be added

**Notice** that this PR needs the platform patch attached in [bug 994280](https://bugzilla.mozilla.org/show_bug.cgi?id=994280) to work properly.
And [bug 1037528](https://bugzilla.mozilla.org/show_bug.cgi?id=1037528) is a probably a blocker to land this feature.
## API

I slightly changed the API in the last commit. The previous API was:

``` js
// old API
let button = ActionButton({
  id: 'my-button',
  label: 'my button',
  icon: './icon.png',
  badge: {
    text: '+1',  // both string and number
    color: 'red' // optional, just string
})
```

Now the API is:

``` js
// new API
let button = ActionButton({
  id: 'my-button',
  label: 'my button',
  icon: './icon.png',
  badge: '+1',
  badgeColor: 'red'
});
```

Where I don't like "prefixing" object properties in such ways – see all the `contentScript*` we have – after I tried to use a bit the old API implementation, I noticed it was a bit too cumbersome; considering that our nested objects are immutable – they're snapshot, just "descriptor", in order to avoid side effects.

To be more clear, let's consider a really simple use case: increase the value of the badge, and then change color based on that value. With the current new API, this is the code:

``` js
// new API
let button = ActionButton({
  id: 'my-button',
  label: 'my button',
  icon: './icon.png',
  badge: 1,
  onClick: function() {
    // every time we click, we increment by one
    this.badge += 1;
  }
});

// let's assume that now we want to change just the color,
// based on some event or content we received:

myservice.on("ContentReceived", data => {
  button.badgeColor = data.type === 'warning' ? 'yellow' : '';
});
```

In this way the click is independent, the only thing changed is the color, and it doesn't matter if we passed a number, or a string previously.
With the previous API, it's a different thing:

``` js
// old API
let button = ActionButton({
  id: 'my-button',
  label: 'my button',
  icon: './icon.png',
  badge: {
    text: 1
  },
  onClick: function() {
    // every time we click, we increment by one
    this.badge = {text: this.badge.text + 1};
  }
});

// let's assume that now we want to change just the color,
// based on some event or content we received:

myservice.on("ContentReceived", data => {
  // we need to get the text value as first thing:
  let { text } = button.badge;
  let color = data.type === 'warning' ? 'yellow' : '';

   button.badge = { text: text, color: color };
});
```

Also, with the old API it was verbose to simply set a text, without color, that is likely the more common use case. Of course, we could also makes the `badge` property takes an object,  `number` or `string`, but if the user wanted to change color later, it would be more verbose to him:

``` js
myservice.on("ContentReceived", data => {
  // we need to get the text value as first thing:
  let text = "text" in button.badge ? button.badge.text : button.badge;
  let color = data.type === 'warning' ? 'yellow' : '';

   button.badge = { text: text, color: color };
});
```

Notice also that thanks to the `state` method, the developer is still able to set both properties in one line, as object, even in the new API, if he really likes that, or have a set of objects with defined properties – but I don't think is the case for badges:

``` js
  button.state(button, {badge: '+1', badgeColor: 'red'});
```
