### PR TITLE
Bug 1094392: Don't claim page-mods are weak referential when we already hold a strong reference to them

### DIFF
--- a/lib/sdk/page-mod.js
+++ b/lib/sdk/page-mod.js
@@ -113,7 +113,6 @@ const PageMod = Class({
     modContract.properties(modelFor),
     EventTarget,
     Disposable,
-    WeakReference
   ],
   extends: WorkerHost(workerFor),
   setup: function PageMod(options) {


### PR DESCRIPTION
Since page mods are strongly held in the set pagemods there isn't any point trying to claim they are weak references.
