### PR TITLE
Bug 939496 - Emit tabs open event for the first tab in a new window

### DIFF
--- a/lib/sdk/tabs/tabs-firefox.js
+++ b/lib/sdk/tabs/tabs-firefox.js
@@ -111,6 +111,7 @@ function addWindowTab(window, tabElement) {
   if (window)
     addListItem(window.tabs, tab);
   addListItem(allTabs, tab);
+  emit(allTabs, "open", tab);
 }
 
 // Find tabs in already open windows

--- a/test/tabs/test-firefox-tabs.js
+++ b/test/tabs/test-firefox-tabs.js
@@ -1261,6 +1261,21 @@ exports["test ready event after window.open"] = function (assert, done) {
   });
 }
 
+// related to bug #939496
+exports["test tab open event for new window"] = function(assert, done) {
+  // ensure popups open in a new window and disable popup blocker
+  setPref(OPEN_IN_NEW_WINDOW_PREF, 2);
+  setPref(DISABLE_POPUP_PREF, false);
+
+  tabs.once('open', function onOpen(window) {
+    assert.pass("tab open has occured");
+    window.close(done);
+  });
+
+  // open window to trigger observers
+  browserWindows.open("about:logo");
+};
+
 after(exports, function*(name, assert) {
   resetPopupPrefs();
   yield cleanUI();


### PR DESCRIPTION
This patch fixes part of the problem in bug [939496](https://bugzilla.mozilla.org/show_bug.cgi?id= 939496) and adds a test for it.

The other part of the problem, related with window.open(), actually comes from the bug [989288](https://bugzilla.mozilla.org/show_bug.cgi?id=989288). That one needs to be fixed to fully fix this one.