### PR TITLE
Bug 1219732: fix page-worker test addon manifest for JPM

### DIFF
--- a/test/addons/page-worker/package.json
+++ b/test/addons/page-worker/package.json
@@ -1,3 +1,5 @@
 {
-  "id": "test-page-worker"
+  "name": "test-page-worker",
+  "version": "0.0.1",
+  "main": "./main.js"
 }


### PR DESCRIPTION
Patch to modify the manifest in one of the test addons so it can be run with jpm. Fixes [bug report #1219732](https://bugzilla.mozilla.org/show_bug.cgi?id=1219732).
