### PR TITLE
Bug 1219712: fix syntax error in test

### DIFF
--- a/test/test-simple-storage.js
+++ b/test/test-simple-storage.js
@@ -284,7 +284,7 @@ exports.testSetNoSetRead = function (assert, done) {
 
 
 function setGetRoot(assert, done, val, compare) {
-  compare = compare || (a, b) => a === b;
+  compare = compare || ((a, b) => a === b);
 
   // Load the module once, set a value.
   let loader = Loader(module);


### PR DESCRIPTION
This patch fixes some ambiguity in the code. Corresponding to [bug report #1219712](https://bugzilla.mozilla.org/show_bug.cgi?id=1219712).