### PR TITLE
Bug 951058 - correct chrome sub-dirnames iteration for the generation of xpi

### DIFF
--- a/python-lib/cuddlefish/xpi.py
+++ b/python-lib/cuddlefish/xpi.py
@@ -58,7 +58,7 @@ def build_xpi(template_root_dir, manifest, xpi_path,
           goodfiles = list(filter_filenames(filenames, IGNORED_FILES))
           dirnames[:] = filter_dirnames(dirnames)
           for dirname in dirnames:
-            arcpath = make_zipfile_path(template_root_dir,
+            arcpath = make_zipfile_path(pkgdir,
                                         os.path.join(dirpath, dirname))
             dirs_to_create.add(arcpath)
           for filename in goodfiles:


### PR DESCRIPTION
dirpath is the full path of the addon. template_root_dir is the path of the addon sdk.
What we want to use here is pkgdir in order to have a relative path.
