### PR TITLE
Bug 1124703: Send synthetic pageshow events when asynchronous message passing mean that we miss the real ones.

### DIFF
--- a/lib/sdk/content/worker-child.js
+++ b/lib/sdk/content/worker-child.js
@@ -37,7 +37,17 @@ const WorkerChild = Class({
     this.receive = this.receive.bind(this);
     this.manager.addMessageListener('sdk/worker/message', this.receive);
 
-    this.sandbox = WorkerSandbox(this, getByInnerId(this.window));
+    let window = getByInnerId(this.window);
+    this.sandbox = WorkerSandbox(this, window);
+
+    if (options.currentReadyState != "complete" &&
+        window.document.readyState == "complete") {
+      // If we attempted to attach the worker before the document was loaded but
+      // it has now completed loading then the parent should reasonably expect
+      // to see a pageshow event.
+      this.sandbox.emitSync("pageshow");
+      this.send("pageshow");
+    }
   },
   // messages
   receive({ data: { id, args }}) {

--- a/lib/sdk/content/worker.js
+++ b/lib/sdk/content/worker.js
@@ -124,6 +124,7 @@ attach.define(Worker, function(worker, window) {
 
   model.window = window;
   model.options.window = getInnerId(window);
+  model.options.currentReadyState = window.document.readyState;
   model.id = model.options.id = String(uuid());
 
   let tab = getTabForContentWindow(window);

--- a/lib/sdk/page-mod.js
+++ b/lib/sdk/page-mod.js
@@ -262,6 +262,20 @@ function onContent (mod, window) {
       return;
     domOff(window, eventName, onReady, true);
     createWorker(mod, window);
+
+    // Attaching is asynchronous so if the document is already loaded we will
+    // miss the pageshow event so send a synthetic one.
+    if (window.document.readyState == "complete") {
+      mod.on('attach', worker => {
+        try {
+          worker.send('pageshow');
+          emit(worker, 'pageshow');
+        }
+        catch (e) {
+          // This can fail if an earlier attach listener destroyed the worker
+        }
+      });
+    }
   }, true);
 }
 


### PR DESCRIPTION
Sends synthetic pageshow events when we missed the real ones and adds some tests to that effect. Note that due to self.port being asynchronous worker.on('pageshow') arrives before any messages from the worker script itself.