### PR TITLE
Bug 1058091 - FATAL ERROR: Non-local network connections are disabled and a connection attempt to tiles.up.mozillalabs.com (54.243.106.119) was made.

### DIFF
--- a/python-lib/cuddlefish/prefs.py
+++ b/python-lib/cuddlefish/prefs.py
@@ -55,6 +55,10 @@ DEFAULT_NO_CONNECTIONS_PREFS = {
     # Disable app update
     'app.update.enabled' : False,
 
+    # Disable about:newtab content fetch and ping
+    'browser.newtabpage.directory.source': 'data:application/json,{"jetpack":1}',
+    'browser.newtabpage.directory.ping': '',
+
     # Point update checks to a nonexistent local URL for fast failures.
     'extensions.update.url' : 'http://localhost/extensions-dummy/updateURL',
     'extensions.blocklist.url' : 'http://localhost/extensions-dummy/blocklistURL',


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1058091
