### PR TITLE
First attempt for hotkey simple-preference

### DIFF
--- a/lib/sdk/preferences/native-options.js
+++ b/lib/sdk/preferences/native-options.js
@@ -17,7 +17,7 @@ const { defer } = require("sdk/core/promise");
 const DEFAULT_OPTIONS_URL = 'data:text/xml,<placeholder/>';
 
 const VALID_PREF_TYPES = ['bool', 'boolint', 'integer', 'string', 'color',
-                          'file', 'directory', 'control', 'menulist', 'radio'];
+                          'file', 'directory', 'control', 'menulist', 'radio', 'hotkey'];
 
 function enable({ preferences, id }) {
   let enabled = defer();
@@ -76,6 +76,9 @@ function validate(preferences) {
           throw Error("Each option requires both a value and a label");
       }
     }
+    if (type === 'hotkey') {
+      // Todo: Check exact format expected for hotkeys (put it as method of KeySelector.validate(str)!)
+    }
 
     // TODO: check that pref type matches default value type
   }
@@ -111,6 +114,10 @@ exports.setDefaults = setDefaults;
 
 // dynamically injects inline options into about:addons page at runtime
 function injectOptions({ preferences, preferencesBranch, document, parent, id }) {
+  const branch = Cc['@mozilla.org/preferences-service;1'].
+                 getService(Ci.nsIPrefService).
+                 getBranch('extensions.' + preferencesBranch + '.');
+
   for (let { name, type, hidden, title, description, label, options, on, off } of preferences) {
 
     if (hidden) {
@@ -121,7 +128,7 @@ function injectOptions({ preferences, preferencesBranch, document, parent, id })
     setting.setAttribute('pref-name', name);
     setting.setAttribute('data-jetpack-id', id);
     setting.setAttribute('pref', 'extensions.' + preferencesBranch + '.' + name);
-    setting.setAttribute('type', type);
+    setting.setAttribute('type', type === 'hotkey' ? 'string' : type);
     setting.setAttribute('title', title);
     if (description)
       setting.setAttribute('desc', description);
@@ -153,6 +160,87 @@ function injectOptions({ preferences, preferencesBranch, document, parent, id })
       }
       menulist.appendChild(menupopup);
       setting.appendChild(menulist);
+    }
+    else if (type === 'hotkey') {
+      // Todo: Better way to import and inject this code?
+      var keySelectorCode = `var KeySelector = (function () {'use strict';
+            var winOn = false;
+            function keydown (e) {
+                var target = e.target,
+                    str = '';
+                target.value = '';
+                if (e.shiftKey)  {
+                    str += 'shift';
+                }
+                if (e.ctrlKey) {
+                    str += (str ? '+' : '') + 'ctrl';
+                }
+                if (e.altKey)  {
+                    str += (str ? '+' : '') + 'alt';
+                }
+                if (e.keyCode === 91) { // Win key
+                    winOn = (str ? (str + '+') : '') + 'win';
+                }
+                else {
+                    target.value = str;
+                }
+            }
+            function keypress (e) {
+                var target = e.target;
+                target.value += (target.value ? '+' : '') + String.fromCharCode(e.charCode);
+                e.preventDefault();
+            }
+            function keyup (e) {
+                if (e.keyCode === 91) { // Win key
+                    return;
+                }
+                var target = e.target;
+                if (winOn) {
+                    target.value = winOn +
+                        ([16, 17, 18].indexOf(e.keyCode) === -1 ? '+' : '') + // If this is just another special key, don't add a "+"
+                            String.fromCharCode(e.keyCode);
+                    winOn = false;
+                }
+                if (!target.value.match(/\\+.$/)) { // Use this block to disallow just special keys or normal keys alone
+                    target.value = '';
+                }
+                e.preventDefault();
+            }
+
+            function addListeners (input) {
+                input.addEventListener('keydown', keydown);
+                input.addEventListener('keypress', keypress);
+                input.addEventListener('keyup', keyup);
+            }
+
+            var exp;
+            if (typeof exports === 'undefined') {
+                window.KeySelector = {};
+                exp = window.KeySelector;
+            }
+            else {
+                exp = exports;
+            }
+            exp.addListeners = addListeners;
+            return exp;
+        }());
+      `.replace(/\/\/.*$/mg, '').replace(/\n/g, ''); // Note: manually added an extra backslash in a regex above
+
+      setting.addEventListener('blur', function (e) {
+        // We have to manage this ourselves as the preference does not update (why not?)
+        e.target.valueToPreference();
+      }, true);
+      setting.setAttribute(
+        'oninputchanged',
+          keySelectorCode +
+          // "this" has keys: _updatingInput (boolean), input, _observer
+          // See http://mxr.mozilla.org/mozilla-central/source/toolkit/mozapps/extensions/content/setting.xml (and http://stackoverflow.com/questions/24471468/how-to-use-addeventlistener-on-inputchanged-of-inline-options/24471723 and https://developer.mozilla.org/en-US/Add-ons/Inline_Options )
+          "if (!this.getAttribute('data-hotkey-added')) {this.setAttribute('data-hotkey-added', 'true');KeySelector.addListeners(this.input);}"
+      );
+      setting.addEventListener('focus', function (e) { // HACK: Better way to get the oninputchanged to fire?
+        e.target.input.dispatchEvent(new document.defaultView.KeyboardEvent('input', {key: ''})); // Works!
+        // require('sdk/keys').keyEvent(e.target.input, 'input', {key: 'a', window: document.defaultView}); // not working (why not?)
+      }, true);
     }
     else if (type === 'radio') {
       let radiogroup = document.createElement('radiogroup');

--- a/lib/sdk/preferences/native-options.js
+++ b/lib/sdk/preferences/native-options.js
@@ -114,9 +114,6 @@ exports.setDefaults = setDefaults;
 
 // dynamically injects inline options into about:addons page at runtime
 function injectOptions({ preferences, preferencesBranch, document, parent, id }) {
-  const branch = Cc['@mozilla.org/preferences-service;1'].
-                 getService(Ci.nsIPrefService).
-                 getBranch('extensions.' + preferencesBranch + '.');
 
   for (let { name, type, hidden, title, description, label, options, on, off } of preferences) {
 


### PR DESCRIPTION
Functional but hackish attempt to solve https://bugzilla.mozilla.org/show_bug.cgi?id=1123097 .

With package.json like:

```js
...
"preferences": [{
        "name": "opendialog",
        "title": "Open dialog",
        "type": "hotkey",
        "value": "ctrl-o"
    }]
```
...the user's "Open dialog" preference will show with "ctrl-o".

Similarly, lib/main could retrieve this as follows:

```js
exports.main = function () {
    var prefs = require('sdk/simple-prefs');
    console.log("Let's see the last saved value: " + prefs.prefs['opendialog']);
};
```

Anyways, this is just my first attempt, and I should warn that my health has made me fickle in following through with past attempts, but I am having a few good days, so wanted to try this out.

I didn't make any attempt to bake in metadata in the package.json preferences to invoke a particular extension function, and I think it is quite easy and flexible as is to just get the current value from preferences and use that. But my implementation no doubt needs some work. Would be grateful for a lookover.