### PR TITLE
Bug 1103385 - Make json.language() defaults to "en". r=evold

### DIFF
--- a/lib/sdk/l10n/json/core.js
+++ b/lib/sdk/l10n/json/core.js
@@ -32,5 +32,5 @@ exports.locale = function locale() {
 // Returns the short locale code: ja, en, fr
 exports.language = function language() {
   return bestMatchingLocale ? bestMatchingLocale.split("-")[0].toLowerCase()
-                            : null;
+                            : "en";
 }


### PR DESCRIPTION
Second proposal to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1103385