### PR TITLE
Bug 1144742: Clear promise debugging observer after tests and clear all added DOM event listeners on unload.

### DIFF
--- a/lib/sdk/deprecated/unit-test.js
+++ b/lib/sdk/deprecated/unit-test.js
@@ -320,6 +320,8 @@ TestRunner.prototype = {
     });
 
     PromiseDebugging.flushUncaughtErrors();
+    PromiseDebugging.removeUncaughtErrorObserver(this._uncaughtErrorObserver);
+
 
     return all(winPromises).then(() => {
       let browserWins = wins.filter(isBrowser);
@@ -537,7 +539,8 @@ TestRunner.prototype = {
     this.test.errors = {};
     this.test.last = 'START';
     PromiseDebugging.clearUncaughtErrorObservers();
-    PromiseDebugging.addUncaughtErrorObserver(this._uncaughtErrorObserver.bind(this));
+    this._uncaughtErrorObserver = this._uncaughtErrorObserver.bind(this);
+    PromiseDebugging.addUncaughtErrorObserver(this._uncaughtErrorObserver);
 
     this.isDone = false;
     this.onDone = function(self) {

--- a/test/jetpack-package.ini
+++ b/test/jetpack-package.ini
@@ -62,6 +62,7 @@ skip-if = true
 [test-environment.js]
 [test-errors.js]
 [test-event-core.js]
+[test-event-dom.js]
 [test-event-target.js]
 [test-event-utils.js]
 [test-events.js]

--- a/test/test-event-dom.js
+++ b/test/test-event-dom.js
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
+
+const { openWindow, closeWindow } = require('./util');
+const { Loader } = require('sdk/test/loader');
+const { getMostRecentBrowserWindow } = require('sdk/window/utils');
+const { Cc, Ci } = require('chrome');
+const els = Cc["@mozilla.org/eventlistenerservice;1"].
+            getService(Ci.nsIEventListenerService);
+
+function countListeners(target, type) {
+  let listeners = els.getListenerInfoFor(target, {});
+  return listeners.filter(listener => listener.type == type).length;
+}
+
+exports['test window close clears listeners'] = function(assert) {
+  let window = yield openWindow();
+  let loader = Loader(module);
+
+  // Any element will do here
+  let gBrowser = window.gBrowser;
+
+  // Other parts of the app may be listening for this
+  let windowListeners = countListeners(window, "DOMWindowClose");
+
+  // We can assume we're the only ones using the test events
+  assert.equal(countListeners(gBrowser, "TestEvent1"), 0, "Should be no listener for test event 1");
+  assert.equal(countListeners(gBrowser, "TestEvent2"), 0, "Should be no listener for test event 2");
+
+  let { open } = loader.require('sdk/event/dom');
+
+  open(gBrowser, "TestEvent1");
+  assert.equal(countListeners(window, "DOMWindowClose"), windowListeners + 1,
+               "Should have added a DOMWindowClose listener");
+  assert.equal(countListeners(gBrowser, "TestEvent1"), 1, "Should be a listener for test event 1");
+  assert.equal(countListeners(gBrowser, "TestEvent2"), 0, "Should be no listener for test event 2");
+
+  open(gBrowser, "TestEvent2");
+  assert.equal(countListeners(window, "DOMWindowClose"), windowListeners + 1,
+               "Should not have added another DOMWindowClose listener");
+  assert.equal(countListeners(gBrowser, "TestEvent1"), 1, "Should be a listener for test event 1");
+  assert.equal(countListeners(gBrowser, "TestEvent2"), 1, "Should be a listener for test event 2");
+
+  window = yield closeWindow(window);
+
+  assert.equal(countListeners(window, "DOMWindowClose"), windowListeners,
+               "Should have removed a DOMWindowClose listener");
+  assert.equal(countListeners(gBrowser, "TestEvent1"), 0, "Should be no listener for test event 1");
+  assert.equal(countListeners(gBrowser, "TestEvent2"), 0, "Should be no listener for test event 2");
+
+  loader.unload();
+};
+
+exports['test unload clears listeners'] = function(assert) {
+  let window = getMostRecentBrowserWindow();
+  let loader = Loader(module);
+
+  // Any element will do here
+  let gBrowser = window.gBrowser;
+
+  // Other parts of the app may be listening for this
+  let windowListeners = countListeners(window, "DOMWindowClose");
+
+  // We can assume we're the only ones using the test events
+  assert.equal(countListeners(gBrowser, "TestEvent1"), 0, "Should be no listener for test event 1");
+  assert.equal(countListeners(gBrowser, "TestEvent2"), 0, "Should be no listener for test event 2");
+
+  let { open } = loader.require('sdk/event/dom');
+
+  open(gBrowser, "TestEvent1");
+  assert.equal(countListeners(window, "DOMWindowClose"), windowListeners + 1,
+               "Should have added a DOMWindowClose listener");
+  assert.equal(countListeners(gBrowser, "TestEvent1"), 1, "Should be a listener for test event 1");
+  assert.equal(countListeners(gBrowser, "TestEvent2"), 0, "Should be no listener for test event 2");
+
+  open(gBrowser, "TestEvent2");
+  assert.equal(countListeners(window, "DOMWindowClose"), windowListeners + 1,
+               "Should not have added another DOMWindowClose listener");
+  assert.equal(countListeners(gBrowser, "TestEvent1"), 1, "Should be a listener for test event 1");
+  assert.equal(countListeners(gBrowser, "TestEvent2"), 1, "Should be a listener for test event 2");
+
+  loader.unload();
+
+  assert.equal(countListeners(window, "DOMWindowClose"), windowListeners,
+               "Should have removed a DOMWindowClose listener");
+  assert.equal(countListeners(gBrowser, "TestEvent1"), 0, "Should be no listener for test event 1");
+  assert.equal(countListeners(gBrowser, "TestEvent2"), 0, "Should be no listener for test event 2");
+};
+
+require('sdk/test').run(exports);

--- a/test/util.js
+++ b/test/util.js
@@ -31,7 +31,7 @@ const openWindow = () => {
 exports.openWindow = openWindow;
 
 const closeWindow = (window) => {
-  const closed = when(window, "unload", true).then(_target);
+  const closed = when(window, "unload", true).then(_ => window);
   window.close();
   return closed;
 };


### PR DESCRIPTION
Made sdk/event/dom remove various event listeners even when the window for those elements have been closed. In theory this shouldn't be necessary but in practice this is causing some reference cycle between the DOM elements and SDK code. The simplest way to break it is just to remove the listeners when the window closes.

Also clears our promise debugging observer which was keeping the test harness and so a lot of stuff inside that loader alive.