### PR TITLE
Bug 1128478 - sdk/panel's show/hide events not emitted if contentScriptWhen != 'ready'

### DIFF
--- a/lib/sdk/panel.js
+++ b/lib/sdk/panel.js
@@ -295,6 +295,9 @@ let hides = filter(panelEvents, ({type}) => type === "popuphidden");
 let ready = filter(panelEvents, ({type, target}) =>
   getAttachEventType(modelFor(panelFor(target))) === type);
 
+// Panel event emitted when the contents of the panel has been loaded.
+let readyToShow = filter(panelEvents, ({type}) => type === "DOMContentLoaded");
+
 // Styles should be always added as soon as possible, and doesn't makes them
 // depends on `contentScriptWhen`
 let start = filter(panelEvents, ({type}) => type === "document-element-inserted");
@@ -317,6 +320,10 @@ on(ready, "data", ({target}) => {
   let window = domPanel.getContentDocument(target).defaultView;
 
   workerFor(panel).attach(window);
+});
+
+on(readyToShow, "data", ({target}) => {
+  let panel = panelFor(target);
 
   if (!modelFor(panel).ready) {
     modelFor(panel).ready = true;

--- a/test/test-panel.js
+++ b/test/test-panel.js
@@ -1297,7 +1297,6 @@ exports["test panel addon global object"] = function*(assert) {
 exports["test panel load doesn't show"] = function*(assert) {
   let loader = Loader(module);
 
-  let showCount = 0;
   let panel = loader.require("sdk/panel").Panel({
     contentScript: "addEventListener('load', function(event) { self.postMessage('load'); });",
     contentScriptWhen: "start",
@@ -1332,6 +1331,24 @@ exports["test panel load doesn't show"] = function*(assert) {
   panel.contentURL = "data:text/html;charset=utf-8,<html/>";
 
   yield messaged.promise;
+  loader.unload();
+}
+
+exports["test Panel without contentURL and contentScriptWhen=start should show"] = function*(assert) {
+  let loader = Loader(module);
+
+  let panel = loader.require("sdk/panel").Panel({
+    contentScriptWhen: "start",
+    // No contentURL, the bug only shows up when contentURL is not explicitly set.
+  });
+
+  yield new Promise(resolve => {
+    panel.once("show", resolve);
+    panel.show();
+  });
+
+  assert.pass("Received show event");
+
   loader.unload();
 }
 


### PR DESCRIPTION
To verify whether the patch worked, I followed the following steps:

1. Update tests only and change `if (packaging.isNative) {` to `if (packaging.isNative && false) {` because otherwise all panel tests would be skipped.
2. Ran `JPM_FIREFOX_BINARY=/usr/bin/firefox-nightly node ./bin/jpm-test.js --type modules --filter test-panel:contentScriptWhen=start`
3. Observed that the new test failed.
4. Apply the fix.
5. Repeat step 2.
6. Observe that the new test passes.
7. Remove the `&& false` modification at step 1 and submit the patch.

This patch fixes a regression caused by https://bugzilla.mozilla.org/show_bug.cgi?id=1083391.