### PR TITLE
Bug 1036625: Loader shouldn't be attempting to load files just to resolve modules

### DIFF
--- a/lib/toolkit/loader.js
+++ b/lib/toolkit/loader.js
@@ -393,6 +393,49 @@ const resolve = iced(function resolve(id, base) {
 });
 exports.resolve = resolve;
 
+function fileExists(uri) {
+  let url = NetUtil.newURI(uri);
+
+  switch (url.scheme) {
+    case "jar":
+      let jarfile = url.QueryInterface(Ci.nsIJARURI).JARFile;
+
+      // Don't support nested JARs for now
+      if (!(jarfile instanceof Ci.nsIFileURL))
+        return false;
+
+      let zipcache = Cc["@mozilla.org/libjar/zip-reader-cache;1"].
+                     getService(Ci.nsIZipReaderCache);
+      let zipreader = zipcache.getZip(jarfile.file);
+      return zipreader.hasEntry(jarfile.JAREntry);
+
+    case "file":
+      return url.QueryInterface(Ci.nsIFileURL).file.exists();
+
+    case "chrome":
+      let registry = Cc["@mozilla.org/chrome/chrome-registry;1"].
+                     getService(Ci.nsIChromeRegistry)
+      return fileExists(ChromeRegistry.convertChromeURL(url).spec);
+
+    case "resource":
+      let handler = Cc["@mozilla.org/network/protocol;1?name=resource"].
+                    getService(Ci.nsIResProtocolHandler);
+      let resolved;
+      try {
+        resolved = handler.resolveURI(url);
+      }
+      catch (e) {
+        // Resource protocol handler throws for unknown mappings
+        return false;
+      }
+      return fileExists(resolved);
+
+    default:
+      // Don't handle other URI schemes for now
+      return false;
+  }
+}
+
 // Node-style module lookup
 // Takes an id and path and attempts to load a file using node's resolving
 // algorithm.
@@ -407,7 +450,7 @@ const nodeResolve = iced(function nodeResolve(id, requirer, { rootURI }) {
   let fullId = join(rootURI, id);
   let resolvedPath;
 
-  if ((resolvedPath = loadAsFile(fullId)))
+  if ((resolvedPath = findFile(fullId)))
     return stripBase(rootURI, resolvedPath);
 
   if ((resolvedPath = loadAsDirectory(fullId)))
@@ -417,7 +460,7 @@ const nodeResolve = iced(function nodeResolve(id, requirer, { rootURI }) {
   // in the `dependencies` list
   let dirs = getNodeModulePaths(dirname(join(rootURI, requirer))).map(dir => join(dir, id));
   for (let i = 0; i < dirs.length; i++) {
-    if ((resolvedPath = loadAsFile(dirs[i])))
+    if ((resolvedPath = findFile(dirs[i])))
       return stripBase(rootURI, resolvedPath);
 
     if ((resolvedPath = loadAsDirectory(dirs[i])))
@@ -431,23 +474,20 @@ const nodeResolve = iced(function nodeResolve(id, requirer, { rootURI }) {
 });
 exports.nodeResolve = nodeResolve;
 
-// Attempts to load `path` and then `path.js`
+// Attempts to find `path` and then `path.js`
 // Returns `path` with valid file, or `undefined` otherwise
-function loadAsFile (path) {
-  let found;
-
+function findFile (path) {
   // As per node's loader spec,
   // we first should try and load 'path' (with no extension)
   // before trying 'path.js'. We will not support this feature
   // due to performance, but may add it if necessary for adoption.
-  try {
-    // Append '.js' to path name unless it's another support filetype
-    path = normalizeExt(path);
-    readURI(path);
-    found = path;
-  } catch (e) {}
 
-  return found;
+  // Append '.js' to path name unless it's another support filetype
+  path = normalizeExt(path);
+  if (fileExists(path))
+    return path;
+
+  return null;
 }
 
 // Attempts to load `path/package.json`'s `main` entry,
@@ -456,25 +496,21 @@ function loadAsDirectory (path) {
   try {
     // If `path/package.json` exists, parse the `main` entry
     // and attempt to load that
-    let main = getManifestMain(JSON.parse(readURI(path + '/package.json')));
-    if (main != null) {
-      let tmpPath = join(path, main);
-      let found = loadAsFile(tmpPath);
-      if (found)
-        return found
+    if (fileExists(path + '/package.json')) {
+      let main = getManifestMain(JSON.parse(readURI(path + '/package.json')));
+      if (main != null) {
+        let tmpPath = join(path, main);
+        let found = findFile(tmpPath);
+        if (found)
+          return found
+      }
     }
-    try {
-      let tmpPath = path + '/index.js';
-      readURI(tmpPath);
-      return tmpPath;
-    } catch (e) {}
-  } catch (e) {
-    try {
-      let tmpPath = path + '/index.js';
-      readURI(tmpPath);
-      return tmpPath;
-    } catch (e) {}
-  }
+  } catch (e) { }
+
+  let tmpPath = path + '/index.js';
+  if (fileExists(tmpPath))
+    return tmpPath;
+
   return void 0;
 }
 


### PR DESCRIPTION
This causes a crazy amount of debug spew in debug builds now as it keeps trying to resolve unmapped resource URIs. Switches to using file and jar APIs to verify the presence of files.
