### PR TITLE
Bug 1043648 Calling `window.stop` in page-worker's content script cause error in console

### DIFF
--- a/lib/sdk/content/worker.js
+++ b/lib/sdk/content/worker.js
@@ -138,13 +138,13 @@ attach.define(Worker, function (worker, window) {
   model.windowID = getInnerId(model.window);
   events.on("inner-window-destroyed", model.documentUnload);
 
+  // will set model.contentWorker pointing to the private API:
+  model.contentWorker = WorkerSandbox(worker, model.window);
+
   // Listen to pagehide event in order to freeze the content script
   // while the document is frozen in bfcache:
   model.window.addEventListener("pageshow", model.pageShow, true);
   model.window.addEventListener("pagehide", model.pageHide, true);
-
-  // will set model.contentWorker pointing to the private API:
-  model.contentWorker = WorkerSandbox(worker, model.window);
 
   // Mainly enable worker.port.emit to send event to the content worker
   model.inited = true;

--- a/test/test-page-worker.js
+++ b/test/test-page-worker.js
@@ -13,6 +13,8 @@ const ERR_DESTROYED =
   "Couldn't find the worker to receive this message. " +
   "The script may not be initialized yet, or may already have been unloaded.";
 
+const Isolate = fn => "(" + fn + ")()";
+
 exports.testSimplePageCreation = function(assert, done) {
   let page = new Page({
     contentScript: "self.postMessage(window.location.href)",
@@ -476,6 +478,38 @@ exports.testMessageQueue = function (assert, done) {
     done();
   });
 };
+
+exports.testWindowStopDontBreak = function (assert, done) {
+  const { Ci, Cc } = require('chrome');
+  const consoleService = Cc['@mozilla.org/consoleservice;1'].
+                            getService(Ci.nsIConsoleService);
+  const listener = {
+    observe: ({message}) => {
+      if (message.contains('contentWorker is null'))
+        assert.fail('contentWorker is null');
+    }
+  };
+  consoleService.registerListener(listener)
+
+  let page = new Page({
+    contentURL: 'data:text/html;charset=utf-8,testWindowStopDontBreak',
+    contentScriptWhen: 'ready',
+    contentScript: Isolate(() => {
+      window.stop();
+      self.port.on('ping', () => self.port.emit('pong'));
+    })
+  });
+
+  page.port.on('pong', () => {
+    assert.pass('page-worker works after window.stop');
+    page.destroy();
+    consoleService.unregisterListener(listener);
+    done();
+  });
+
+  page.port.emit("ping");
+};
+
 
 function isDestroyed(page) {
   try {


### PR DESCRIPTION
It seems that `window.stop` makes `pageshow` to be emitted, before the `contentWorker` is actually set.
Set the `contentWorker` before the listeners seems resolve the issue.

Notice that the unit test is on `test-page-worker` instead of `test-content-worker` because using directly the worker doesn't cause such issue – probably because some frame stuff related.
