### PR TITLE
Bug 1100644: Use browser.hiddenWindowChromeURL as a fallback since brows...

### DIFF
--- a/lib/sdk/window/utils.js
+++ b/lib/sdk/window/utils.js
@@ -25,10 +25,10 @@ const FM = Cc["@mozilla.org/focus-manager;1"].
 
 const XUL_NS = 'http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul';
 
+const prefs = require("../preferences/service");
 const BROWSER = 'navigator:browser',
-      URI_BROWSER = Cc['@mozilla.org/preferences-service;1'].
-                    getService(Ci.nsIPrefService).
-                    getBranch(null).getCharPref('browser.chromeURL'),
+      URI_BROWSER = prefs.get('browser.chromeURL',
+                              prefs.get('browser.hiddenWindowChromeURL', '')),
       NAME = '_blank',
       FEATURES = 'chrome,all,dialog=no,non-private';
 


### PR DESCRIPTION
...er.ChromeURL is not defined on all Thunderbird versions. r=erikvold