### PR TITLE
Bug 1153952 - social buttons are too large

### DIFF
--- a/lib/sdk/ui/button/view.js
+++ b/lib/sdk/ui/button/view.js
@@ -142,7 +142,7 @@ function create(options) {
       node.setAttribute('label', label);
       node.setAttribute('tooltiptext', label);
       node.setAttribute('image', image);
-      node.setAttribute('sdk-button', 'true');
+      node.setAttribute('constrain-size', 'true');
 
       views.set(id, {
         area: this.currentArea,


### PR DESCRIPTION
 - Updated the sdk specific attribute to the new more generic `constrain-size`, to have the buttons that fits the toolbar and the panel.

Notice that without this PR the buttons will be broken in the next uplift. See bug 1153952.