### PR TITLE
Bug 1023661 - make window/utils.js use the 'browser.chromeURL' preferenc...

### DIFF
--- a/lib/sdk/window/utils.js
+++ b/lib/sdk/window/utils.js
@@ -26,7 +26,9 @@ const FM = Cc["@mozilla.org/focus-manager;1"].
 const XUL_NS = 'http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul';
 
 const BROWSER = 'navigator:browser',
-      URI_BROWSER = 'chrome://browser/content/browser.xul',
+      URI_BROWSER = Cc['@mozilla.org/preferences-service;1'].
+                    getService(Ci.nsIPrefService).
+                    getBranch(null).getCharPref('browser.chromeURL'),
       NAME = '_blank',
       FEATURES = 'chrome,all,dialog=no,non-private';
 


### PR DESCRIPTION
...e instead of 'chrome://browser/content/browser.xul'. r=erikvold

Tested on SeaMonkey nightly with the minimal test

```
  var utils = require('sdk/window/utils');
  utils.open();
```
