### PR TITLE
Bug 1300735 - Make sure string bundles are flushed on extension update

### DIFF
--- a/lib/sdk/l10n/properties/core.js
+++ b/lib/sdk/l10n/properties/core.js
@@ -13,6 +13,9 @@ const { Services } = Cu.import("resource://gre/modules/Services.jsm", {});
 const baseURI = rootURI + "locale/";
 const preferedLocales = getPreferedLocales(true);
 
+// Make sure we don't get stale data after an update
+Services.strings.flushBundles();
+
 function getLocaleURL(locale) {
   // if the locale is a valid chrome URI, return it
   try {


### PR DESCRIPTION
This issue impacts the user experience quite massively right now - every time a larger update is published users will be stuck with missing or outdated strings until they restart their browser.