### PR TITLE
Bug 1116632 - JavaScript 1.7's let expressions are deprecated

### DIFF
--- a/lib/sdk/clipboard.js
+++ b/lib/sdk/clipboard.js
@@ -125,26 +125,28 @@ exports.set = function(aData, aDataType) {
   switch (flavor) {
     case "text/html":
       // add text/html flavor
-      let (str = Cc["@mozilla.org/supports-string;1"].
-                 createInstance(Ci.nsISupportsString))
       {
+      let str = Cc["@mozilla.org/supports-string;1"].
+                 createInstance(Ci.nsISupportsString);
+    
         str.data = options.data;
         xferable.addDataFlavor(flavor);
         xferable.setTransferData(flavor, str, str.data.length * 2);
-      }
+      };
 
       // add a text/unicode flavor (html converted to plain text)
-      let (str = Cc["@mozilla.org/supports-string;1"].
-                 createInstance(Ci.nsISupportsString),
-           converter = Cc["@mozilla.org/feed-textconstruct;1"].
-                       createInstance(Ci.nsIFeedTextConstruct))
       {
+        let str = Cc["@mozilla.org/supports-string;1"].
+                 createInstance(Ci.nsISupportsString);
+        let converter = Cc["@mozilla.org/feed-textconstruct;1"].
+                       createInstance(Ci.nsIFeedTextConstruct);
+      
         converter.type = "html";
         converter.text = options.data;
         str.data = converter.plainText();
         xferable.addDataFlavor("text/unicode");
         xferable.setTransferData("text/unicode", str, str.data.length * 2);
-      }
+      };
       break;
 
     // Set images to the clipboard is not straightforward, to have an idea how


### PR DESCRIPTION
JavaScript 1.7's let expressions are deprecated https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#Non-standard_let_extensions
