### PR TITLE
Bug 1100644 - Declare some low-level modules compatible with Thunderbird...

### DIFF
--- a/lib/sdk/ui/button/view/events.js
+++ b/lib/sdk/ui/button/view/events.js
@@ -8,7 +8,8 @@ module.metadata = {
   'stability': 'experimental',
   'engines': {
     'Firefox': '*',
-    'SeaMonkey': '*'
+    'SeaMonkey': '*',
+    'Thunderbird': '*'
   }
 };
 

--- a/lib/sdk/ui/state.js
+++ b/lib/sdk/ui/state.js
@@ -9,7 +9,8 @@ module.metadata = {
   'stability': 'experimental',
   'engines': {
     'Firefox': '*',
-    'SeaMonkey': '*'
+    'SeaMonkey': '*',
+    'Thunderbird': '*'
   }
 };
 

--- a/lib/sdk/ui/state/events.js
+++ b/lib/sdk/ui/state/events.js
@@ -8,7 +8,8 @@ module.metadata = {
   'stability': 'experimental',
   'engines': {
     'Firefox': '*',
-    'SeaMonkey': '*'
+    'SeaMonkey': '*',
+    'Thunderbird': '*'
   }
 };
 


### PR DESCRIPTION
.... r=erikvold

This is the same as https://github.com/mozilla/addon-sdk/pull/1707

As for SeaMonkey, I'm not sure whether it's very useful to use them directly and I didn't test them with Thunderbird.
