### PR TITLE
Bug 1142330: Make child loaders user a unique ID so they don't inherit the preferences of the parent loader.

### DIFF
--- a/test/pagemod-test-helpers.js
+++ b/test/pagemod-test-helpers.js
@@ -17,7 +17,7 @@ const PATH = '/test-contentScriptWhen.html';
 
 function createLoader () {
   let options = merge({}, require('@loader/options'),
-                      { prefixURI: require('./fixtures').url() });
+                      { id: "testloader", prefixURI: require('./fixtures').url() });
   return Loader(module, null, options);
 }
 exports.createLoader = createLoader;

--- a/test/test-page-worker.js
+++ b/test/test-page-worker.js
@@ -281,7 +281,7 @@ exports.testLoadContentPageRelativePath = function(assert, done) {
   const { merge } = require("sdk/util/object");
 
   const options = merge({}, require('@loader/options'),
-      { prefixURI: require('./fixtures').url() });
+      { id: "testloader", prefixURI: require('./fixtures').url() });
 
   let loader = Loader(module, null, options);
 


### PR DESCRIPTION
By using a different ID the test loader doesn't have any `baseURI` pref set in `sdk/self` and so `data.url` will use `prefixURI`.
