### PR TITLE
Bug 1023661 - Declare some low-level modules compatible with SeaMonkey. ...

### DIFF
--- a/lib/sdk/panel/window.js
+++ b/lib/sdk/panel/window.js
@@ -8,7 +8,8 @@
 module.metadata = {
   'stability': 'unstable',
   'engines': {
-    'Firefox': '*'
+    'Firefox': '*',
+    'SeaMonkey': '*'
   }
 };
 

--- a/lib/sdk/ui/button/view/events.js
+++ b/lib/sdk/ui/button/view/events.js
@@ -7,7 +7,8 @@
 module.metadata = {
   'stability': 'experimental',
   'engines': {
-    'Firefox': '*'
+    'Firefox': '*',
+    'SeaMonkey': '*'
   }
 };
 

--- a/lib/sdk/ui/state.js
+++ b/lib/sdk/ui/state.js
@@ -8,7 +8,8 @@
 module.metadata = {
   'stability': 'experimental',
   'engines': {
-    'Firefox': '*'
+    'Firefox': '*',
+    'SeaMonkey': '*'
   }
 };
 

--- a/lib/sdk/ui/state/events.js
+++ b/lib/sdk/ui/state/events.js
@@ -7,7 +7,8 @@
 module.metadata = {
   'stability': 'experimental',
   'engines': {
-    'Firefox': '*'
+    'Firefox': '*',
+    'SeaMonkey': '*'
   }
 };
 


### PR DESCRIPTION
...r=erikvold

As I understand, these are low-level modules that are used by the higher-level ui modules or by the tests. Not sure whether it's very useful to use them directly, but there is nothing incompatible with SeaMonkey in these files, so let's declare them compatible too.
