### PR TITLE
Bug 1102504 - tabs-fennec.js ReferenceError: t is not defined

### DIFF
--- a/lib/sdk/windows/tabs-fennec.js
+++ b/lib/sdk/windows/tabs-fennec.js
@@ -158,7 +158,7 @@ function onTabSelect(event) {
   emit(tab, 'activate', tab);
   emit(gTabs, 'activate', tab);
 
-  for (let t in gTabs) {
+  for (let t of gTabs) {
     if (t === tab) continue;
     emit(t, 'deactivate', t);
     emit(gTabs, 'deactivate', t);


### PR DESCRIPTION
We want to iterate over property values, not property names.
