### PR TITLE
Fit the PEP-394 standard

### DIFF
--- a/bin/activate
+++ b/bin/activate
@@ -81,4 +81,4 @@ if [ -n "$BASH" -o -n "$ZSH_VERSION" ] ; then
     hash -r
 fi
 
-python -c "from jetpack_sdk_env import welcome; welcome()"
+python2 -c "from jetpack_sdk_env import welcome; welcome()"

--- a/bin/cfx
+++ b/bin/cfx
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/bin/integration-scripts/integration-check
+++ b/bin/integration-scripts/integration-check
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
Fix activating addon-sdk environment on systems have Python 3
as default interpreter, this fit the PEP-394 standard too
https://www.python.org/dev/peps/pep-0394/
