### PR TITLE
Bug 1039825 - "ReferenceError: newTab is not defined" running `test-widget`

### DIFF
--- a/test/test-widget.js
+++ b/test/test-widget.js
@@ -36,8 +36,6 @@ function openNewWindowTab(url, options) {
     if (options.onLoad) {
       options.onLoad({ target: { defaultView: window } })
     }
-
-    return newTab;
   });
 }
 
@@ -538,7 +536,7 @@ exports.testConstructor = function(assert, done) {
       assert.equal(widgetCount2(), widgetStartCount2, "2nd window has correct number of child elements after second destroy");
 
       close(browserWindow).then(doneTest);
-    }});
+    }}).catch(assert.fail);
   });
 
   // test window closing
@@ -634,7 +632,7 @@ exports.testConstructor = function(assert, done) {
         browserWindow.setToolbarVisibility(container(), true);
 
         close(browserWindow2).then(doneTest);
-      }});
+      }}).catch(assert.fail);
     });
   }
 
@@ -1179,7 +1177,7 @@ exports.testReinsertion = function(assert, done) {
       loader.unload();
       done();
     });
-  }});
+  }}).catch(assert.fail);
 };
 
 exports.testWideWidget = function testWideWidget(assert) {


### PR DESCRIPTION
- Added `.catch(assert.fail)` after each `openNewWindowTab` calls
- Removed unused and undeclared `newTab` variable
