### PR TITLE
Remove one useless __iterator__ use

### DIFF
--- a/lib/sdk/util/array.js
+++ b/lib/sdk/util/array.js
@@ -98,14 +98,8 @@ exports.flatten = function flatten(array){
 
 function fromIterator(iterator) {
   let array = [];
-  if (iterator.__iterator__) {
-    for (let item of iterator)
-      array.push(item);
-  }
-  else {
-    for (let item of iterator)
-      array.push(item);
-  }
+  for (let item of iterator)
+    array.push(item);
   return array;
 }
 exports.fromIterator = fromIterator;


### PR DESCRIPTION
We really need to move people using the addon-sdk away from using `__iterator__`, i.e. using for-in to iterate over collections etc. (Bug 1098617)

At least here somebody probably made a mistake and used for-of instead of for-in inside the if.