### PR TITLE
Open a new e10s window before each test

### DIFF
--- a/test/addons/e10s-tabs/lib/main.js
+++ b/test/addons/e10s-tabs/lib/main.js
@@ -5,15 +5,41 @@
 
 const { merge } = require('sdk/util/object');
 const { version } = require('sdk/system');
-
-merge(module.exports, require('./test-tab'));
-merge(module.exports, require('./test-tab-events'));
-merge(module.exports, require('./test-tab-observer'));
-merge(module.exports, require('./test-tab-utils'));
+const { getMostRecentBrowserWindow } = require('sdk/window/utils');
+const { promise: windowPromise, close, focus } = require('sdk/window/helpers');
 
 // run e10s tests only on builds from trunk, fx-team, Nightly..
 if (!version.endsWith('a1')) {
   module.exports = {};
 }
+
+function openE10sWindow() {
+  let window = getMostRecentBrowserWindow().OpenBrowserWindow({ remote: true });
+  return windowPromise(window, 'load').then(focus);
+}
+
+function makeE10sTests(exports) {
+  let newExports = {};
+
+  for (let key of Object.keys(exports)) {
+    if (typeof(exports[key]) == "function" && key.substring(0, 4) == "test") {
+      let testFunction = exports[key];
+      newExports[key] = function(assert, done) {
+        openE10sWindow().then(window => {
+          testFunction(assert, () => {
+            close(window).then(done);
+          });
+        });
+      }
+    }
+  }
+
+  return newExports;
+}
+
+merge(module.exports, makeE10sTests(require('./test-tab')));
+merge(module.exports, makeE10sTests(require('./test-tab-events')));
+merge(module.exports, makeE10sTests(require('./test-tab-observer')));
+merge(module.exports, makeE10sTests(require('./test-tab-utils')));
 
 require('sdk/test/runner').runTestsFromModule(module);

--- a/test/addons/e10s-tabs/lib/test-tab-utils.js
+++ b/test/addons/e10s-tabs/lib/test-tab-utils.js
@@ -38,7 +38,7 @@ if (isWindowPBSupported) {
         assert.equal(isPrivate(window), false, 'all found windows are not private');
       });
 
-      assert.equal(windows(null, {includePrivate: true}).length, 2, 'there are really two windows');
+      assert.equal(windows(null, {includePrivate: true}).length, 3, 'there are really three windows');
 
       close(window).then(done);
     });
@@ -57,7 +57,7 @@ else if (isTabPBSupported) {
                  'there are two tabs found');
     assert.equal(utils_tabs[utils_tabs.length-1], tab,
                  'the last tab is the opened tab');
-    assert.equal(browserWindows.length, 1, 'there is only one window');
+    assert.equal(browserWindows.length, 2, 'there is only two windows');
     closeTab(tab);
 
     done();

--- a/test/addons/e10s-tabs/package.json
+++ b/test/addons/e10s-tabs/package.json
@@ -5,6 +5,5 @@
   "description": "run tab tests in e10s mode",
   "author": "Tomislav Jovanovic",
   "license": "MPL 2.0",
-  "version": "0.1",
-  "e10s": true
+  "version": "0.1"
 }

--- a/test/addons/e10s/package.json
+++ b/test/addons/e10s/package.json
@@ -1,10 +1,9 @@
 {
-  "name": "e10s-flag",
-  "title": "e10s-flag",
+  "name": "e10s",
+  "title": "e10s",
   "id": "jid1-DYaXFHAPlHwbgw",
   "description": "a basic e10s test add-on",
   "author": "Tomislav Jovanovic",
   "license": "MPL 2.0",
-  "version": "0.1",
-  "e10s": true
+  "version": "0.1"
 }


### PR DESCRIPTION
It should be easy to remove this block when Nightly goes all-e10s.
