### PR TITLE
bug 1138545 - should be able to pass in a bare regex to page-worker

### DIFF
--- a/lib/sdk/page-worker.js
+++ b/lib/sdk/page-worker.js
@@ -52,7 +52,7 @@ let pageContract = contract(merge({
     is: ['function', 'undefined']
   },
   include: {
-    is: ['string', 'array', 'undefined']
+    is: ['string', 'array', 'regexp', 'undefined']
   },
   contentScriptWhen: {
     is: ['string', 'undefined']

--- a/test/test-page-worker.js
+++ b/test/test-page-worker.js
@@ -513,6 +513,29 @@ exports.testWindowStopDontBreak = function (assert, done) {
   page.port.emit("ping");
 };
 
+/**  
+ * bug 1138545 - the docs claim you can pass in a bare regexp.
+ */
+exports.testRegexArgument = function (assert, done) {
+  let url = 'data:text/html;charset=utf-8,testWindowStopDontBreak';
+
+  let page = new Page({
+    contentURL: url,
+    contentScriptWhen: 'ready',
+    contentScript: Isolate(() => {
+     self.port.emit("pong", document.location.href); 
+    }),
+    include: /^data\:text\/html;.*/
+  });    
+
+  assert.pass("We can pass in a RegExp into page-worker's include option.");
+
+  page.port.on("pong", (href) => {
+    assert.equal(href, url, "we get back the same url from the content script.");
+    page.destroy();
+    done();
+  });
+};
 
 function isDestroyed(page) {
   try {


### PR DESCRIPTION
See http://stackoverflow.com/questions/28813605/firefox-addon-sdk-page-worker-regex/