### PR TITLE
Bug 1142114: Rename loader to loaderModule to avoid conflicts with the devtools loader

### DIFF
--- a/lib/sdk/remote/parent.js
+++ b/lib/sdk/remote/parent.js
@@ -22,16 +22,16 @@ const { emit } = require('../event/core');
 const system = require('../system/events');
 const { EventParent } = require('./utils');
 const options = require('@loader/options');
-const loader = require('toolkit/loader');
+const loaderModule = require('toolkit/loader');
 const { getTabForBrowser } = require('../tabs/utils');
 
 // Chose the right function for resolving relative a module id
 let moduleResolve;
 if (options.isNative) {
-  moduleResolve = (id, requirer) => loader.nodeResolve(id, requirer, { rootURI: options.rootURI });
+  moduleResolve = (id, requirer) => loaderModule.nodeResolve(id, requirer, { rootURI: options.rootURI });
 }
 else {
-  moduleResolve = loader.resolve;
+  moduleResolve = loaderModule.resolve;
 }
 // Build the sorted path mapping structure that resolveURI requires
 let pathMapping = Object.keys(options.paths)
@@ -317,7 +317,7 @@ function remoteRequire(id, module = null) {
   // Resolve relative to calling module if passed
   if (module)
     id = moduleResolve(id, module.id);
-  let uri = loader.resolveURI(id, pathMapping);
+  let uri = loaderModule.resolveURI(id, pathMapping);
 
   // Don't reload the same module
   if (remoteModules.has(uri))


### PR DESCRIPTION
The devtools loader injects a loader variable into every module so if you try to declare a const or var loader in your module it will throw an exception.