### PR TITLE
Bug 1140361 - Remove __noSuchMethod__ from the Add-on SDK

### DIFF
--- a/lib/sdk/content/sandbox.js
+++ b/lib/sdk/content/sandbox.js
@@ -229,8 +229,16 @@ const WorkerSandbox = Class({
         timeEnd: genPropDesc('timeEnd'),
         profile: genPropDesc('profile'),
         profileEnd: genPropDesc('profileEnd'),
-       __noSuchMethod__: { enumerable: true, configurable: true, writable: true,
-                            value: function() {} }
+        exception: genPropDesc('exception'),
+        assert: genPropDesc('assert'),
+        count: genPropDesc('count'),
+        table: genPropDesc('table'),
+        clear: genPropDesc('clear'),
+        dirxml: genPropDesc('dirxml'),
+        markTimeline: genPropDesc('markTimeline'),
+        timeline: genPropDesc('timeline'),
+        timelineEnd: genPropDesc('timelineEnd'),
+        timeStamp: genPropDesc('timeStamp'),
       };
 
       Object.defineProperties(con, properties);

--- a/lib/sdk/deprecated/traits-worker.js
+++ b/lib/sdk/deprecated/traits-worker.js
@@ -274,8 +274,16 @@ const WorkerSandbox = EventEmitter.compose({
         timeEnd: genPropDesc('timeEnd'),
         profile: genPropDesc('profile'),
         profileEnd: genPropDesc('profileEnd'),
-       __noSuchMethod__: { enumerable: true, configurable: true, writable: true,
-                            value: function() {} }
+        exception: genPropDesc('exception'),
+        assert: genPropDesc('assert'),
+        count: genPropDesc('count'),
+        table: genPropDesc('table'),
+        clear: genPropDesc('clear'),
+        dirxml: genPropDesc('dirxml'),
+        markTimeline: genPropDesc('markTimeline'),
+        timeline: genPropDesc('timeline'),
+        timelineEnd: genPropDesc('timelineEnd'),
+        timeStamp: genPropDesc('timeStamp'),
       };
 
       Object.defineProperties(con, properties);

--- a/test/context-menu/test-helper.js
+++ b/test/context-menu/test-helper.js
@@ -28,6 +28,9 @@ const TEST_DOC_URL = module.uri.replace(/context-menu\/test-helper\.js$/, "test-
 // WARNING: This looks up items in popups by comparing labels, so don't give two
 // items the same label.
 function TestHelper(assert, done) {
+  // Methods on the wrapped test can be called on this object.
+  for (var prop in assert)
+    this[prop] = () => assert[prop].apply(assert, arguments);
   this.assert = assert;
   this.end = done;
   this.loaders = [];
@@ -56,11 +59,6 @@ TestHelper.prototype = {
 
   get tabBrowser() {
     return this.browserWindow.gBrowser;
-  },
-
-  // Methods on the wrapped test can be called on this object.
-  __noSuchMethod__: function (methodName, args) {
-    this.assert[methodName].apply(this.assert, args);
   },
 
   // Asserts that elt, a DOM element representing item, looks OK.


### PR DESCRIPTION
Two commits:

(1) Don't use __noSuchMethod__ in context-menu/test-helper.js
(2) Fix the 'fake' console objects to match the real console object. We removed __noSuchMethod__ from that one in bug 1139794.