### PR TITLE
Fixed python detection.

### DIFF
--- a/bin/activate.bat
+++ b/bin/activate.bat
@@ -111,14 +111,14 @@ rem Remove the REG_SZ
 set PYTHONINSTALL=%PYTHONINSTALL:REG_SZ=%
 rem Remove tabs (note the literal \t in the next line
 set PYTHONINSTALL=%PYTHONINSTALL:	=%
-rem Remove spaces.
-set PYTHONINSTALL=%PYTHONINSTALL: =%
-if exist %PYTHONINSTALL%\python.exe goto :EOF
+rem Remove leading spaces.
+for /f "tokens=* delims= " %%a in ("%PYTHONINSTALL%") do set PYTHONINSTALL=%%a
+if exist "%PYTHONINSTALL%\python.exe" goto :EOF
 rem It may be a 32bit Python directory built from source, in which case the
 rem executable is in the PCBuild directory.
-if exist %PYTHONINSTALL%\PCBuild\python.exe (set "PYTHONINSTALL=%PYTHONINSTALL%\PCBuild" & goto :EOF)
+if exist "%PYTHONINSTALL%\PCBuild\python.exe" (set "PYTHONINSTALL=%PYTHONINSTALL%\PCBuild" & goto :EOF)
 rem Or maybe a 64bit build directory.
-if exist %PYTHONINSTALL%\PCBuild\amd64\python.exe (set "PYTHONINSTALL=%PYTHONINSTALL%\PCBuild\amd64" & goto :EOF)
+if exist "%PYTHONINSTALL%\PCBuild\amd64\python.exe" (set "PYTHONINSTALL=%PYTHONINSTALL%\PCBuild\amd64" & goto :EOF)
 
 rem And try HKCU
 FOR /F "usebackq tokens=2 delims=)>" %%A IN (`%reg% QUERY HKCU\%key% /ve 2^>NUL`) DO SET "%~1=%%A"

--- a/lib/sdk/preferences/native-options.js
+++ b/lib/sdk/preferences/native-options.js
@@ -111,7 +111,7 @@ exports.setDefaults = setDefaults;
 
 // dynamically injects inline options into about:addons page at runtime
 function injectOptions({ preferences, preferencesBranch, document, parent, id }) {
-  for (let { name, type, hidden, title, description, label, options, on, off } of preferences) {
+  for (let { name, type, hidden, title, description, label, options, on, off, style } of preferences) {
 
     if (hidden) {
       continue;
@@ -125,6 +125,8 @@ function injectOptions({ preferences, preferencesBranch, document, parent, id })
     setting.setAttribute('title', title);
     if (description)
       setting.setAttribute('desc', description);
+	if (style)
+      setting.setAttribute('style', style);
 
     if (type === 'file' || type === 'directory') {
       setting.setAttribute('fullpath', 'true');
@@ -146,9 +148,15 @@ function injectOptions({ preferences, preferencesBranch, document, parent, id })
       let menulist = document.createElement('menulist');
       let menupopup = document.createElement('menupopup');
       for (let { value, label } of options) {
-        let menuitem = document.createElement('menuitem');
-        menuitem.setAttribute('value', value);
-        menuitem.setAttribute('label', label);
+        let menuitem;
+        if (!value && !label){
+          menuitem = document.createElement('menuseparator');
+        }
+        else {
+          menuitem = document.createElement('menuitem');
+          menuitem.setAttribute('value', value);
+          menuitem.setAttribute('label', label);
+        }
         menupopup.appendChild(menuitem);
       }
       menulist.appendChild(menupopup);


### PR DESCRIPTION
Python detection is not working in Win 7 because the standard software
folder may contain spaces: "C:\Program Files\..."