### PR TITLE
Bug 1133301 - Do not use non-standard flag argument of String.prototype.replace in addon-sdk/.

### DIFF
--- a/lib/sdk/test/harness.js
+++ b/lib/sdk/test/harness.js
@@ -344,7 +344,7 @@ function getPotentialLeaks() {
       let item = {
         path: matches[1],
         principal: details[1],
-        location: details[2] ? details[2].replace("\\", "/", "g") : undefined,
+        location: details[2] ? details[2].replace(/\\/g, "/") : undefined,
         source: details[3] ? details[3].split(" -> ").reverse() : undefined,
         toString: function() this.location
       };
@@ -368,8 +368,8 @@ function getPotentialLeaks() {
 
       let item = {
         path: matches[1],
-        location: details[1].replace("\\", "/", "g"),
-        source: [details[1].replace("\\", "/", "g")],
+        location: details[1].replace(/\\/g, "/"),
+        source: [details[1].replace(/\\/g, "/")],
         toString: function() this.location
       };
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1133301