### PR TITLE
Changeset: 6646 (9e93c25d8a02) Bug 1071048 Addon SDK changes to allow Ghostery to work in SeaMonkey.

### DIFF
--- a/lib/sdk/tabs.js
+++ b/lib/sdk/tabs.js
@@ -5,10 +5,6 @@
 
 module.metadata = {
   "stability": "unstable",
-  "engines": {
-    "Firefox": "*",
-    "Fennec": "*"
-  }
 };
 
 const { modelFor } = require("./model/core");

--- a/lib/sdk/tabs/tab.js
+++ b/lib/sdk/tabs/tab.js
@@ -5,10 +5,6 @@
 
 module.metadata = {
   'stability': 'unstable',
-  'engines': {
-    'Firefox': '*',
-    'Fennec': '*'
-  }
 };
 
 const { getTargetWindow } = require("../content/mod");

--- a/lib/sdk/windows.js
+++ b/lib/sdk/windows.js
@@ -5,10 +5,6 @@
 
 module.metadata = {
   'stability': 'stable',
-  'engines': {
-    'Firefox': '*',
-    'Fennec': '*'
-  }
 };
 
 const { isBrowser } = require('./window/utils');


### PR DESCRIPTION
  Philip Chee      2014-09-22 08:26:14 PDT

See Bug 1060858 - Ghostery 5.3.1 does not support SeaMonkey (was Ghostery toolbar button doesn't work)

[tag] [reply] [−] Comment 1 Philip Chee 2014-09-22 08:34:24 PDT

Created attachment 8493149 [details] [diff] [review]
Bug1071048Ghostery.patch

This bug just flags the following modules as SeaMonkey compatible:
/lib/sdk/tabs.js
/lib/sdk/tabs/tab.js
/lib/sdk/windows.js

This is the minimum needed to get Ghostery working in SeaMonkey (Bug 1060858). Other changes may be needed (Bug 1069824) but that's out of scope for this bug.

Attachment #8493149 - Flags: review?(tomica+amo@gmail.com)
CC: tomica+amo@gmail.com
Philip Chee 2014-09-22 09:27:35 PDT
Blocks: 1060858
Dominique Fillon 2014-09-22 09:31:10 PDT
CC: dominique@hp.com
Sven Grull 2014-09-22 09:31:30 PDT
CC: bugzilla.spam2@grull.com
[tag] [reply] [−] Comment 2 Tomislav Jovanovic [:zombie] 2014-09-22 14:24:13 PDT

Comment on attachment 8493149 [details] [diff] [review]
Bug1071048Ghostery.patch
## Review of attachment 8493149 [details] [diff] [review]:

i'm reluctant to add "seamonkey" to module metadata when it's something we don't test even manually, let alone have CI for. somebody may read that as official proclamation of "support".

however, with empty `engines` metadata field (or with none at all), the it's assumed all applications are supported, and since all the cases in this bug already support both Firefox and Fennec, we can probably (safely) just remove the engines field, and let SeaMonkey work by default.

so please verify that change would work in SeaMonkey, and submit a patch for review? (preferably as a github PR, since that's how we operate.. see https://github.com/mozilla/addon-sdk/wiki/contribute or feel free to ask if you have any questions).

Attachment #8493149 - Flags: review?(tomica+amo@gmail.com) → review-
