### PR TITLE
Bug 918600 - Tooltips in panels should be visible

### DIFF
--- a/lib/sdk/panel/utils.js
+++ b/lib/sdk/panel/utils.js
@@ -241,6 +241,7 @@ function setupPanelFrame(frame) {
   frame.setAttribute("flex", 1);
   frame.setAttribute("transparent", "transparent");
   frame.setAttribute("autocompleteenabled", true);
+  frame.setAttribute("tooltip", "aHTMLTooltip");
   if (platform === "darwin") {
     frame.style.borderRadius = "6px";
     frame.style.padding = "1px";


### PR DESCRIPTION
As mentioned under https://bugzilla.mozilla.org/show_bug.cgi?id=918600#c8, this is merely a matter of adding an attribute.