### PR TITLE
firefox33: Bug 1058091 - FATAL ERROR: Non-local network connections are disabled and a connection attempt to tiles.up.mozillalabs.com (54.243.106.119) was made.

### DIFF
--- a/python-lib/cuddlefish/prefs.py
+++ b/python-lib/cuddlefish/prefs.py
@@ -36,6 +36,10 @@ DEFAULT_COMMON_PREFS = {
     # Disable app update
     'app.update.enabled' : False,
 
+    # Disable about:newtab content fetch and ping
+    'browser.newtabpage.directory.source': 'data:application/json,{"jetpack":1}',
+    'browser.newtabpage.directory.ping': '',
+
     # Point update checks to a nonexistent local URL for fast failures.
     'extensions.update.url' : 'http://localhost/extensions-dummy/updateURL',
     'extensions.blocklist.url' : 'http://localhost/extensions-dummy/blocklistURL',


### PR DESCRIPTION
Already uplifted to mozilla-aurora: https://hg.mozilla.org/releases/mozilla-aurora/rev/67de711e13d9
(cherry picked from commit eedf51a3dd1410556f17f2ada0e4f8b623f7f68c)
