### PR TITLE
Support Add-on SDK env detection for Add-ons

### DIFF
--- a/lib/sdk/addon/runner.js
+++ b/lib/sdk/addon/runner.js
@@ -65,7 +65,12 @@ function definePseudo(loader, id, exports) {
 function startup(reason, options) Startup.onceInitialized.then(() => {
   // Inject globals ASAP in order to have console API working ASAP
   Object.defineProperties(options.loader.globals, descriptor(globals));
-
+  // Provides add-ons with a reliable way to detect the SDK environment
+  Object.defineProperty(options.loader.globals, 'JETPACK', {
+    __proto__: null,
+    value: {}
+  });
+  
   // NOTE: Module is intentionally required only now because it relies
   // on existence of hidden window, which does not exists until startup.
   let { ready } = require('../addon/window');


### PR DESCRIPTION
Adds a new global constant for environment detection.

Alternative method is to append the following to sdk/system/globals.
https://github.com/mozilla/addon-sdk/blob/master/lib/sdk/system/globals.js#L22
```js
Object.defineProperty(exports, 'JETPACK', {
 __proto__: null,
 value: {}
});
```