### PR TITLE
Bug 866733 - Replace 'for each (v in iterable)' loops

### DIFF
--- a/lib/sdk/clipboard.js
+++ b/lib/sdk/clipboard.js
@@ -304,7 +304,7 @@ function currentFlavors() {
   // confirmation for specific flavors any other way. This is supposed to be
   // an inexpensive call, so performance shouldn't be impacted (much).
   var currentFlavors = [];
-  for each (var flavor in kAllowableFlavors) {
+  for (var flavor of kAllowableFlavors) {
     var matches = clipboardService.hasDataMatchingFlavors(
       [flavor],
       1,
@@ -321,7 +321,7 @@ Object.defineProperty(exports, "currentFlavors", { get : currentFlavors });
 // SUPPORT FUNCTIONS ////////////////////////////////////////////////////////
 
 function toJetpackFlavor(aFlavor) {
-  for each (let flavorMap in kFlavorMap)
+  for (let flavorMap of kFlavorMap)
     if (flavorMap.long == aFlavor)
       return flavorMap.short;
   // Return null in the case where we don't match
@@ -330,7 +330,7 @@ function toJetpackFlavor(aFlavor) {
 
 function fromJetpackFlavor(aJetpackFlavor) {
   // TODO: Handle proper flavors better
-  for each (let flavorMap in kFlavorMap)
+  for (let flavorMap of kFlavorMap)
     if (flavorMap.short == aJetpackFlavor || flavorMap.long == aJetpackFlavor)
       return flavorMap.long;
   // Return null in the case where we don't match.

--- a/lib/sdk/content/content-worker.js
+++ b/lib/sdk/content/content-worker.js
@@ -41,7 +41,7 @@ Object.freeze({
         return [];
       let args = Array.slice(arguments, 1);
       let results = [];
-      for each (let callback in listeners[name]) {
+      for (let callback of listeners[name]) {
         results.push(callback.apply(null, args));
       }
       return results;

--- a/lib/sdk/deprecated/events.js
+++ b/lib/sdk/deprecated/events.js
@@ -148,7 +148,7 @@ const eventEmitter =  {
     if (!listeners.length)
       return false;
     let params = Array.slice(arguments, 2);
-    for each (let listener in listeners) {
+    for (let listener of listeners) {
       try {
         listener.apply(targetObj, params);
       } catch(e) {

--- a/lib/sdk/deprecated/traits-worker.js
+++ b/lib/sdk/deprecated/traits-worker.js
@@ -367,7 +367,7 @@ const WorkerSandbox = EventEmitter.compose({
    */
   _importScripts: function _importScripts(url) {
     let urls = Array.slice(arguments, 0);
-    for each (let contentScriptFile in urls) {
+    for (let contentScriptFile of urls) {
       try {
         let uri = URL(contentScriptFile);
         if (uri.scheme === 'resource')

--- a/lib/sdk/deprecated/traits.js
+++ b/lib/sdk/deprecated/traits.js
@@ -32,7 +32,7 @@ const defineProperties = Object.defineProperties,
 function _create(proto, trait) {
   let properties = {},
       keys = Object.getOwnPropertyNames(trait);
-  for each(let key in keys) {
+  for (let key of keys) {
     let descriptor = trait[key];
     if (descriptor.required &&
         !Object.prototype.hasOwnProperty.call(proto, key))
@@ -73,7 +73,7 @@ function TraitDescriptor(object)
 function Public(instance, trait) {
   let result = {},
       keys = Object.getOwnPropertyNames(trait);
-  for each (let key in keys) {
+  for (let key of keys) {
     if ('_' === key.charAt(0) && '__iterator__' !== key )
       continue;
     let property = trait[key],

--- a/lib/sdk/deprecated/traits/core.js
+++ b/lib/sdk/deprecated/traits/core.js
@@ -53,7 +53,7 @@ function areSame(desc1, desc2) {
  */
 function Map(names) {
   let map = {};
-  for each (let name in names)
+  for (let name of names)
     map[name] = true;
   return map;
 }
@@ -115,7 +115,7 @@ function Conflict(name) {
 function trait(properties) {
   let result = {},
       keys = getOwnPropertyNames(properties);
- for each (let key in keys) {
+ for (let key of keys) {
    let descriptor = getOwnPropertyDescriptor(properties, key);
    result[key] = (required === descriptor.value) ? Required(key) : descriptor;
  }
@@ -139,9 +139,9 @@ exports.Trait = exports.trait = trait;
 function compose(trait1, trait2) {
   let traits = Array.slice(arguments, 0),
       result = {};
-  for each (let trait in traits) {
+  for (let trait of traits) {
     let keys = getOwnPropertyNames(trait);
-    for each (let key in keys) {
+    for (let key of keys) {
       let descriptor = trait[key];
       // if property already exists and it's not a requirement
       if (hasOwn.call(result, key) && !result[key].required) {
@@ -176,7 +176,7 @@ function exclude(keys, trait) {
 
   keys = getOwnPropertyNames(trait);
 
-  for each (let key in keys) {
+  for (let key of keys) {
     if (!hasOwn.call(exclusions, key) || trait[key].required)
       result[key] = trait[key];
     else
@@ -209,9 +209,9 @@ function exclude(keys, trait) {
 function override() {
   let traits = Array.slice(arguments, 0),
       result = {};
-  for each (let trait in traits) {
+  for (let trait of traits) {
     let keys = getOwnPropertyNames(trait);
-    for each(let key in keys) {
+    for (let key of keys) {
       let descriptor = trait[key];
       if (!hasOwn.call(result, key) || result[key].required)
         result[key] = descriptor;
@@ -237,7 +237,7 @@ exports.override = override;
 function rename(map, trait) {
   let result = {},
       keys = getOwnPropertyNames(trait);
-  for each(let key in keys) {
+  for (let key of keys) {
     // must be renamed & it's not requirement
     if (hasOwn.call(map, key) && !trait[key].required) {
       let alias = map[key];
@@ -282,7 +282,7 @@ function resolve(resolutions, trait) {
   let renames = {},
       exclusions = [],
       keys = getOwnPropertyNames(resolutions);
-  for each (let key in keys) {  // pre-process renamed and excluded properties
+  for (let key of keys) {  // pre-process renamed and excluded properties
     if (resolutions[key])       // old name -> new name
       renames[key] = resolutions[key];
     else                        // name -> undefined
@@ -307,7 +307,7 @@ exports.resolve = resolve;
 function create(proto, trait) {
   let properties = {},
       keys = getOwnPropertyNames(trait);
-  for each(let key in keys) {
+  for (let key of keys) {
     let descriptor = trait[key];
     if (descriptor.required && !hasOwn.call(proto, key))
       throw new Error(ERR_REQUIRED + key);

--- a/lib/sdk/deprecated/unit-test-finder.js
+++ b/lib/sdk/deprecated/unit-test-finder.js
@@ -157,7 +157,7 @@ TestFinder.prototype = {
         }
 
         if (this.testInProcess) {
-          for each (let name in Object.keys(suiteModule).sort()) {
+          for (let name of Object.keys(suiteModule).sort()) {
             if (NOT_TESTS.indexOf(name) === -1 && filter(suite, name)) {
               tests.push({
                 setup: suiteModule.setup,

--- a/lib/sdk/deprecated/window-utils.js
+++ b/lib/sdk/deprecated/window-utils.js
@@ -51,7 +51,7 @@ exports.windowIterator = windowIterator;
  *    interface.
  */
 function browserWindowIterator() {
-  for each (let window in windowIterator()) {
+  for (let window of windowIterator()) {
     if (isBrowser(window))
       yield window;
   }
@@ -66,7 +66,7 @@ function WindowTracker(delegate) {
   this._delegate = delegate;
   this._loadingWindows = [];
 
-  for each (let window in getWindows())
+  for (let window of getWindows())
     this._regWindow(window);
   windowWatcher.registerNotification(this);
   this._onToplevelWindowReady = this._onToplevelWindowReady.bind(this);
@@ -120,7 +120,7 @@ WindowTracker.prototype = {
   unload: function unload() {
     windowWatcher.unregisterNotification(this);
     events.off('toplevel-window-ready', this._onToplevelWindowReady);
-    for each (let window in getWindows())
+    for (let window of getWindows())
       this._unregWindow(window);
   },
 

--- a/lib/sdk/keyboard/observer.js
+++ b/lib/sdk/keyboard/observer.js
@@ -51,7 +51,7 @@ windowObserver.on("close", function onClose(window) {
 });
 
 // Making observer aware of already opened windows.
-for each (let window in browserWindowIterator())
+for (let window of browserWindowIterator())
   observer.observe(window);
 
 exports.observer = observer;

--- a/lib/sdk/l10n/locale.js
+++ b/lib/sdk/l10n/locale.js
@@ -54,7 +54,7 @@ function getPreferedLocales(caseSensitve) {
   if (contentLocales) {
     // This list is a string of locales seperated by commas.
     // There is spaces after commas, so strip each item
-    for each(let locale in contentLocales.split(","))
+    for (let locale of contentLocales.split(","))
       addLocale(locale.replace(/(^\s+)|(\s+$)/g, ""));
   }
 
@@ -88,9 +88,9 @@ exports.findClosestLocale = function findClosestLocale(aLocales, aMatchLocales) 
   // The number of locale parts in the match
   let bestpartcount = 0;
 
-  for each (let locale in aMatchLocales) {
+  for (let locale of aMatchLocales) {
     let lparts = locale.split("-");
-    for each (let localized in aLocales) {
+    for (let localized of aLocales) {
       let found = localized.toLowerCase();
       // Exact match is returned immediately
       if (locale == found)

--- a/lib/sdk/panel/window.js
+++ b/lib/sdk/panel/window.js
@@ -28,7 +28,7 @@ function getWindow(anchor) {
     let anchorDocument = anchorWindow.document;
 
     // loop thru supported windows
-    for each(let enumWindow in windows) {
+    for (let enumWindow of windows) {
       // Check if the anchor is in this browser window.
       if (enumWindow == anchorWindow) {
         window = anchorWindow;

--- a/lib/sdk/tabs/observer.js
+++ b/lib/sdk/tabs/observer.js
@@ -93,6 +93,6 @@ windowObserver.on("activate", function onWindowActivate(chromeWindow) {
 
 // We should synchronize state, since probably we already have at least one
 // window open.
-for each (let window in browserWindowIterator()) onWindowOpen(window);
+for (let window of browserWindowIterator()) onWindowOpen(window);
 
 exports.observer = observer;

--- a/lib/sdk/tabs/tab-firefox.js
+++ b/lib/sdk/tabs/tab-firefox.js
@@ -7,6 +7,7 @@ const { Trait } = require("../deprecated/traits");
 const { EventEmitter } = require("../deprecated/events");
 const { defer } = require("../lang/functional");
 const { has } = require("../util/array");
+const { each } = require("../util/object");
 const { EVENTS } = require("./events");
 const { getThumbnailURIForWindow } = require("../content/thumbnail");
 const { getFaviconURIForLocation } = require("../io/data");
@@ -48,7 +49,7 @@ const TabTrait = Trait.compose(EventEmitter, {
     let window = this.window = options.window || require('../windows').BrowserWindow({ window: getOwnerWindow(this._tab) });
 
     // Setting event listener if was passed.
-    for each (let type in EVENTS) {
+    each(EVENTS, (type) => {
       let listener = options[type.listener];
       if (listener) {
         this.on(type.name, options[type.listener]);
@@ -56,7 +57,7 @@ const TabTrait = Trait.compose(EventEmitter, {
       // window spreads this event.
       if (!has(['ready', 'load', 'pageshow'], (type.name)))
         window.tabs.on(type.name, this._onEvent.bind(this, type.name));
-    }
+    });
 
     this.on(EVENTS.close.name, this.destroy.bind(this));
 
@@ -281,7 +282,7 @@ const getTabView = tab => viewNS(tab).tab;
 
 function Tab(options, existingOnly) {
   let chromeTab = options.tab;
-  for each (let tab in TABS) {
+  for (let tab of TABS) {
     if (chromeTab == tab._tab)
       return tab._public;
   }

--- a/lib/sdk/tabs/tabs-firefox.js
+++ b/lib/sdk/tabs/tabs-firefox.js
@@ -51,7 +51,7 @@ Object.defineProperties(tabs, {
 });
 
 function getWindow(privateState) {
-  for each (let window in windows) {
+  for (let window of windows) {
     if (privateState === isPrivate(window)) {
       return window;
     }

--- a/lib/sdk/tabs/utils.js
+++ b/lib/sdk/tabs/utils.js
@@ -113,13 +113,13 @@ exports.getOwnerWindow = getOwnerWindow;
 
 // fennec
 function getWindowHoldingTab(rawTab) {
-  for each (let window in getWindows()) {
+  for (let window of getWindows()) {
     // this function may be called when not using fennec,
     // but BrowserApp is only defined on Fennec
     if (!window.BrowserApp)
       continue;
 
-    for each (let tab in window.BrowserApp.tabs) {
+    for (let tab of window.BrowserApp.tabs) {
       if (tab === rawTab)
         return window;
     }
@@ -285,12 +285,12 @@ exports.getSelectedTab = getSelectedTab;
 
 
 function getTabForBrowser(browser) {
-  for each (let window in getWindows()) {
+  for (let window of getWindows()) {
     // this function may be called when not using fennec
     if (!window.BrowserApp)
       continue;
 
-    for each (let tab in window.BrowserApp.tabs) {
+    for  (let tab of window.BrowserApp.tabs) {
       if (tab.browser === browser)
         return tab;
     }

--- a/lib/sdk/test/harness.js
+++ b/lib/sdk/test/harness.js
@@ -164,8 +164,8 @@ function reportMemoryUsage() {
     mgr.getReportsForThisProcess(logReporter, null, /* anonymize = */ false);
 
     var weakrefs = [info.weakref.get()
-                    for each (info in memory.getObjects())];
-    weakrefs = [weakref for each (weakref in weakrefs) if (weakref)];
+                    for (info of memory.getObjects())];
+    weakrefs = [weakref for (weakref of weakrefs) if (weakref)];
     print("Tracked memory objects in testing sandbox: " + weakrefs.length + "\n");
   }));
 }
@@ -227,7 +227,7 @@ function cleanup() {
 
     if (profileMemory) {
       gWeakrefInfo = [{ weakref: info.weakref, bin: info.bin }
-                      for each (info in memory.getObjects())];
+                      for (info of memory.getObjects())];
     }
 
     loader.unload();
@@ -392,7 +392,7 @@ function nextIteration(tests) {
 
     reportMemoryUsage().then(_ => {
       let testRun = [];
-      for each (let test in tests.testRunSummary) {
+      for (let test of tests.testRunSummary) {
         let testCopy = {};
         for (let info in test) {
           testCopy[info] = test[info];
@@ -446,7 +446,7 @@ var consoleListener = {
       return;
     this.errorsLogged++;
     var message = object.QueryInterface(Ci.nsIConsoleMessage).message;
-    var pointless = [err for each (err in POINTLESS_ERRORS)
+    var pointless = [err for (err of POINTLESS_ERRORS)
                          if (message.indexOf(err) >= 0)];
     if (pointless.length == 0 && message)
       testConsole.log(message);

--- a/lib/sdk/test/runner.js
+++ b/lib/sdk/test/runner.js
@@ -53,13 +53,13 @@ function printFailedTests(tests, print) {
 
   print("\nThe following tests failed:\n");
 
-  for each (let testRun in tests.testRuns) {
+  for (let testRun of tests.testRuns) {
     iterationNumber++;
 
     if (!singleIteration)
       print("  Iteration " + iterationNumber + ":\n");
 
-    for each (let test in testRun) {
+    for (let test of testRun) {
       if (test.failed > 0) {
         print(padding + "  " + test.name + ": " + test.errors +"\n");
       }
@@ -102,7 +102,7 @@ exports.runTestsFromModule = function runTestsFromModule(module) {
 
     // Reproduce what is done in sdk/deprecated/unit-test-finder.findTests()
     let tests = [];
-    for each (let name in Object.keys(exports).sort()) {
+    for (let name of Object.keys(exports).sort()) {
       tests.push({
         setup: exports.setup,
         teardown: exports.teardown,

--- a/lib/sdk/util/array.js
+++ b/lib/sdk/util/array.js
@@ -99,7 +99,7 @@ exports.flatten = function flatten(array){
 function fromIterator(iterator) {
   let array = [];
   if (iterator.__iterator__) {
-    for each (let item in iterator)
+    for (let item of iterator)
       array.push(item);
   }
   else {

--- a/lib/sdk/util/list.js
+++ b/lib/sdk/util/list.js
@@ -44,7 +44,7 @@ const listOptions = {
   __iterator__: function __iterator__(onKeys, onKeyValue) {
     let array = listNS(this).keyValueMap.slice(0),
                 i = -1;
-    for each(let element in array)
+    for (let element of array)
       yield onKeyValue ? [++i, element] : onKeys ? ++i : element;
   },
 };

--- a/lib/sdk/util/registry.js
+++ b/lib/sdk/util/registry.js
@@ -21,7 +21,7 @@ const Registry = EventEmitter.compose({
   },
   _destructor: function _destructor() {
     let _registry = this._registry.slice(0);
-    for each (let instance in _registry)
+    for (let instance of _registry)
       this._emit('remove', instance);
     this._registry.splice(0);
   },

--- a/lib/sdk/widget.js
+++ b/lib/sdk/widget.js
@@ -322,7 +322,7 @@ const WidgetTrait = LightTrait.compose(EventEmitterTrait, LightTrait({
    *         Window that has been closed
    */
   _onWindowClosed: function _onWindowClosed(window) {
-    for each (let view in this._views) {
+    for (let view of this._views) {
       if (view._isInChromeWindow(window)) {
         view.destroy();
         break;
@@ -336,7 +336,7 @@ const WidgetTrait = LightTrait.compose(EventEmitterTrait, LightTrait({
    *         BrowserWindow reference from "windows" module
    */
   getView: function getView(window) {
-    for each (let view in this._views) {
+    for (let view of this._views) {
       if (view._isInWindow(window)) {
         return view._public;
       }

--- a/lib/sdk/windows/fennec.js
+++ b/lib/sdk/windows/fennec.js
@@ -40,7 +40,7 @@ const browserWindows = exports.browserWindows = BrowserWindows();
  * registered, `null` otherwise.
  */
 function getRegisteredWindow(chromeWindow) {
-  for each (let window in browserWindows) {
+  for (let window of browserWindows) {
     if (chromeWindow === windowNS(window).window)
       return window;
   }

--- a/lib/sdk/windows/firefox.js
+++ b/lib/sdk/windows/firefox.js
@@ -124,7 +124,7 @@ const BrowserWindowTrait = Trait.compose(
  * registered, `null` otherwise.
  */
 function getRegisteredWindow(chromeWindow) {
-  for each (let window in windows) {
+  for (let window of windows) {
     if (chromeWindow === window._window)
       return window;
   }

--- a/lib/sdk/windows/tabs-fennec.js
+++ b/lib/sdk/windows/tabs-fennec.js
@@ -158,7 +158,7 @@ function onTabSelect(event) {
   emit(tab, 'activate', tab);
   emit(gTabs, 'activate', tab);
 
-  for each (let t in gTabs) {
+  for (let of in gTabs) {
     if (t === tab) continue;
     emit(t, 'deactivate', t);
     emit(gTabs, 'deactivate', t);

--- a/lib/sdk/windows/tabs-firefox.js
+++ b/lib/sdk/windows/tabs-firefox.js
@@ -65,7 +65,7 @@ const WindowTabTracker = Trait.compose({
     this._onTabPinned = this._onTabEvent.bind(this, "pinned");
     this._onTabUnpinned = this._onTabEvent.bind(this, "unpinned");
 
-    for each (let tab in getTabs(this._window)) {
+    for (let tab of getTabs(this._window)) {
       // We emulate "open" events for all open tabs since gecko does not emits
       // them on the tabs that new windows are open with. Also this is
       // necessary to synchronize tabs lists with an actual state.
@@ -86,7 +86,7 @@ const WindowTabTracker = Trait.compose({
   _destroyWindowTabTracker: function _destroyWindowTabTracker() {
     // We emulate close events on all tabs, since gecko does not emits such
     // events by itself.
-    for each (let tab in this.tabs)
+    for (let tab of this.tabs)
       this._emitEvent("close", tab);
 
     this._tabs._clear();

--- a/test/tabs/test-fennec-tabs.js
+++ b/test/tabs/test-fennec-tabs.js
@@ -135,7 +135,7 @@ exports.testTabProperties = function(assert, done) {
 exports.testTabsIteratorAndLength = function(assert, done) {
   let newTabs = [];
   let startCount = 0;
-  for each (let t in tabs) startCount++;
+  for (let t of tabs) startCount++;
 
   assert.equal(startCount, tabs.length, "length property is correct");
 
@@ -146,7 +146,7 @@ exports.testTabsIteratorAndLength = function(assert, done) {
     url: url,
     onOpen: function(tab) {
       let count = 0;
-      for each (let t in tabs) count++;
+      for (let t of tabs) count++;
       assert.equal(count, startCount + 3, "iterated tab count matches");
       assert.equal(startCount + 3, tabs.length, "iterated tab count matches length property");
 

--- a/test/tabs/test-firefox-tabs.js
+++ b/test/tabs/test-firefox-tabs.js
@@ -278,7 +278,7 @@ exports.testTabContentTypeAndReload = function(assert, done) {
 exports.testTabsIteratorAndLength = function(assert, done) {
   open(null, { features: { chrome: true, toolbar: true } }).then(focus).then(function(window) {
     let startCount = 0;
-    for each (let t in tabs) startCount++;
+    for (let t of tabs) startCount++;
     assert.equal(startCount, tabs.length, "length property is correct");
     let url = "data:text/html;charset=utf-8,default";
 
@@ -288,7 +288,7 @@ exports.testTabsIteratorAndLength = function(assert, done) {
       url: url,
       onOpen: function(tab) {
         let count = 0;
-        for each (let t in tabs) count++;
+        for (let t of tabs) count++;
         assert.equal(count, startCount + 3, "iterated tab count matches");
         assert.equal(startCount + 3, tabs.length, "iterated tab count matches length property");
 

--- a/test/test-api-utils.js
+++ b/test/test-api-utils.js
@@ -289,7 +289,7 @@ exports.testAddIterator = function testAddIterator (assert) {
   apiUtils.addIterator(
     obj,
     function keysValsGen() {
-      for each (let keyVal in keysVals)
+      for (let keyVal of keysVals)
         yield keyVal;
     }
   );

--- a/test/test-file.js
+++ b/test/test-file.js
@@ -66,7 +66,7 @@ exports.testBasename = function(assert) {
 
 exports.testList = function(assert) {
   let list = file.list(profilePath);
-  let found = [ true for each (name in list)
+  let found = [ true for (name of list)
                     if (name === fileNameInProfile) ];
 
   if (found.length > 1)

--- a/test/test-list.js
+++ b/test/test-list.js
@@ -16,7 +16,7 @@ exports.testList = function(assert) {
   }
 
   let count = 0;
-  for each (let ele in list) {
+  for (let ele of list) {
     assert.equal(ele, 1, 'ele is correct');
     assert.equal(++count, 1, 'count is correct');
   }
@@ -41,7 +41,7 @@ exports.testImplementsList = function(assert) {
   let list2 = List2();
   let count = 0;
 
-  for each (let ele in list2) {
+  for (let ele of list2) {
     assert.equal(ele, count++, 'ele is correct');
   }
 

--- a/test/test-page-worker.js
+++ b/test/test-page-worker.js
@@ -79,7 +79,7 @@ exports.testUnwrappedDOM = function(assert, done) {
 exports.testPageProperties = function(assert) {
   let page = new Page();
 
-  for each (let prop in ['contentURL', 'allow', 'contentScriptFile',
+  for (let prop of ['contentURL', 'allow', 'contentScriptFile',
                          'contentScript', 'contentScriptWhen', 'on',
                          'postMessage', 'removeListener']) {
     assert.ok(prop in page, prop + " property is defined on page.");

--- a/test/test-tabs-common.js
+++ b/test/test-tabs-common.js
@@ -23,9 +23,9 @@ exports.testTabCounts = function(assert, done) {
     onReady: function(tab) {
       let count1 = 0,
           count2 = 0;
-      for each(let window in browserWindows) {
+      for (let window of browserWindows) {
         count1 += window.tabs.length;
-        for each(let tab in window.tabs) {
+        for (let tab of window.tabs) {
           count2 += 1;
         }
       }

--- a/test/test-windows-common.js
+++ b/test/test-windows-common.js
@@ -15,7 +15,7 @@ exports.testBrowserWindowsIterator = function(assert) {
   let activeWindowCount = 0;
   let windows = [];
   let i = 0;
-  for each (let window in browserWindows) {
+  for (let window of browserWindows) {
     if (window === browserWindows.activeWindow)
       activeWindowCount++;
 


### PR DESCRIPTION
Replace deprecated 'for each (v in iterable)' syntax
with 'for (v of iterable)'

There are several remaining uses of 'for each' which
iterate over objects that are not iterables.
