### PR TITLE
Bug 1072702 - The addon-sdk 'activate' script updates a working shell's PS1, but it's processing is insufficient for more sophisticated shell PS1's whose first char is a newline

### DIFF
--- a/bin/odoncaoa
+++ b/bin/odoncaoa
@@ -1,0 +1,108 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This file must be used with "source bin/activate" *from bash*
+# you cannot run it directly
+
+deactivate () {
+    if [ -n "$_OLD_VIRTUAL_PATH" ] ; then
+        PATH="$_OLD_VIRTUAL_PATH"
+        export PATH
+        unset _OLD_VIRTUAL_PATH
+    fi
+
+    # This should detect bash and zsh, which have a hash command that must
+    # be called to get it to forget past commands.  Without forgetting
+    # past commands the $PATH changes we made may not be respected
+    if [ -n "$BASH" -o -n "$ZSH_VERSION" ] ; then
+        hash -r
+    fi
+
+    if [ -n "$_OLD_VIRTUAL_PS1" ] ; then
+        PS1="$_OLD_VIRTUAL_PS1"
+        export PS1
+        unset _OLD_VIRTUAL_PS1
+    fi
+
+    PYTHONPATH="$_OLD_PYTHONPATH"
+    export PYTHONPATH
+    unset _OLD_PYTHONPATH
+
+    unset CUDDLEFISH_ROOT
+
+    unset VIRTUAL_ENV
+    if [ ! "$1" = "nondestructive" ] ; then
+    # Self destruct!
+        unset deactivate
+    fi
+}
+
+# Binary function, to indicate whether first 2 chars of PS1 represent a newline 
+function PS1nlChk() {
+
+	local ps1=`echo $PS1 | cut -c1`
+	local ps2=`echo $PS1 | cut -c2`
+
+	if [ $ps1 = '\' -a $ps2 = 'n' ]
+	then	echo 1
+	else	echo 0
+	fi
+}
+
+# When first 2 chars of original PS2 represent a newline,
+# then update accordancingly
+function doPS1nl() {
+
+	if	[ `PS1nlChk` = 1  ]
+	then	PS1="\\n(`basename \"$VIRTUAL_ENV\"`)`echo $PS1 | cut -c3-`"
+	else	PS1="(`basename \"$VIRTUAL_ENV\"`)$PS1"
+	fi	
+}
+
+
+# unset irrelavent variables
+deactivate nondestructive
+
+_OLD_PYTHONPATH="$PYTHONPATH"
+_OLD_VIRTUAL_PATH="$PATH"
+
+VIRTUAL_ENV="`pwd`"
+
+if [ "x$OSTYPE" = "xmsys" ] ; then
+  CUDDLEFISH_ROOT="`pwd -W | sed s,/,\\\\\\\\,g`"
+  PATH="`pwd`/bin:$PATH"
+  # msys will convert any env vars with PATH in it to use msys
+  # form and will unconvert before launching
+  PYTHONPATH="`pwd -W`/python-lib;$PYTHONPATH"
+else
+  CUDDLEFISH_ROOT="$VIRTUAL_ENV"
+  PYTHONPATH="$VIRTUAL_ENV/python-lib:$PYTHONPATH"
+  PATH="$VIRTUAL_ENV/bin:$PATH"
+fi
+
+VIRTUAL_ENV="`pwd`"
+
+export CUDDLEFISH_ROOT
+export PYTHONPATH
+export PATH
+
+_OLD_VIRTUAL_PS1="$PS1"
+if [ "`basename \"$VIRTUAL_ENV\"`" = "__" ] ; then
+    # special case for Aspen magic directories
+    # see http://www.zetadev.com/software/aspen/
+    PS1="[`basename \`dirname \"$VIRTUAL_ENV\"\``] $PS1"
+else
+    # Account for PS1's, whose first 2 chars represent a newline
+    doPS1nl
+fi
+export PS1
+
+# This should detect bash and zsh, which have a hash command that must
+# be called to get it to forget past commands.  Without forgetting
+# past commands the $PATH changes we made may not be respected
+if [ -n "$BASH" -o -n "$ZSH_VERSION" ] ; then
+    hash -r
+fi
+
+python -c "from jetpack_sdk_env import welcome; welcome()"


### PR DESCRIPTION
Added PS1nlChk(), doPS1nl() functions to account for original PS1's, whose first 2 chars represent a newline. PS1 gets adjusted accordingly; so that the new PS1 version too, begins with a newline.
