### PR TITLE
Bug 1100639 - Remove support for Sunbird. r=erikvold

### DIFF
--- a/modules/system/XulApp.js
+++ b/modules/system/XulApp.js
@@ -28,13 +28,10 @@ var platformVersion = exports.platformVersion = appInfo.platformVersion;
 // re-branded versions of a product have different names: for instance,
 // Firefox, Minefield, Iceweasel, and Shiretoko all have the same
 // GUID.
-// This mapping is duplicated in `app-extensions/bootstrap.js`. They should keep
-// in sync, so if you change one, change the other too!
 
 var ids = exports.ids = {
   Firefox: "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
   Mozilla: "{86c18b42-e466-45a9-ae7a-9b95ba6f5640}",
-  Sunbird: "{718e30fb-e89b-41dd-9da7-e25a45638b28}",
   SeaMonkey: "{92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}",
   Fennec: "{aa3c5121-dab2-40e2-81ca-7ea25febc110}",
   Thunderbird: "{3550f703-e582-4d05-9a08-453d09bdfdc6}"

--- a/test/test-xul-app.js
+++ b/test/test-xul-app.js
@@ -27,8 +27,7 @@ exports["test xulapp"] = function(assert) {
                 "is('" + name + "') is true or false.");
   }
 
-  var apps = ["Firefox", "Mozilla", "Sunbird", "SeaMonkey",
-              "Fennec", "Thunderbird"];
+  var apps = ["Firefox", "Mozilla", "SeaMonkey", "Fennec", "Thunderbird"];
 
   apps.forEach(testSupport);
 


### PR DESCRIPTION
I don't find the duplicate mapping in app-extensions/bootstrap.js, so I'm assuming it is obsolete.
