### PR TITLE
Bug 956461 - context menuitems have no id in the dom.

### DIFF
--- a/lib/sdk/context-menu.js
+++ b/lib/sdk/context-menu.js
@@ -256,6 +256,17 @@ var labelledItemRules =  mix(baseItemRules, {
     ok: v => !!v,
     msg: "The item must have a non-empty string label."
   },
+  id: {
+    map: stringOrNull,
+    is: ["string", "undefined", "null"],
+    ok: v => {
+      if (!v) {
+        return true;
+      }
+      return typeof v == "string";
+    },
+    msg: "The item must have a non-empty string id"
+  },
   accesskey: {
     map: stringOrNull,
     is: ["string", "undefined", "null"],
@@ -482,6 +493,16 @@ var LabelledItem = Class({
 
   set label(val) {
     internal(this).options.label = val;
+
+    MenuManager.updateItem(this);
+  },
+
+  get id() {
+    return internal(this).options.id;
+  },
+
+  set id(val) {
+    internal(this).options.id = val;
 
     MenuManager.updateItem(this);
   },
@@ -862,6 +883,8 @@ var MenuWrapper = Class({
     xulNode.setAttribute("class", ITEM_CLASS);
     if (item instanceof LabelledItem) {
       xulNode.setAttribute("label", item.label);
+      if (item.id)
+       xulNode.setAttribute("id", item.id);
       if (item.accesskey)
         xulNode.setAttribute("accesskey", item.accesskey);
       if (item.image) {
@@ -906,6 +929,11 @@ var MenuWrapper = Class({
     // TODO figure out why this requires setAttribute
     xulNode.setAttribute("label", item.label);
     xulNode.setAttribute("accesskey", item.accesskey || "");
+
+    if (item.id)
+      xulNode.setAttribute("id", item.id);
+    else
+      xulNode.removeAttribute("id");
 
     if (item.image) {
       xulNode.setAttribute("image", item.image);

--- a/test/test-context-menu.js
+++ b/test/test-context-menu.js
@@ -2688,6 +2688,58 @@ exports.testItemNoData = function (assert, done) {
 }
 
 
+exports.testItemNoId = function (assert, done) {
+  let test = new TestHelper(assert, done);
+  let loader = test.newLoader();
+
+  let item1 = new loader.cm.Item({ label: "item 1" });
+  let item2 = new loader.cm.Item({ label: "item 2", id: null });
+  let item3 = new loader.cm.Item({ label: "item 3", id: undefined });
+
+  assert.equal(item1.id, undefined, "Should be no defined id");
+  assert.equal(item2.id, null, "Should be no defined id");
+  assert.equal(item3.id, undefined, "Should be no defined id");
+
+  test.showMenu().
+  then((popup) => test.checkMenu([item1, item2, item3], [], [])).
+  then(test.done).
+  catch(assert.fail);
+}
+
+
+// Test id support.
+exports.testItemId = function (assert, done) {
+  let test = new TestHelper(assert, done);
+  let loader = test.newLoader();
+
+  let item = new loader.cm.Item({ label: "item", id: "abc" });
+  assert.equal(item.id, "abc", "Should have set the id to abc");
+
+  let menu = new loader.cm.Menu({ label: "menu", id: "def", items: [
+    loader.cm.Item({ label: "subitem" })
+  ]});
+  assert.equal(menu.id, "def", "Should have set the id to def");
+
+  test.showMenu().then((popup) => {
+    test.checkMenu([item, menu], [], []);
+
+    let id = "xyz";
+    menu.id = item.id = id;
+    assert.equal(item.id, id, "Should have set the id to " + id);
+    assert.equal(menu.id, id, "Should have set the id to " + id);
+    test.checkMenu([item, menu], [], []);
+
+    item.id = null;
+    menu.id = null;
+    assert.equal(item.id, null, "Should have set the id to " + id);
+    assert.equal(menu.id, null, "Should have set the id to " + id);
+    test.checkMenu([item, menu], [], []);
+  }).
+  then(test.done).
+  catch(assert.fail);
+};
+
+
 exports.testItemNoAccessKey = function (assert, done) {
   let test = new TestHelper(assert, done);
   let loader = test.newLoader();
@@ -2696,9 +2748,9 @@ exports.testItemNoAccessKey = function (assert, done) {
   let item2 = new loader.cm.Item({ label: "item 2", accesskey: null });
   let item3 = new loader.cm.Item({ label: "item 3", accesskey: undefined });
 
-  assert.equal(item1.accesskey, undefined, "Should be no defined image");
-  assert.equal(item2.accesskey, null, "Should be no defined image");
-  assert.equal(item3.accesskey, undefined, "Should be no defined image");
+  assert.equal(item1.accesskey, undefined, "Should be no defined accesskey");
+  assert.equal(item2.accesskey, null, "Should be no defined accesskey");
+  assert.equal(item3.accesskey, undefined, "Should be no defined accesskey");
 
   test.showMenu().
   then((popup) => test.checkMenu([item1, item2, item3], [], [])).
@@ -2713,7 +2765,7 @@ exports.testItemAccessKey = function (assert, done) {
   let loader = test.newLoader();
 
   let item = new loader.cm.Item({ label: "item", accesskey: "i" });
-  assert.equal(item.accesskey, "i", "Should have set the image to i");
+  assert.equal(item.accesskey, "i", "Should have set the accesskey to i");
 
   let menu = new loader.cm.Menu({ label: "menu", accesskey: "m", items: [
     loader.cm.Item({ label: "subitem" })


### PR DESCRIPTION
Add code for adding "id" attribute on context-menu items; fix test labeling for accesskey tests.

When attempting to run `npm test` locally, it hangs, so currently cannot confirm this PR is working properly.