### PR TITLE
Bug 1078665: Ignore exceptions thrown out of getBrowserForDocument.

### DIFF
--- a/lib/sdk/panel/window.js
+++ b/lib/sdk/panel/window.js
@@ -35,10 +35,14 @@ function getWindow(anchor) {
       }
 
       // Check if the anchor is in a browser tab in this browser window.
-      let browser = enumWindow.gBrowser.getBrowserForDocument(anchorDocument);
-      if (browser) {
-        window = enumWindow;
-        break;
+      try {
+        let browser = enumWindow.gBrowser.getBrowserForDocument(anchorDocument);
+        if (browser) {
+          window = enumWindow;
+          break;
+        }
+      }
+      catch (e) {
       }
 
       // Look in other subdocuments (sidebar, etc.)?


### PR DESCRIPTION
There are nicer ways to do this whole lot of code, but they aren't e10s compatible either so might as well just take the quick fix now and rework this all later.
