### PR TITLE
Bug 1142186: Only delete the test preferences.

### DIFF
--- a/test/test-native-options.js
+++ b/test/test-native-options.js
@@ -163,7 +163,11 @@ exports.testSimplePrefs = function(assert) {
   assert.strictEqual(simple.prefs.test3, "1", "test3 is '1'");
   assert.strictEqual(simple.prefs.test4, "red", "test4 is 'red'");
 
-  branch.deleteBranch('');
+  for (let setting of parent.children) {
+    let name = setting.getAttribute('pref-name');
+    branch.deleteBranch("." + name);
+  }
+
   assert.strictEqual(simple.prefs.test, undefined, "test is undefined");
   assert.strictEqual(simple.prefs.test2, undefined, "test2 is undefined");
   assert.strictEqual(simple.prefs.test3, undefined, "test3 is undefined");


### PR DESCRIPTION
This test was deleting the entire test add-ons preferences, this includes the preferences that the mochitest-jetpack harness uses to override the values in sdk/self which was breaking logging testing in later tests.