### PR TITLE
Bug 1088641: Strip all but the low-bytes of characters when calling base64.encode without a charset.

### DIFF
--- a/lib/sdk/base64.js
+++ b/lib/sdk/base64.js
@@ -29,14 +29,15 @@ function isUTF8(charset) {
 
 exports.decode = function (data, charset) {
   if (isUTF8(charset))
-		return decodeURIComponent(escape(atob(data)))
+    return decodeURIComponent(escape(atob(data)))
 
-	return atob(data);
+  return atob(data);
 }
 
 exports.encode = function (data, charset) {
   if (isUTF8(charset))
     return btoa(unescape(encodeURIComponent(data)))
 
-	return btoa(data);
+  data = String.fromCharCode(...[(c.charCodeAt(0) & 0xff) for (c of data)]);
+  return btoa(data);
 }

--- a/test/test-base64.js
+++ b/test/test-base64.js
@@ -9,7 +9,8 @@ const base64 = require("sdk/base64");
 const text = "Awesome!";
 const b64text = "QXdlc29tZSE=";
 
-const utf8text = "✓ à la mode";
+const utf8text = "\u2713 à la mode";
+const badutf8text = "\u0013 à la mode";
 const b64utf8text = "4pyTIMOgIGxhIG1vZGU=";
 
 exports["test base64.encode"] = function (assert) {
@@ -66,8 +67,8 @@ exports["test base64.decode with wrong charset"] = function (assert) {
 
 exports["test encode/decode Unicode without utf-8 as charset"] = function (assert) {
 
-  assert.notEqual(base64.decode(base64.encode(utf8text)), utf8text,
-    "Unicode strings needs 'utf-8' charset"
+  assert.equal(base64.decode(base64.encode(utf8text)), badutf8text,
+    "Unicode strings needs 'utf-8' charset or will be mangled"
   );
 
 }


### PR DESCRIPTION
This is what our base64 implementation used to do.
