### PR TITLE
Bug 724632 - Detraitify sdk/content/loader.

### DIFF
--- a/lib/sdk/content/loader.js
+++ b/lib/sdk/content/loader.js
@@ -8,7 +8,9 @@ module.metadata = {
   "stability": "unstable"
 };
 
-const { EventEmitter } = require('../deprecated/events');
+const { Class } = require('../core/heritage');
+const { EventTarget } = require('../event/target');
+const { emit } = require('../event/core');
 const { isValidURI, isLocalURL, URL } = require('../url');
 const file = require('../io/file');
 const { contract } = require('../util/contract');
@@ -75,36 +77,51 @@ function Allow(script) ({
   set script(value) script = !!value
 })
 
+
+// private interface
+const allow = Symbol("content/loader/allow");
+const contentURL = Symbol("content/loader/contentURL");
+const contentScriptWhen = Symbol("content/loader/content-script-when");
+const contentScriptOptions = Symbol("content/loader/content-script-options");
+const contentScriptFile = Symbol("content/loader/content-script-file");
+const contentScript = Symbol("content/loader/content-script-source")
 /**
  * Trait is intended to be used in some composition. It provides set of core
  * properties and bounded validations to them. Trait is useful for all the
  * compositions providing high level APIs for interaction with content.
  * Property changes emit `"propertyChange"` events on instances.
  */
-const Loader = EventEmitter.compose({
+const Loader = Class({
+  implements: [EventTarget],
   /**
    * Permissions for the content, with the following keys:
    * @property {Object} [allow = { script: true }]
    * @property {Boolean} [allow.script = true]
    *    Whether or not to execute script in the content.  Defaults to true.
    */
-  get allow() this._allow || (this._allow = Allow(true)),
-  set allow(value) this.allow.script = value && value.script,
-  _allow: null,
+  get allow() {
+    return this[allow] || (this[allow] = Allow(true))
+  },
+  set allow(value) {
+    this.allow.script = value && value.script;
+  },
+  [allow]: null,
   /**
    * The content to load. Either a string of HTML or a URL.
    * @type {String}
    */
-  get contentURL() this._contentURL,
+  get contentURL() {
+    return this[contentURL]
+  },
   set contentURL(value) {
     value = validate(value, valid.contentURL);
-    if (this._contentURL != value) {
-      this._emit('propertyChange', {
-        contentURL: this._contentURL = value
+    if (this[contentURL] != value) {
+      emit(this, 'propertyChange', {
+        contentURL: this[contentURL] = value
       });
     }
   },
-  _contentURL: null,
+  [contentURL]: null,
   /**
    * When to load the content scripts.
    * Possible values are "end" (default), which loads them once all page
@@ -116,16 +133,18 @@ const Loader = EventEmitter.compose({
    * and new value.
    * @type {'start'|'ready'|'end'}
    */
-  get contentScriptWhen() this._contentScriptWhen,
+  get contentScriptWhen() {
+    return this[contentScriptWhen]
+  },
   set contentScriptWhen(value) {
     value = validate(value, valid.contentScriptWhen);
-    if (value !== this._contentScriptWhen) {
-      this._emit('propertyChange', {
-        contentScriptWhen: this._contentScriptWhen = value
+    if (value !== this[contentScriptWhen]) {
+      emit(this, 'propertyChange', {
+        contentScriptWhen: this[contentScriptWhen] = value
       });
     }
   },
-  _contentScriptWhen: 'end',
+  [contentScriptWhen]: 'end',
   /**
    * Options avalaible from the content script as `self.options`.
    * The value of options can be of any type (object, array, string, etc.)
@@ -135,41 +154,45 @@ const Loader = EventEmitter.compose({
    * and new value.
    * @type {Object}
    */
-  get contentScriptOptions() this._contentScriptOptions,
-  set contentScriptOptions(value) this._contentScriptOptions = value,
-  _contentScriptOptions: null,
+  get contentScriptOptions() {
+    return this[contentScriptOptions];
+  },
+  set contentScriptOptions(value) {
+    this[contentScriptOptions] = value;
+  },
+  [contentScriptOptions]: null,
   /**
    * The URLs of content scripts.
    * Property change emits `propertyChange` event on instance with this key
    * and new value.
    * @type {String[]}
    */
-  get contentScriptFile() this._contentScriptFile,
+  get contentScriptFile() this[contentScriptFile],
   set contentScriptFile(value) {
     value = validate(value, valid.contentScriptFile);
-    if (value != this._contentScriptFile) {
-      this._emit('propertyChange', {
-        contentScriptFile: this._contentScriptFile = value
+    if (value != this[contentScriptFile]) {
+      emit(this, 'propertyChange', {
+        contentScriptFile: this[contentScriptFile] = value
       });
     }
   },
-  _contentScriptFile: null,
+  [contentScriptFile]: null,
   /**
    * The texts of content script.
    * Property change emits `propertyChange` event on instance with this key
    * and new value.
    * @type {String|undefined}
    */
-  get contentScript() this._contentScript,
+  get contentScript() this[contentScript],
   set contentScript(value) {
     value = validate(value, valid.contentScript);
-    if (value != this._contentScript) {
-      this._emit('propertyChange', {
-        contentScript: this._contentScript = value
+    if (value != this[contentScript]) {
+      emit(this, 'propertyChange', {
+        contentScript: this[contentScript] = value
       });
     }
   },
-  _contentScript: null
+  [contentScript]: null
 });
 exports.Loader = Loader;
 


### PR DESCRIPTION
``` sh
(addon-sdk)➜  ~CFX_ROOT  (detraitify-content-loader) cfx test -b /Applications/FirefoxNightly.app -f content-loader
Warning: missing module: resource://gre/modules/Preferences.jsm
Warning: missing module: ../../framescript/FrameScriptManager.jsm
Warning: missing module: ../framescript/FrameScriptManager.jsm
Warning: missing module: resource://gre/modules/AddonManager.jsm
Using binary at '/Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin'.
Using profile at '/var/folders/0z/nztt5n4d4kg7b43dg9nv_3fc0000gp/T/tmp8ohAaD.mozrunner'.
Running tests on Firefox 36.0a1/Gecko 36.0a1 ({ec8030f7-c20a-464f-9b0e-13a3a9e97384}) under darwin/x86_64.
..........................................
42 of 42 tests passed.
Total time: 4.795490 seconds
Program terminated successfully.
(addon-sdk)➜  ~CFX_ROOT  (detraitify-content-loader)
```
