### PR TITLE
Bug 1167327: Add event listeners to existing tabs on startup.

### DIFF
--- a/lib/sdk/windows/tabs-fennec.js
+++ b/lib/sdk/windows/tabs-fennec.js
@@ -16,6 +16,7 @@ const { on, once, off, emit } = require('../event/core');
 const { method } = require('../lang/functional');
 const { EVENTS } = require('../tabs/events');
 const { EventTarget } = require('../event/target');
+const { pipe } = require('../event/utils');
 const { when: unload } = require('../system/unload');
 const { windowIterator } = require('../deprecated/window-utils');
 const { List, addListItem, removeListItem } = require('../util/list');
@@ -36,13 +37,15 @@ const Tabs = Class({
     let window = tabsNS(this).window = options.window || mainWindow;
 
     EventTarget.prototype.initialize.call(this, options);
-    List.prototype.initialize.apply(this, getTabs(window).map(Tab));
+    List.prototype.initialize.call(this)
 
     // TabOpen event
     window.BrowserApp.deck.addEventListener(EVENTS.open.dom, onTabOpen, false);
 
     // TabSelect
     window.BrowserApp.deck.addEventListener(EVENTS.activate.dom, onTabSelect, false);
+
+    this.on('close', onTabClose);
   },
   get activeTab() {
     return getTabForRawTab(getSelectedTab(tabsNS(this).window));
@@ -91,6 +94,8 @@ const Tabs = Class({
   }
 });
 let gTabs = exports.tabs = Tabs(mainWindow);
+for (let rawTab of getTabs(mainWindow))
+  addTab(Tab(rawTab));
 
 function tabsUnloader(event, window) {
   window = window || (event && event.target);
@@ -109,6 +114,7 @@ unload(function() {
 
 function addTab(tab) {
   addListItem(gTabs, tab);
+  pipe(tab, gTabs);
   return tab;
 }
 
@@ -135,14 +141,7 @@ function onTabOpen(event) {
 
   tabNS(tab).opened = true;
 
-  tab.on('ready', function() emit(gTabs, 'ready', tab));
-  tab.once('close', onTabClose);
-
-  tab.on('pageshow', function(_tab, persisted)
-    emit(gTabs, 'pageshow', tab, persisted));
-
   emit(tab, 'open', tab);
-  emit(gTabs, 'open', tab);
 }
 
 // TabSelect
@@ -168,5 +167,4 @@ function onTabSelect(event) {
 // TabClose
 function onTabClose(tab) {
   removeTab(tab);
-  emit(gTabs, EVENTS.close.name, tab);
 }


### PR DESCRIPTION
This seems like a safer way to make sure we're getting events for all tabs.