### PR TITLE
Bug 1132522 - Update proxy handlers in the Addon SDK for ES6 error handling

### DIFF
--- a/lib/sdk/preferences/service.js
+++ b/lib/sdk/preferences/service.js
@@ -48,6 +48,7 @@ const Branch = function(branchName) {
     },
     set(target, name, value, receiver) {
       set(`${branchName}${name}`, value);
+      return true;
     },
     has(target, name) {
       return this.hasOwn(target, name);


### PR DESCRIPTION
See [bug 1132522](https://bugzilla.mozilla.org/show_bug.cgi?id=1132522).

We definitely need this particular change. I'm about 95% sure this is the only one, since we won't be changing the behavior of legacy Proxy.create() proxies.