### PR TITLE
Stop parenthesizing array/object pattern destructuring assignment targets

### DIFF
--- a/lib/sdk/io/buffer.js
+++ b/lib/sdk/io/buffer.js
@@ -247,11 +247,11 @@ Object.defineProperties(Buffer.prototype, {
     value: function(string, offset, length, encoding = 'utf8') {
       // write(string, encoding);
       if (typeof(offset) === 'string' && Number.isNaN(parseInt(offset))) {
-        ([offset, length, encoding]) = [0, null, offset];
+        [offset, length, encoding] = [0, null, offset];
       }
       // write(string, offset, encoding);
       else if (typeof(length) === 'string')
-        ([length, encoding]) = [null, length];
+        [length, encoding] = [null, length];
 
       if (offset < 0 || offset > this.length)
         throw new RangeError('offset is outside of valid range');

--- a/lib/sdk/panel/utils.js
+++ b/lib/sdk/panel/utils.js
@@ -129,7 +129,7 @@ function display(panel, options, anchor) {
 
     let viewportRect = document.defaultView.gBrowser.getBoundingClientRect();
 
-    ({x, y, width, height}) = calculateRegion(options, viewportRect);
+    ({x, y, width, height} = calculateRegion(options, viewportRect));
   }
   else {
     // The XUL Panel has an arrow, so the margin needs to be reset
@@ -145,7 +145,7 @@ function display(panel, options, anchor) {
     // chrome browser window, and therefore there is no need for this check.
     if (CustomizableUI) {
       let node = anchor;
-      ({anchor}) = CustomizableUI.getWidget(anchor.id).forWindow(window);
+      ({anchor} = CustomizableUI.getWidget(anchor.id).forWindow(window));
 
       // if `node` is not the `anchor` itself, it means the widget is
       // positioned in a panel, therefore we have to hide it before show

--- a/lib/sdk/util/sequence.js
+++ b/lib/sdk/util/sequence.js
@@ -245,7 +245,7 @@ const map = (f, ...sequences) => seq(function* () {
       let index = 0;
       let value = void(0);
       while (index < count && !done) {
-        ({ done, value }) = inputs[index].next();
+        ({ done, value } = inputs[index].next());
 
         // If input is not exhausted yet store value in args.
         if (!done) {
@@ -273,10 +273,10 @@ const reductions = (...params) => {
   let hasInitial = false;
   let f, initial, source;
   if (count === 2) {
-    ([f, source]) = params;
+    [f, source] = params;
   }
   else if (count === 3) {
-    ([f, initial, source]) = params;
+    [f, initial, source] = params;
     hasInitial = true;
   }
   else {


### PR DESCRIPTION
These syntaxes are invalid in ES6:

    var v;
    ([v]) = [0]; // BAD way to assign v = 0
    ({v}) = { v: 0 }; // BAD way to assign v = 0

ES6 says that when destructuring assignment is used (or when a variable or variables are declared using a destructuring pattern), array/object patterns must not be parenthesized.

There's no reason at all to parenthesize array patterns (you can assign directly to an unparenthesized pattern), so this only rarely happens.  But some people have parenthesized object patterns, as a way to disambiguate them from normal JS block statements.  However, ES6 doesn't sanction such disambiguation attempts.  The right way to fix this is to parenthesize the entire assignment, not just the object pattern.

There are a few uses of this in the addon SDK, that need fixing before I can land my patch for https://bugzilla.mozilla.org/show_bug.cgi?id=1146136 upstream.  Mind pulling this in for me?  (And, is it a problem if my patch upstream also patches the imported addon-sdk/ files, for you to overwrite next time you pull?  Or must I wait for the next Github -> mozilla-central import to happen first?)