### PR TITLE
Fix invalid method syntax used in URL constructor

### DIFF
--- a/lib/sdk/url.js
+++ b/lib/sdk/url.js
@@ -152,20 +152,28 @@ function URL(url, base) {
 
   Object.defineProperties(this, {
     toString: {
-      value() new String(uri.spec).toString(),
+      value() {
+        return new String(uri.spec).toString();
+      },
       enumerable: false
     },
     valueOf: {
-      value() new String(uri.spec).valueOf(),
+      value() {
+        return new String(uri.spec).valueOf();
+      },
       enumerable: false
     },
     toSource: {
-      value() new String(uri.spec).toSource(),
+      value() {
+        return new String(uri.spec).toSource();
+      },
       enumerable: false
     },
     // makes more sense to flatten to string, easier to travel across JSON
     toJSON: {
-      value() new String(uri.spec).toString(),
+      value() {
+        return new String(uri.spec).toString();
+      },
       enumerable: false
     }
   });


### PR DESCRIPTION
This blocks landing a patch in bug 1158222, where I want to disallow this syntax. (It's against the ES6 spec)