### PR TITLE
Bug 1139113: Use DOMDocElementInserted events rather than the observer service to detect new documents to page-mod.

### DIFF
--- a/lib/sdk/content/page-mod.js
+++ b/lib/sdk/content/page-mod.js
@@ -29,21 +29,10 @@ const { List, addListItem, removeListItem } = require('../util/list');
 const { when } = require("../system/unload");
 const { uuid } = require('../util/uuid');
 const { frames, process } = require('../remote/child');
-const { Cc, Ci, Cu } = require('chrome');
 
 const pagemods = new Map();
 const styles = new WeakMap();
 let styleFor = (mod) => styles.get(mod);
-
-// We use the raw observer service here because the e10s shims make
-// sdk/system/events do extensive unnecessary CPOW traffic.
-const { addObserver, removeObserver } = Cc['@mozilla.org/observer-service;1'].
-                                          getService(Ci.nsIObserverService);
-
-addObserver(onContentWindow, 'document-element-inserted', false);
-when(() => {
-  removeObserver(onContentWindow, 'document-element-inserted');
-});
 
 // Helper functions
 let modMatchesURI = (mod, uri) => mod.include.matchesAny(uri) && !mod.exclude.matchesAny(uri);
@@ -107,11 +96,7 @@ const ChildPageMod = Class({
   }
 });
 
-function onContentWindow(document) {
-  // The in-process child might see CPOWs from other processes if shims are enabled
-  if (Cu.isCrossProcessWrapper(document))
-    return;
-
+function onContentWindow({ target: document }) {
   // Return if we have no pagemods
   if (pagemods.size === 0)
     return;
@@ -121,9 +106,10 @@ function onContentWindow(document) {
   if (!window)
     return;
 
+  // Frame event listeners are bound to the frame the event came from by default
+  let frame = this;
   // We apply only on documents in tabs of Firefox
-  let frame = frames.getFrameForWindow(window.top);
-  if (!frame || !frame.isTab)
+  if (!frame.isTab)
     return;
 
   // When the tab is private, only addons with 'private-browsing' flag in
@@ -136,6 +122,7 @@ function onContentWindow(document) {
       onContent(pagemod, window);
   }
 }
+frames.addEventListener("DOMDocElementInserted", onContentWindow, true);
 
 function applyOnExistingDocuments (mod) {
   for (let frame of frames) {


### PR DESCRIPTION
This removes the remaining CPOW traffic from page-mod.