### PR TITLE
Bug 1224863: Fix window initialization in private browsing mode

### DIFF
--- a/lib/sdk/windows/firefox.js
+++ b/lib/sdk/windows/firefox.js
@@ -182,7 +182,7 @@ function makeNewWindow(domWindow, browserHint = false) {
     return new Window(domWindow);
 }
 
-for (let domWindow of windows()) {
+for (let domWindow of windows(null, {includePrivate: supportPrivateWindows})) {
   let window = makeNewWindow(domWindow);
   if (window instanceof BrowserWindow)
     addListItem(browserWindows, window);


### PR DESCRIPTION
Hi,

I found a way to solve an annoying bug about ```sdk/windows``` API which prevents to get the first browser window when private browsing is enabled by default. All details are explained in the [bug 1224863](https://bugzilla.mozilla.org/show_bug.cgi?id=1224863) and it also describes how to reproduce it.

I know each contribution should be proposed with its related tests but I didn't figure out how to test it. Could you please help me to write tests and give me your opinion about my PR?

Thanks.