### PR TITLE
Bug 724632 - Detraitify symbiont.

### DIFF
--- a/lib/sdk/deprecated/legacy-worker.js
+++ b/lib/sdk/deprecated/legacy-worker.js
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = require("./traits-worker");

--- a/lib/sdk/deprecated/symbiont.js
+++ b/lib/sdk/deprecated/symbiont.js
@@ -7,16 +7,36 @@ module.metadata = {
   "stability": "deprecated"
 };
 
-const { Worker } = require('./traits-worker');
+const { Class } = require('../core/heritage');
+const { Disposable } = require('../core/disposable');
+const { Bond } = require('../util/bond');
+const { Worker } = require('./legacy-worker');
 const { Loader } = require('../content/loader');
-const hiddenFrames = require('../frame/hidden-frame');
 const { on, off } = require('../system/events');
-const unload = require('../system/unload');
 const { getDocShell } = require("../frame/utils");
 const { ignoreWindow } = require('../private-browsing/utils');
+const hiddenFrames = require('../frame/hidden-frame');
 
 // Everything coming from add-on's xpi considered an asset.
 const assetsURI = require('../self').data.url().replace(/data\/$/, "");
+
+// Private interface
+
+const setupWorker = Symbol("deprecated/symbiont/setup-worker");
+const disposeWorker = Symbol("deprecated/symbiont/dispose-worker");
+
+const attachFrame = Symbol("deprecated/symbiont/attach-frame");
+const detachFrame = Symbol("deprecated/symbiont/detach-frame");
+const setupFrame = Symbol("deprecated/symbol/setup-frame");
+
+const frame = Symbol("deprecated/symbiont/frame");
+const hiddenFrame = Symbol("deprecated/symbiont/hidden-frame");
+
+const injectInDocument = Worker.injectInDocument;
+const onAttach = Symbol("deprecated/symbiont/on-frame-attached");
+const onStart = Symbol("deprecated/symbiont/on-start");
+const onReadyStateChange = Symbol("deprecated/symbiont/on-ready-state-change")
+const onFrameReady = Symbol("deprecated/symbiont/on-frame-ready");
 
 /**
  * This trait is layered on top of `Worker` and in contrast to symbiont
@@ -24,25 +44,50 @@ const assetsURI = require('../self').data.url().replace(/data\/$/, "");
  * that will be loaded in the provided frame, if frame is not provided
  * Worker will create hidden one.
  */
-const Symbiont = Worker.resolve({
-    constructor: '_initWorker',
-    destroy: '_workerDestroy'
-  }).compose(Loader, {
-
+const Symbiont = Class({
+  implements: [
+    Worker,
+    Loader,
+    Disposable,
+    Bond({
+      [onAttach]({subject, topic}) {
+        if (this[frame].contentWindow == subject) {
+          off(topic, this[onAttach]);
+          this[setupFrame](this[frame]);
+        }
+      },
+      [onStart]({subject, topic}) {
+        const window = subject.defaultView;
+        if (window &&
+            !ignoreWindow(window) &&
+            window == this[frame].contentWindow)
+        {
+          off(topic, this[onStart]);
+          this[onFrameReady]();
+        }
+      },
+      [onReadyStateChange]({type, target}) {
+        if (target === this[frame].contentDocument) {
+          target.removeEventListener(type, this[onReadyStateChange], true);
+          this[onFrameReady]();
+        }
+      }
+    })
+  ],
+  [setupWorker]: Worker.prototype.setup,
+  [disposeWorker]: Worker.prototype.dispose,
   /**
    * The constructor requires all the options that are required by
    * `require('content').Worker` with the difference that the `frame` option
    * is optional. If `frame` is not provided, `contentURL` is expected.
    * @param {Object} options
    * @param {String} options.contentURL
-   *    URL of a content to load into `this._frame` and create worker for.
+   *    URL of a content to load into `this[frame]` and create worker for.
    * @param {Element} [options.frame]
    *    iframe element that is used to load `options.contentURL` into.
    *    if frame is not provided hidden iframe will be created.
    */
-  constructor: function Symbiont(options) {
-    options = options || {};
-
+  setup(options={}) {
     if ('contentURL' in options)
         this.contentURL = options.contentURL;
     if ('contentScriptWhen' in options)
@@ -60,34 +105,30 @@ const Symbiont = Worker.resolve({
     if ('onMessage' in options)
         this.on('message', options.onMessage);
     if ('frame' in options) {
-      this._initFrame(options.frame);
+      this[attachFrame](options.frame);
     }
     else {
-      let self = this;
-      this._hiddenFrame = hiddenFrames.HiddenFrame({
-        onReady: function onFrame() {
-          self._initFrame(this.element);
+      this[hiddenFrame] = hiddenFrames.HiddenFrame({
+        onReady: (element) => {
+          this[attachFrame](element);
         },
-        onUnload: function onUnload() {
-          // Bug 751211: Remove reference to _frame when hidden frame is
+        onUnload: () => {
+          // Bug 751211: Remove reference to this[frame] when hidden frame is
           // automatically removed on unload, otherwise we are going to face
           // "dead object" exception
-          self.destroy();
+          this.destroy();
         }
       });
-      hiddenFrames.add(this._hiddenFrame);
+      hiddenFrames.add(this[hiddenFrame]);
     }
-
-    unload.ensure(this._public, "destroy");
   },
 
-  destroy: function destroy() {
-    this._workerDestroy();
-    this._unregisterListener();
-    this._frame = null;
-    if (this._hiddenFrame) {
-      hiddenFrames.remove(this._hiddenFrame);
-      this._hiddenFrame = null;
+  dispose() {
+    this[disposeWorker]();
+    this[detachFrame]();
+    if (this[hiddenFrame]) {
+      hiddenFrames.remove(this[hiddenFrame]);
+      this[hiddenFrame] = null;
     }
   },
 
@@ -96,47 +137,33 @@ const Symbiont = Worker.resolve({
    * Used to create `ContentSymbiont` from.
    * @type {nsIFrame|nsIBrowser}
    */
-  _frame: null,
+  [frame]: null,
 
   /**
    * Listener to the `'frameReady"` event (emitted when `iframe` is ready).
    * Removes listener, sets right permissions to the frame and loads content.
    */
-  _initFrame: function _initFrame(frame) {
-    if (this._loadListener)
-      this._unregisterListener();
+  [attachFrame](target) {
+    this[detachFrame]();
+    this[frame] = target;
 
-    this._frame = frame;
-
-    if (getDocShell(frame)) {
-      this._reallyInitFrame(frame);
+    if (getDocShell(target)) {
+      this[setupFrame](target);
     }
     else {
-      if (this._waitForFrame) {
-        off('content-document-global-created', this._waitForFrame);
-      }
-      this._waitForFrame = this.__waitForFrame.bind(this, frame);
-      on('content-document-global-created', this._waitForFrame);
+      on('content-document-global-created', this[onAttach]);
     }
   },
 
-  __waitForFrame: function _waitForFrame(frame, { subject: win }) {
-    if (frame.contentWindow == win) {
-      off('content-document-global-created', this._waitForFrame);
-      delete this._waitForFrame;
-      this._reallyInitFrame(frame);
-    }
-  },
-
-  _reallyInitFrame: function _reallyInitFrame(frame) {
+  [setupFrame](frame) {
     getDocShell(frame).allowJavascript = this.allow.script;
-    frame.setAttribute("src", this._contentURL);
+    frame.setAttribute("src", this.contentURL);
 
     // Inject `addon` object in document if we load a document from
     // one of our addon folder and if no content script are defined. bug 612726
     let isDataResource =
-      typeof this._contentURL == "string" &&
-      this._contentURL.indexOf(assetsURI) == 0;
+      typeof this.contentURL == "string" &&
+      this.contentURL.indexOf(assetsURI) == 0;
     let hasContentScript =
       (Array.isArray(this.contentScript) ? this.contentScript.length > 0
                                              : !!this.contentScript) ||
@@ -144,85 +171,52 @@ const Symbiont = Worker.resolve({
                                              : !!this.contentScriptFile);
     // If we have to inject `addon` we have to do it before document
     // script execution, so during `start`:
-    this._injectInDocument = isDataResource && !hasContentScript;
-    if (this._injectInDocument)
+    this[injectInDocument] = isDataResource && !hasContentScript;
+    if (this[injectInDocument]) {
       this.contentScriptWhen = "start";
+    }
 
     if ((frame.contentDocument.readyState == "complete" ||
         (frame.contentDocument.readyState == "interactive" &&
          this.contentScriptWhen != 'end' )) &&
-        frame.contentDocument.location == this._contentURL) {
+        frame.contentDocument.location == this.contentURL)
+    {
       // In some cases src doesn't change and document is already ready
       // (for ex: when the user moves a widget while customizing toolbars.)
-      this._onInit();
-      return;
+      this[onFrameReady]();
     }
-
-    let self = this;
-
-    if ('start' == this.contentScriptWhen) {
-      this._loadEvent = 'start';
-      on('document-element-inserted',
-        this._loadListener = function onStart({ subject: doc }) {
-          let window = doc.defaultView;
-
-          if (ignoreWindow(window)) {
-            return;
-          }
-
-          if (window && window == frame.contentWindow) {
-            self._unregisterListener();
-            self._onInit();
-          }
-
-        });
-      return;
+    else if (this.contentScriptWhen === 'start') {
+      on('document-element-inserted', this[onStart]);
     }
-
-    let eventName = 'end' == this.contentScriptWhen ? 'load' : 'DOMContentLoaded';
-    this._loadEvent = eventName;
-    frame.addEventListener(eventName,
-      this._loadListener = function _onReady(event) {
-
-        if (event.target != frame.contentDocument)
-          return;
-        self._unregisterListener();
-
-        self._onInit();
-
-      }, true);
-
+    else if (this.contentScriptWhen === 'ready') {
+      frame.addEventListener('DOMContentLoaded', this[onReadyStateChange], true);
+    }
+    else {
+      frame.addEventListener('load', this[onReadyStateChange], true);
+    }
   },
 
   /**
    * Unregister listener that watchs for document being ready to be injected.
-   * This listener is registered in `Symbiont._initFrame`.
+   * This listener is registered in `this[attachFrame]`.
    */
-  _unregisterListener: function _unregisterListener() {
-    if (this._waitForFrame) {
-      off('content-document-global-created', this._waitForFrame);
-      delete this._waitForFrame;
+  [detachFrame]() {
+    const target = this[frame];
+    if (target) {
+      off('content-document-global-created', this[onAttach]);
+      off('document-element-inserted', this[onStart]);
+      target.removeEventListener("load", this[onReadyStateChange], true);
+      target.removeEventListener("DOMContentLoaded", this[onReadyStateChange], true);
+      this[frame] = null;
     }
-
-    if (!this._loadListener)
-      return;
-    if (this._loadEvent == "start") {
-      off('document-element-inserted', this._loadListener);
-    }
-    else {
-      this._frame.removeEventListener(this._loadEvent, this._loadListener,
-                                      true);
-    }
-    this._loadListener = null;
   },
 
   /**
    * Called by Symbiont itself when the frame is ready to load
    * content scripts according to contentScriptWhen. Overloaded by Panel.
    */
-  _onInit: function () {
-    this._initWorker({ window: this._frame.contentWindow });
+  [onFrameReady]() {
+    this[setupWorker]({window: this[frame].contentWindow});
   }
-
 });
 exports.Symbiont = Symbiont;

--- a/lib/sdk/deprecated/traits-worker.js
+++ b/lib/sdk/deprecated/traits-worker.js
@@ -16,15 +16,16 @@ module.metadata = {
   "stability": "deprecated"
 };
 
-const { Trait } = require('./traits');
-const { EventEmitter, EventEmitterTrait } = require('./events');
+const { Class } = require('../core/heritage');
+const { Disposable } = require('../core/disposable');
+const { Bond } = require('../util/bond');
+const { EventTarget } = require('../event/target');
+const { emit, setListeners, off } = require('../event/core');
 const { Ci, Cu, Cc } = require('chrome');
 const timer = require('../timers');
 const { URL } = require('../url');
-const unload = require('../system/unload');
 const observers = require('../system/events');
-const { Cortex } = require('./cortex');
-const { sandbox, evaluate, load } = require("../loader/sandbox");
+const { sandbox: Sandbox, evaluate: evalInSandbox, load } = require("../loader/sandbox");
 const { merge } = require('../util/object');
 const { getInnerId } = require("../window/utils");
 const { getTabForWindow } = require('../tabs/helpers');
@@ -34,8 +35,7 @@ const { getTabForContentWindow } = require('../tabs/utils');
   require('../content/content-worker.js');
   Then, retrieve URL of these files in the XPI:
 */
-let prefix = module.uri.split('deprecated/traits-worker.js')[0];
-const CONTENT_WORKER_URL = prefix + 'content/content-worker.js';
+const CONTENT_WORKER_URL = require.resolve('../content/content-worker');
 
 // Fetch additional list of domains to authorize access to for each content
 // script. It is stored in manifest `metadata` field which contains
@@ -54,64 +54,68 @@ const ERR_FROZEN = "The page is currently hidden and can no longer be used " +
                    "until it is visible again.";
 
 
-const WorkerSandbox = EventEmitter.compose({
+// JSON.stringify is buggy with cross-sandbox values,
+// it may return "{}" on functions. This utility replacer will help
+// avoid that broken behavior.
+const functionDrop = (_, x) => typeof(x) === "function" ? void(0) : x;
 
-  /**
-   * Emit a message to the worker content sandbox
-   */
-  emit: function emit() {
-    // First ensure having a regular array
-    // (otherwise, `arguments` would be mapped to an object by `stringify`)
-    let array = Array.slice(arguments);
-    // JSON.stringify is buggy with cross-sandbox values,
-    // it may return "{}" on functions. Use a replacer to match them correctly.
-    function replacer(k, v) {
-      return typeof v === "function" ? undefined : v;
-    }
-    // Ensure having an asynchronous behavior
-    let self = this;
-    timer.setTimeout(function () {
-      self._emitToContent(JSON.stringify(array, replacer));
-    }, 0);
-  },
+// private interface
+const emitToContent = Symbol("worker-sandbox/emit-to-content");
+const onContentEvent = Symbol("worker-sandbox/on-content-event");
+const injectInDocument = Symbol("injectInDocument");
+const sandbox = Symbol("worker-sandbox/sandbox");
 
-  /**
-   * Synchronous version of `emit`.
-   * /!\ Should only be used when it is strictly mandatory /!\
-   *     Doesn't ensure passing only JSON values.
-   *     Mainly used by context-menu in order to avoid breaking it.
-   */
-  emitSync: function emitSync() {
-    let args = Array.slice(arguments);
-    return this._emitToContent(Cu.cloneInto(args, this._addonWorker._window));
-  },
+const addonWorker = Symbol("addon-worker");
+const target = Symbol("worker/target");
+const onContentScriptEvent = Symbol();
+const importScripts = Symbol();
+const evaluate = Symbol();
 
-  /**
-   * Method called by the worker sandbox when it needs to send a message
-   */
-  _onContentEvent: function onContentEvent(args) {
-    // As `emit`, we ensure having an asynchronous behavior
-    let self = this;
-    timer.setTimeout(function () {
-      // We emit event to chrome/addon listeners
-      self._emit.apply(self, JSON.parse(args));
-    }, 0);
-  },
+const WorkerSandbox = Class({
+  implements: [
+    EventTarget,
+    Bond({
+      /**
+       * Emit a message to the worker content sandbox
+       */
+      emit(...args) {
+        timer.setTimeout(() => {
+          this[emitToContent](JSON.stringify(args, functionDrop));
+        }, 0);
+      },
 
+      /**
+       * Synchronous version of `emit`.
+       * /!\ Should only be used when it is strictly mandatory /!\
+       *     Doesn't ensure passing only JSON values.
+       *     Mainly used by context-menu in order to avoid breaking it.
+       */
+      emitSync(...args) {
+        return this[emitToContent](Cu.cloneInto(args, this[addonWorker][target]));
+      },
+
+      /**
+       * Method called by the worker sandbox when it needs to send a message
+       */
+      [onContentEvent](args) {
+        // As `emit`, we ensure having an asynchronous behavior
+        timer.setTimeout(() => {
+          // We emit event to chrome/addon listeners
+          emit(this, ...JSON.parse(args));
+        }, 0);
+      }
+    })
+  ],
   /**
    * Configures sandbox and loads content scripts into it.
    * @param {Worker} worker
    *    content worker
    */
-  constructor: function WorkerSandbox(worker) {
-    this._addonWorker = worker;
-
-    // Ensure that `emit` has always the right `this`
-    this.emit = this.emit.bind(this);
-    this.emitSync = this.emitSync.bind(this);
+  initialize(worker) {
+    this[addonWorker] = worker;
 
     // We receive a wrapped window, that may be an xraywrapper if it's content
-    let window = worker._window;
+    let window = worker[target];
     let proto = window;
 
     // Eventually use expanded principal sandbox feature, if some are given.
@@ -126,9 +130,9 @@ const WorkerSandbox = EventEmitter.compose({
     // can't be accessed by "mono-principals" (principal with only one domain).
     // Even if this principal is for a domain that is specified in the multiple
     // domain principal.
-    let principals  = window;
+    let principals = window;
     let wantGlobalProperties = []
-    if (EXPANDED_PRINCIPALS.length > 0 && !worker._injectInDocument) {
+    if (EXPANDED_PRINCIPALS.length > 0 && !worker[injectInDocument]) {
       principals = EXPANDED_PRINCIPALS.concat(window);
       // We have to replace XHR constructor of the content document
       // with a custom cross origin one, automagically added by platform code:
@@ -138,9 +142,9 @@ const WorkerSandbox = EventEmitter.compose({
 
     // Create the sandbox and bind it to window in order for content scripts to
     // have access to all standard globals (window, document, ...)
-    let content = this._sandbox = sandbox(principals, {
+    let content = this[sandbox] = Sandbox(principals, {
       sandboxPrototype: proto,
-      wantXrays: !worker._injectInDocument,
+      wantXrays: !worker[injectInDocument],
       wantGlobalProperties: wantGlobalProperties,
       sameZoneAs: window,
       metadata: {
@@ -159,6 +163,7 @@ const WorkerSandbox = EventEmitter.compose({
       get top() top,
       get parent() parent
     });
+
     // Use the Greasemonkey naming convention to provide access to the
     // unwrapped window object so the content script can access document
     // JavaScript values.
@@ -192,50 +197,49 @@ const WorkerSandbox = EventEmitter.compose({
         clearInterval: timer.clearInterval.bind(timer),
       },
       sandbox: {
-        evaluate: evaluate,
+        evaluate: evalInSandbox,
       },
     }, ContentWorker, {cloneFunctions: true});
-    let onEvent = Cu.exportFunction(this._onContentEvent.bind(this), ContentWorker);
+    let onEvent = Cu.exportFunction(this[onContentEvent], ContentWorker);
     let result = Cu.waiveXrays(ContentWorker).inject(content, chromeAPI, onEvent, options);
-    this._emitToContent = result;
+    this[emitToContent] = result;
 
     // Handle messages send by this script:
-    let self = this;
     // console.xxx calls
-    this.on("console", function consoleListener(kind) {
-      console[kind].apply(console, Array.slice(arguments, 1));
-    });
+    this.on("console", (kind, ...etc) => console[kind](...etc));
 
     // self.postMessage calls
-    this.on("message", function postMessage(data) {
+    this.on("message", data => {
       // destroyed?
-      if (self._addonWorker)
-        self._addonWorker._emit('message', data);
+      if (this[addonWorker]) {
+        emit(this[addonWorker], 'message', data);
+      }
     });
 
     // self.port.emit calls
-    this.on("event", function portEmit(name, args) {
+    this.on("event", (name, ...etc) => {
       // destroyed?
-      if (self._addonWorker)
-        self._addonWorker._onContentScriptEvent.apply(self._addonWorker, arguments);
+      if (this[addonWorker]) {
+        this[addonWorker][onContentScriptEvent](name, ...ect);
+      }
     });
 
     // unwrap, recreate and propagate async Errors thrown from content-script
-    this.on("error", function onError({instanceOfError, value}) {
-      if (self._addonWorker) {
+    this.on("error", ({instanceOfError, value}) => {
+      if (this[addonWorker]) {
         let error = value;
         if (instanceOfError) {
           error = new Error(value.message, value.fileName, value.lineNumber);
           error.stack = value.stack;
           error.name = value.name;
         }
-        self._addonWorker._emit('error', error);
+        emit(this[addonWorker], 'error', error);
       }
     });
 
     // Inject `addon` global into target document if document is trusted,
     // `addon` in document is equivalent to `self` in content script.
-    if (worker._injectInDocument) {
+    if (worker[injectInDocument]) {
       let win = window.wrappedJSObject ? window.wrappedJSObject : window;
       Object.defineProperty(win, "addon", {
           value: content.self
@@ -292,33 +296,33 @@ const WorkerSandbox = EventEmitter.compose({
 
     if (contentScriptFile) {
       if (Array.isArray(contentScriptFile))
-        this._importScripts.apply(this, contentScriptFile);
+        this[importScripts](...contentScriptFile);
       else
-        this._importScripts(contentScriptFile);
+        this[importScripts](contentScriptFile);
     }
     if (contentScript) {
-      this._evaluate(
+      this[evaluate](
         Array.isArray(contentScript) ? contentScript.join(';\n') : contentScript
       );
     }
   },
   destroy: function destroy() {
     this.emitSync("detach");
-    this._sandbox = null;
-    this._addonWorker = null;
+    this[sandbox] = null;
+    this[addonWorker] = null;
   },
 
   /**
    * JavaScript sandbox where all the content scripts are evaluated.
    * {Sandbox}
    */
-  _sandbox: null,
+  [sandbox]: null,
 
   /**
    * Reference to the addon side of the worker.
    * @type {Worker}
    */
-  _addonWorker: null,
+  [addonWorker]: null,
 
   /**
    * Evaluates code in the sandbox.
@@ -327,12 +331,12 @@ const WorkerSandbox = EventEmitter.compose({
    * @param {String} [filename='javascript:' + code]
    *    Name of the file
    */
-  _evaluate: function(code, filename) {
+  [evaluate](code, filename) {
     try {
-      evaluate(this._sandbox, code, filename || 'javascript:' + code);
+      evalInSandbox(this[sandbox], code, filename || 'javascript:' + code);
     }
     catch(e) {
-      this._addonWorker._emit('error', e);
+      emit(this[addonWorker], 'error', e);
     }
   },
   /**
@@ -344,20 +348,46 @@ const WorkerSandbox = EventEmitter.compose({
    * scripts may be able to do it synchronously since IO operation
    * takes place in the UI process.
    */
-  _importScripts: function _importScripts(url) {
-    let urls = Array.slice(arguments, 0);
+  [importScripts](...urls) {
     for (let contentScriptFile of urls) {
       try {
         let uri = URL(contentScriptFile);
         if (uri.scheme === 'resource')
-          load(this._sandbox, String(uri));
+          load(this[sandbox], String(uri));
         else
           throw Error("Unsupported `contentScriptFile` url: " + String(uri));
       }
       catch(e) {
-        this._addonWorker._emit('error', e);
+        emit(this[addonWorker], 'error', e);
       }
     }
+  }
+});
+
+// private interface
+const scheduledEvents = Symbol("worker/scheduled-events");
+const inited = Symbol("worker/inited");
+const port = Symbol("worker/port");
+const emitEventToContent = Symbol("worker/emit-to-content");
+const frozen = Symbol("worker/frozen");
+const onDocumentUnload = Symbol("worker/onDocumentUnload");
+const onPageShow = Symbol("worker/onPageShow");
+const onPageHide = Symbol("worker/onPageHide");
+const attach = Symbol("worker/attach");
+const windowID = Symbol("worker/window-id");
+const contentWorker = Symbol("worker/content-worker");
+const workerCleanup = Symbol("wroker/cleanup");
+const dispatchEvent = Symbol("worker/dispatch-event");
+const scheduleEvent = Symbol("worker/schedule-event");
+const portOwner = Symbol("worker/port/owner");
+
+const WorkerPort = Class({
+  implements: [EventTarget],
+  emit(type, ...args) {
+    this[portOwner][emitEventToContent](type, ...args);
+  },
+  initialize(owner) {
+    this[portOwner] = owner;
   }
 });
 
@@ -366,15 +396,41 @@ const WorkerSandbox = EventEmitter.compose({
  * in the content and add-on process.
  * @see https://developer.mozilla.org/en-US/Add-ons/SDK/Low-Level_APIs/content_worker
  */
-const Worker = EventEmitter.compose({
-  on: Trait.required,
-  _removeAllListeners: Trait.required,
+const Worker = Class({
+  implements: [
+    Disposable,
+    EventTarget,
+    Bond({
+      [onDocumentUnload](event) {
+        const { topic, subject, data } = event;
+        let innerWinID = subject.QueryInterface(Ci.nsISupportsPRUint64).data;
+        if (innerWinID !== this[windowID]) {
+          return false;
+        } else {
+          this[workerCleanup]();
+          return true;
+        }
+      },
 
-  // List of messages fired before worker is initialized
-  get _earlyEvents() {
-    delete this._earlyEvents;
-    this._earlyEvents = [];
-    return this._earlyEvents;
+      [onPageShow](event) {
+        this[contentWorker].emitSync("pageshow");
+        emit(this, "pageshow");
+        this[frozen] = false;
+      },
+
+      [onPageHide]() {
+        this[contentWorker].emitSync("pagehide");
+        emit(this, "pagehide");
+        this[frozen] = true;
+      }
+    })
+  ],
+
+  // Queue of events fired before worker was initialized
+  get [scheduledEvents]() {
+    Object.defineProperty(this, scheduledEvents, { value: [] });
+
+    return this[scheduledEvents];
   },
 
   /**
@@ -389,13 +445,8 @@ const Worker = EventEmitter.compose({
    * implementing `onMessage` function in the global scope of this worker.
    * @param {Number|String|JSON} data
    */
-  postMessage: function (data) {
-    let args = ['message'].concat(Array.slice(arguments));
-    if (!this._inited) {
-      this._earlyEvents.push(args);
-      return;
-    }
-    processMessage.apply(this, args);
+  postMessage: function (...args) {
+    this[scheduleEvent]("message", ...args);
   },
 
   /**
@@ -407,54 +458,29 @@ const Worker = EventEmitter.compose({
   get port() {
     // We generate dynamically this attribute as it needs to be accessible
     // before Worker.constructor gets called. (For ex: Panel)
-
-    // create an event emitter that receive and send events from/to the worker
-    this._port = EventEmitterTrait.create({
-      emit: this._emitEventToContent.bind(this)
+    Object.defineProperty(this, "port", {
+      // create an event emitter that receive and send events from/to the worker
+      value: new WorkerPort(this)
     });
 
-    // expose wrapped port, that exposes only public properties:
-    // We need to destroy this getter in order to be able to set the
-    // final value. We need to update only public port attribute as we never
-    // try to access port attribute from private API.
-    delete this._public.port;
-    this._public.port = Cortex(this._port);
-    // Replicate public port to the private object
-    delete this.port;
-    this.port = this._public.port;
-
-    return this._port;
+    return this.port;
   },
-
-  /**
-   * Same object than this.port but private API.
-   * Allow access to _emit, in order to send event to port.
-   */
-  _port: null,
-
   /**
    * Emit a custom event to the content script,
    * i.e. emit this event on `self.port`
    */
-  _emitEventToContent: function () {
-    let args = ['event'].concat(Array.slice(arguments));
-    if (!this._inited) {
-      this._earlyEvents.push(args);
-      return;
-    }
-    processMessage.apply(this, args);
+  [emitEventToContent](...args) {
+    this[scheduleEvent]("event", ...args);
   },
 
   // Is worker connected to the content worker sandbox ?
-  _inited: false,
+  [inited]: false,
 
   // Is worker being frozen? i.e related document is frozen in bfcache.
   // Content script should not be reachable if frozen.
-  _frozen: true,
+  [frozen]: true,
 
-  constructor: function Worker(options) {
-    options = options || {};
-
+  setup(options={}) {
     if ('contentScriptFile' in options)
       this.contentScriptFile = options.contentScriptFile;
     if ('contentScriptOptions' in options)
@@ -462,166 +488,151 @@ const Worker = EventEmitter.compose({
     if ('contentScript' in options)
       this.contentScript = options.contentScript;
 
-    this._setListeners(options);
+    setListeners(this, options);
 
-    unload.ensure(this._public, "destroy");
+    Object.assign({
+      [inited]: false,
+      [frozen]: true,
+      [contentWorker]: null,
+      [target]: null
+    });
 
     // Ensure that worker._port is initialized for contentWorker to be able
     // to send events during worker initialization.
     this.port;
 
-    this._documentUnload = this._documentUnload.bind(this);
-    this._pageShow = this._pageShow.bind(this);
-    this._pageHide = this._pageHide.bind(this);
-
-    if ("window" in options) this._attach(options.window);
+    if ("window" in options) {
+      this[attach](options.window);
+    }
   },
 
-  _setListeners: function(options) {
-    if ('onError' in options)
-      this.on('error', options.onError);
-    if ('onMessage' in options)
-      this.on('message', options.onMessage);
-    if ('onDetach' in options)
-      this.on('detach', options.onDetach);
-  },
-
-  _attach: function(window) {
-    this._window = window;
+  [attach](window) {
+    this[target] = window;
     // Track document unload to destroy this worker.
     // We can't watch for unload event on page's window object as it
     // prevents bfcache from working:
     // https://developer.mozilla.org/En/Working_with_BFCache
-    this._windowID = getInnerId(this._window);
-    observers.on("inner-window-destroyed", this._documentUnload);
+    this[windowID] = getInnerId(window);
+
+    observers.on("inner-window-destroyed", this[onDocumentUnload]);
 
     // Listen to pagehide event in order to freeze the content script
     // while the document is frozen in bfcache:
-    this._window.addEventListener("pageshow", this._pageShow, true);
-    this._window.addEventListener("pagehide", this._pageHide, true);
+    this[target].addEventListener("pageshow", this[onPageShow], true);
+    this[target].addEventListener("pagehide", this[onPageHide], true);
 
     // will set this._contentWorker pointing to the private API:
-    this._contentWorker = WorkerSandbox(this);
+    this[contentWorker] = WorkerSandbox(this);
 
     // Mainly enable worker.port.emit to send event to the content worker
-    this._inited = true;
-    this._frozen = false;
+    this[inited] = true;
+    this[frozen] = false;
 
-    // Process all events and messages that were fired before the
+    // Process all scheduled events and messages that were fired before the
     // worker was initialized.
-    this._earlyEvents.forEach((function (args) {
-      processMessage.apply(this, args);
-    }).bind(this));
+    this[scheduledEvents].forEach(({type, args}) =>
+      this[dispatchEvent](type, ...args));
   },
 
-  _documentUnload: function _documentUnload({ subject, data }) {
-    let innerWinID = subject.QueryInterface(Ci.nsISupportsPRUint64).data;
-    if (innerWinID != this._windowID) return false;
-    this._workerCleanup();
-    return true;
-  },
 
-  _pageShow: function _pageShow() {
-    this._contentWorker.emitSync("pageshow");
-    this._emit("pageshow");
-    this._frozen = false;
-  },
-
-  _pageHide: function _pageHide() {
-    this._contentWorker.emitSync("pagehide");
-    this._emit("pagehide");
-    this._frozen = true;
-  },
 
   get url() {
     // this._window will be null after detach
-    return this._window ? this._window.document.location.href : null;
+    return this[target] ? this[target].document.location.href : null;
   },
 
   get tab() {
     // this._window will be null after detach
-    if (this._window)
-      return getTabForWindow(this._window);
-    return null;
+    return this[target] ? getTabForWindow(this[target]) : null;
   },
 
   /**
    * Tells content worker to unload itself and
    * removes all the references from itself.
    */
-  destroy: function destroy() {
-    this._workerCleanup();
-    this._inited = true;
-    this._removeAllListeners();
+  dispose() {
+    this[workerCleanup]();
+    this[inited] = true;
+    off(this);
   },
 
   /**
    * Remove all internal references to the attached document
    * Tells _port to unload itself and removes all the references from itself.
    */
-  _workerCleanup: function _workerCleanup() {
+  [workerCleanup]() {
     // maybe unloaded before content side is created
     // As Symbiont call worker.constructor on document load
-    if (this._contentWorker)
-      this._contentWorker.destroy();
-    this._contentWorker = null;
-    if (this._window) {
-      this._window.removeEventListener("pageshow", this._pageShow, true);
-      this._window.removeEventListener("pagehide", this._pageHide, true);
+    if (this[contentWorker]) {
+      this[contentWorker].destroy();
     }
-    this._window = null;
+    this[contentWorker] = null;
+
+    if (this[target]) {
+      this[target].removeEventListener("pageshow", this[onPageShow], true);
+      this[target].removeEventListener("pagehide", this[onPageHide], true);
+    }
+    this[target] = null;
     // This method may be called multiple times,
     // avoid dispatching `detach` event more than once
-    if (this._windowID) {
-      this._windowID = null;
-      observers.off("inner-window-destroyed", this._documentUnload);
-      this._earlyEvents.length = 0;
-      this._emit("detach");
+    if (this[windowID]) {
+      this[windowID] = null;
+      observers.off("inner-window-destroyed", this[onDocumentUnload]);
+      this[scheduledEvents].splice(0);
+      emit(this, "detach");
     }
-    this._inited = false;
+    this[inited] = false;
   },
 
   /**
    * Receive an event from the content script that need to be sent to
    * worker.port. Provide a way for composed object to catch all events.
    */
-  _onContentScriptEvent: function _onContentScriptEvent() {
-    this._port._emit.apply(this._port, arguments);
+  [onContentScriptEvent](...etc) {
+    emit(this.port, ...etc);
   },
 
   /**
    * Reference to the content side of the worker.
    * @type {WorkerGlobalScope}
    */
-  _contentWorker: null,
+  [contentWorker]: null,
 
   /**
    * Reference to the window that is accessible from
    * the content scripts.
    * @type {Object}
    */
-  _window: null,
+  [target]: null,
 
   /**
    * Flag to enable `addon` object injection in document. (bug 612726)
    * @type {Boolean}
    */
-  _injectInDocument: false
+  [injectInDocument]: false,
+
+  [scheduleEvent](type, ...args) {
+    if (this[inited]) {
+      this[dispatchEvent](type, ...args);
+    } else {
+      this[earlyEvents].push({type, args});
+    }
+  },
+  /**
+   * Fired from this.postMessage and this[emitEventToContent], or from the
+   * this[scheduledEvents] queue if events were scheduled before content was loaded.
+   * Sends arguments to contentWorker if able.
+   */
+  [dispatchEvent](type, ...args) {
+    if (!this[contentWorker]) {
+      throw new Error(ERR_DESTROYED);
+    }
+    if (this[frozen]) {
+      throw new Error(ERR_FROZEN);
+    }
+
+    this[contentWorker].emit(type, ...args);
+  }
 });
-
-/**
- * Fired from postMessage and _emitEventToContent, or from the _earlyMessage
- * queue when fired before the content is loaded. Sends arguments to
- * contentWorker if able
- */
-
-function processMessage () {
-  if (!this._contentWorker)
-    throw new Error(ERR_DESTROYED);
-  if (this._frozen)
-    throw new Error(ERR_FROZEN);
-
-  this._contentWorker.emit.apply(null, Array.slice(arguments));
-}
-
+Worker.injectInDocument = injectInDocument;
 exports.Worker = Worker;

--- a/lib/sdk/frame/hidden-frame.js
+++ b/lib/sdk/frame/hidden-frame.js
@@ -92,7 +92,7 @@ function addHidenFrame(frame) {
   elements.set(frame, element);
 
   contentLoaded(element).then(function onFrameReady(element) {
-    emit(frame, "ready");
+    emit(frame, "ready", element);
   }, console.exception);
 
   return frame;


### PR DESCRIPTION
This change implicitly depends on changes from following pull requests:

- #1733
- #1725

And if merged together with those changes it passes all symbiont tests

```sh
(addon-sdk)➜  ~CFX_ROOT  (detraitify-symbiont-no-deps) git merge detraitify-content-loader detraitify-bond
Trying simple merge with detraitify-content-loader
Trying simple merge with detraitify-bond
Merge made by the 'octopus' strategy.
 lib/sdk/content/loader.js |  79 +++++++++++++++++++++++++++++++++------------------
 lib/sdk/util/bond.js      |  36 +++++++++++++++++++++++
 test/test-bond.js         | 169 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 256 insertions(+), 28 deletions(-)
 create mode 100644 lib/sdk/util/bond.js
 create mode 100644 test/test-bond.js
(addon-sdk)➜  ~CFX_ROOT  (detraitify-symbiont-no-deps) cfx test -b /Applications/FirefoxNightly.app -f symbiont -v
Warning: missing module: resource://gre/modules/Preferences.jsm
Warning: missing module: ../../framescript/FrameScriptManager.jsm
Warning: missing module: ../framescript/FrameScriptManager.jsm
Warning: missing module: resource://gre/modules/AddonManager.jsm
Using binary at '/Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin'.
Using profile at '/var/folders/0z/nztt5n4d4kg7b43dg9nv_3fc0000gp/T/tmp5gUXyp.mozrunner'.
Running tests on Firefox 36.0a1/Gecko 36.0a1 ({ec8030f7-c20a-464f-9b0e-13a3a9e97384}) under darwin/x86_64.
console.info: addon-sdk: executing 'addon-sdk/tests/test-content-symbiont.test:communication with worker global scope'
console.info: addon-sdk: pass: there is a window
console.info: addon-sdk: pass: Program gets message via onMessage.
console.info: addon-sdk: pass: Program gets message via onMessage2.
console.info: addon-sdk: executing 'addon-sdk/tests/test-content-symbiont.test:constructing symbiont && validating API'
console.info: addon-sdk: pass: There is one contentScriptFile, as specified in options.
console.info: addon-sdk: pass: There are two contentScripts, as specified in options.
console.info: addon-sdk: pass: There are two contentScripts, as specified in options.
console.info: addon-sdk: pass: There are two contentScripts, as specified in options.
console.info: addon-sdk: pass: contentScriptWhen is as specified in options.
console.info: addon-sdk: executing 'addon-sdk/tests/test-content-symbiont.test:content/content deprecation'
console.info: addon-sdk: pass: Should see three warnings
console.info: addon-sdk: pass: Loader from content/content is the exact same object as the one from content/loader
console.info: addon-sdk: pass: Symbiont from content/content is the exact same object as the one from deprecated/symbiont
console.info: addon-sdk: pass: Worker from content/content is the exact same object as the one from content/worker
console.info: addon-sdk: executing 'addon-sdk/tests/test-content-symbiont.test:document element present on 'start''
console.info: addon-sdk: pass: document element present on 'start'
console.info: addon-sdk: executing 'addon-sdk/tests/test-content-symbiont.test:pageWorker'
console.info: addon-sdk: pass: undefined
JavaScript error: resource://gre/modules/RemoteAddonsParent.jsm, line 387: TypeError: window is null

14 of 14 tests passed.
Total time: 6.250998 seconds
Program terminated successfully.
(addon-sdk)➜  ~CFX_ROOT  (detraitify-symbiont-no-deps)
```