### PR TITLE
Bug 1141796: Don't inject the SDK console into pages loaded in tabs.

### DIFF
--- a/lib/sdk/remote/child.js
+++ b/lib/sdk/remote/child.js
@@ -3,6 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
+const { isChildLoader } = require('./core');
+if (!isChildLoader)
+  throw new Error("Cannot load sdk/remote/child in a main process loader.");
+
 const { Ci, Cc } = require('chrome');
 const runtime = require('../system/runtime');
 const { Class } = require('../core/heritage');

--- a/lib/sdk/remote/core.js
+++ b/lib/sdk/remote/core.js
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+"use strict";
+
+const options = require("@loader/options");
+
+exports.isChildLoader = options.childLoader;

--- a/lib/sdk/remote/parent.js
+++ b/lib/sdk/remote/parent.js
@@ -3,6 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
+const { isChildLoader } = require('./core');
+if (isChildLoader)
+  throw new Error("Cannot load sdk/remote/parent in a child loader.");
+
 const { Cu, Ci, Cc } = require('chrome');
 const runtime = require('../system/runtime');
 
@@ -53,6 +57,7 @@ catch (e) {
 }
 const loaderID = getNewLoaderID();
 childOptions.loaderID = loaderID;
+childOptions.childLoader = true;
 
 const ppmm = Cc['@mozilla.org/parentprocessmessagemanager;1'].
              getService(Ci.nsIMessageBroadcaster);

--- a/test/addons/e10s-remote/main.js
+++ b/test/addons/e10s-remote/main.js
@@ -505,7 +505,36 @@ exports["test processID"] = function*(assert) {
       assert.equal(ID, processID, "Remote processes should have the same process ID");
     }
   }
+
+  loader.unload();
 }
+
+// Check that sdk/remote/parent and sdk/remote/child can only be loaded in the
+// appropriate loaders
+exports["test cannot load in wrong loader"] = function*(assert) {
+  let loader = new Loader(module);
+  let { processes } = yield waitForProcesses(loader);
+
+  try {
+    require('sdk/remote/child');
+    assert.fail("Should not have been able to load sdk/remote/child");
+  }
+  catch (e) {
+    assert.ok(/Cannot load sdk\/remote\/child in a main process loader/.test(e),
+              "Should have seen the right exception.");
+  }
+
+  for (let process of processes) {
+    processes.port.emit('sdk/test/parentload');
+    let [_, isChildLoader, loaded, message] = yield promiseEvent(processes.port, 'sdk/test/parentload');
+    assert.ok(isChildLoader, "Process should see itself in a child loader.");
+    assert.ok(!loaded, "Process couldn't load sdk/remote/parent.");
+    assert.ok(/Cannot load sdk\/remote\/parent in a child loader/.test(message),
+              "Should have seen the right exception.");
+  }
+
+  loader.unload();
+};
 
 after(exports, function*(name, assert) {
   yield cleanUI();

--- a/test/addons/e10s-remote/remote-module.js
+++ b/test/addons/e10s-remote/remote-module.js
@@ -8,6 +8,7 @@ const { loaderID } = require('@loader/options');
 const { processID } = require('sdk/system/runtime');
 const system = require('sdk/system/events');
 const { Cu } = require('chrome');
+const { isChildLoader } = require('sdk/remote/core');
 
 function log(str) {
   console.log("remote[" + loaderID + "][" + processID + "]: " + str);
@@ -79,6 +80,24 @@ frames.port.on('sdk/test/sendevent', (frame) => {
   doc.dispatchEvent(event);
   system.off("Test:Reply", listener);
   frame.port.emit('sdk/test/eventsent');
+});
+
+process.port.on('sdk/test/parentload', () => {
+  let loaded = false;
+  let message = "";
+  try {
+    require('sdk/remote/parent');
+    loaded = true;
+  }
+  catch (e) {
+    message = "" + e;
+  }
+
+  process.port.emit('sdk/test/parentload',
+    isChildLoader,
+    loaded,
+    message
+  )
 });
 
 function listener(event) {

--- a/test/addons/remote/main.js
+++ b/test/addons/remote/main.js
@@ -505,7 +505,36 @@ exports["test processID"] = function*(assert) {
       assert.equal(ID, processID, "Remote processes should have the same process ID");
     }
   }
+
+  loader.unload();
 }
+
+// Check that sdk/remote/parent and sdk/remote/child can only be loaded in the
+// appropriate loaders
+exports["test cannot load in wrong loader"] = function*(assert) {
+  let loader = new Loader(module);
+  let { processes } = yield waitForProcesses(loader);
+
+  try {
+    require('sdk/remote/child');
+    assert.fail("Should not have been able to load sdk/remote/child");
+  }
+  catch (e) {
+    assert.ok(/Cannot load sdk\/remote\/child in a main process loader/.test(e),
+              "Should have seen the right exception.");
+  }
+
+  for (let process of processes) {
+    processes.port.emit('sdk/test/parentload');
+    let [_, isChildLoader, loaded, message] = yield promiseEvent(processes.port, 'sdk/test/parentload');
+    assert.ok(isChildLoader, "Process should see itself in a child loader.");
+    assert.ok(!loaded, "Process couldn't load sdk/remote/parent.");
+    assert.ok(/Cannot load sdk\/remote\/parent in a child loader/.test(message),
+              "Should have seen the right exception.");
+  }
+
+  loader.unload();
+};
 
 after(exports, function*(name, assert) {
   yield cleanUI();

--- a/test/addons/remote/remote-module.js
+++ b/test/addons/remote/remote-module.js
@@ -8,6 +8,7 @@ const { loaderID } = require('@loader/options');
 const { processID } = require('sdk/system/runtime');
 const system = require('sdk/system/events');
 const { Cu } = require('chrome');
+const { isChildLoader } = require('sdk/remote/core');
 
 function log(str) {
   console.log("remote[" + loaderID + "][" + processID + "]: " + str);
@@ -79,6 +80,24 @@ frames.port.on('sdk/test/sendevent', (frame) => {
   doc.dispatchEvent(event);
   system.off("Test:Reply", listener);
   frame.port.emit('sdk/test/eventsent');
+});
+
+process.port.on('sdk/test/parentload', () => {
+  let loaded = false;
+  let message = "";
+  try {
+    require('sdk/remote/parent');
+    loaded = true;
+  }
+  catch (e) {
+    message = "" + e;
+  }
+
+  process.port.emit('sdk/test/parentload',
+    isChildLoader,
+    loaded,
+    message
+  )
 });
 
 function listener(event) {


### PR DESCRIPTION
getTabForContentWindow doesn't work in the child process so we accidentally inject the SDK console into any page a page-mod applies to. This switches to using the remote APIs where possible instead.

This adds an API for detecting whether a module is loaded in a child loader or not. It uses that to make it impossible to load sdk/remote/parent or sdk/remote/child in the wrong loader for safety.