### PR TITLE
s/substract/hyphenminus/

### DIFF
--- a/lib/sdk/keyboard/utils.js
+++ b/lib/sdk/keyboard/utils.js
@@ -38,7 +38,7 @@ const CODES = exports.CODES = new function Codes() {
   let nsIDOMKeyEvent = Ci.nsIDOMKeyEvent;
   // Names that will be substituted with a shorter analogs.
   let aliases = {
-    'subtract':     '-',
+    'hyphenminus':  '-',
     'add':          '+',
     'equals':       '=',
     'slash':        '/',

--- a/test/test-keyboard-utils.js
+++ b/test/test-keyboard-utils.js
@@ -58,4 +58,13 @@ exports["test normalize"] = function assert(assert) {
   }, "throws if contains more then on non-modifier key");
 };
 
+/**  
+ * bug 1135312 - can't bind to the '-' key because it is key code 173, not 109
+ */
+exports["test hyphenminus"] = function(assert, done) {
+  assert.equal(utils.getKeyForCode(173), '-');
+  assert.equal(utils.getCodeForKey('-'), 173);
+  done();
+};
+
 require("sdk/test").run(exports);


### PR DESCRIPTION
I can't map to the 'hyphenminus' key in current nightly - this 1-line fix seems to correct it. See https://bugzilla.mozilla.org/show_bug.cgi?id=1135312