### PR TITLE
Add filtering capability to a jpm tests.

### DIFF
--- a/bin/jpm-test.js
+++ b/bin/jpm-test.js
@@ -4,6 +4,7 @@
 "use strict";
 
 var BLACKLIST = [];
+var readParam = require("./node-scripts/utils").readParam;
 var path = require("path");
 var Mocha = require("mocha");
 var mocha = new Mocha({
@@ -12,13 +13,13 @@ var mocha = new Mocha({
   timeout: 200000
 });
 
-var type = process.argv[2] || "";
+var type = readParam("type")
 
 process.env.NODE_ENV = "test";
-
 [
-  (type == "modules") ? require.resolve("../bin/node-scripts/test.modules") : "",
-  (type == "addons" || type == "") ? path.join(__dirname, "..", "bin", "node-scripts", "test.addons.js") : ""
+  type == "modules" && require.resolve("../bin/node-scripts/test.modules"),
+  type == "addons" && require.resolve("../bin/node-scripts/test.addons"),
+  !type && require.resolve("../bin/node-scripts/test.addons"),
 ].forEach(function(filepath) {
   filepath && mocha.addFile(filepath);
 })

--- a/bin/node-scripts/test.addons.js
+++ b/bin/node-scripts/test.addons.js
@@ -10,11 +10,13 @@ var chai = require("chai");
 var expect = chai.expect;
 var assert = chai.assert;
 var exec = utils.exec;
+var readParam = utils.readParam;
 
 var examplesPath = path.join(__dirname, "..", "..", "examples");
 var addonsPath = path.join(__dirname, "..", "..", "test", "addons");
 
 var binary = process.env.JPM_FIREFOX_BINARY || "nightly";
+var filterPattern = readParam("filter");
 
 describe("jpm test sdk addons", function () {
   fs.readdirSync(addonsPath)
@@ -38,7 +40,11 @@ describe("jpm test sdk addons", function () {
 });
 
 function fileFilter(root, file) {
+  var matcher = filterPattern && new RegExp(filterPattern)
   if (/^(l10n|e10s|layout|simple-prefs|page-mod-debugger|private-browsing)/.test(file)) {
+    return false;
+  }
+  if (matcher && !matcher.test(file)) {
     return false;
   }
   var stat = fs.statSync(path.join(root, file))

--- a/bin/node-scripts/utils.js
+++ b/bin/node-scripts/utils.js
@@ -22,3 +22,9 @@ function exec (args, options, callback) {
   });
 }
 exports.exec = exec;
+
+function readParam(name) {
+  var index = process.argv.indexOf("--" + name)
+  return index >= 0 && process.argv[index + 1]
+}
+exports.readParam = readParam;

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "unpack": true,
   "scripts": {
     "test": "node ./bin/jpm-test.js",
-    "modules": "node ./bin/jpm-test.js modules",
-    "addons": "node ./bin/jpm-test.js addons"
+    "modules": "node ./bin/jpm-test.js --type modules",
+    "addons": "node ./bin/jpm-test.js --type addons"
   },
   "homepage": "https://github.com/mozilla/addon-sdk",
   "repository": {


### PR DESCRIPTION
With this change I can run individual tests like:

```
node ./bin/jpm-test.js --filter preferences-branch
```

I'm afraid passing args to `npm test` itself isn't supported, prior npm@2.0 (see https://github.com/npm/npm/pull/5518)
