### PR TITLE
Bug 1119931: Reset results on each call to runTests.

### DIFF
--- a/lib/sdk/test/harness.js
+++ b/lib/sdk/test/harness.js
@@ -58,11 +58,7 @@ var stopOnError;
 var findAndRunTests;
 
 // Combined information from all test runs.
-var results = {
-  passed: 0,
-  failed: 0,
-  testRuns: []
-};
+var results;
 
 // A list of the compartments and windows loaded after startup
 var startLeaks;
@@ -590,6 +586,12 @@ var runTests = exports.runTests = function runTests(options) {
   onDone = options.onDone;
   print = options.print;
   findAndRunTests = options.findAndRunTests;
+
+  results = {
+    passed: 0,
+    failed: 0,
+    testRuns: []
+  };
 
   try {
     consoleListener.register();


### PR DESCRIPTION
This stops the mochitest harness from counting a pass or fail multiple times.