### PR TITLE
Bug 1023661 - Add support for SeaMonkey to "places" modules

### DIFF
--- a/lib/sdk/places/bookmarks.js
+++ b/lib/sdk/places/bookmarks.js
@@ -7,7 +7,8 @@
 module.metadata = {
   "stability": "unstable",
   "engines": {
-    "Firefox": "*"
+    "Firefox": "*",
+    "SeaMonkey": "*"
   }
 };
 

--- a/lib/sdk/places/events.js
+++ b/lib/sdk/places/events.js
@@ -7,7 +7,8 @@
 module.metadata = {
   'stability': 'experimental',
   'engines': {
-    'Firefox': '*'
+    'Firefox': '*',
+    "SeaMonkey": '*'
   }
 };
 

--- a/lib/sdk/places/favicon.js
+++ b/lib/sdk/places/favicon.js
@@ -7,7 +7,8 @@
 module.metadata = {
   "stability": "unstable",
   "engines": {
-    "Firefox": "*"
+    "Firefox": "*",
+    "SeaMonkey": "*"
   }
 };
 

--- a/lib/sdk/places/history.js
+++ b/lib/sdk/places/history.js
@@ -7,7 +7,8 @@
 module.metadata = {
   "stability": "unstable",
   "engines": {
-    "Firefox": "*"
+    "Firefox": "*",
+    "SeaMonkey": "*"
   }
 };
 

--- a/lib/sdk/places/host/host-bookmarks.js
+++ b/lib/sdk/places/host/host-bookmarks.js
@@ -7,7 +7,8 @@
 module.metadata = {
   "stability": "experimental",
   "engines": {
-    "Firefox": "*"
+    "Firefox": "*",
+    "SeaMonkey": "*"
   }
 };
 

--- a/lib/sdk/places/host/host-query.js
+++ b/lib/sdk/places/host/host-query.js
@@ -7,7 +7,8 @@
 module.metadata = {
   "stability": "experimental",
   "engines": {
-    "Firefox": "*"
+    "Firefox": "*",
+    "SeaMonkey": "*"
   }
 };
 

--- a/lib/sdk/places/host/host-tags.js
+++ b/lib/sdk/places/host/host-tags.js
@@ -7,7 +7,8 @@
 module.metadata = {
   "stability": "experimental",
   "engines": {
-    "Firefox": "*"
+    "Firefox": "*",
+    "SeaMonkey": "*"
   }
 };
 

--- a/lib/sdk/places/utils.js
+++ b/lib/sdk/places/utils.js
@@ -7,7 +7,8 @@
 module.metadata = {
   "stability": "experimental",
   "engines": {
-    "Firefox": "*"
+    "Firefox": "*",
+    "SeaMonkey": "*"
   }
 };
 


### PR DESCRIPTION
From a quick look at the places/ modules, it seems they are essentially wrappers to XPCOM backend so they should work on SeaMonkey. Tested with a very minimal add-on:

```
  let { search } = require("sdk/places/history");
  let { getFavicon } = require("sdk/places/favicon");
  let { Bookmark, save } = require("sdk/places/bookmarks");

  // Test history: search the most visited bug page on Bugzilla
  search(
    { url: "https://bugzilla.mozilla.org/*" },
    { sort: "visitCount" }
  ).on("end", function (results) {
      // Extract the favicon url on the Bugzilla page.
      getFavicon(results[0].url).then(function (url) {
          // Save the favicon in the bookmarks.
          let bookmark = Bookmark({ title: results[0].title + " - Favicon",
                                    url: url });
          let emitter = save(bookmark);
      });
  });
```
